### PR TITLE
Changed shebang to python2

### DIFF
--- a/wifiphisher.py
+++ b/wifiphisher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import os


### PR DESCRIPTION
...for compatibility with systems defaulting to python3

Previously, wifiphisher.py was using /usr/bin/env python , which defaults to python2.7 on most systems but python3 on archlinux and some other distros.