### PR TITLE
Define lock outside of if __name__ == "__main__"

### DIFF
--- a/wifiphisher.py
+++ b/wifiphisher.py
@@ -43,6 +43,7 @@ T = '\033[93m'   # tan
 count = 0 # for channel hopping Thread
 APs = {} # for listing APs
 hop_daemon_running = True 
+lock = Lock()
 
 def parse_args():
     #Create the arguments
@@ -752,7 +753,6 @@ if __name__ == "__main__":
     clients_APs = []
     APs = []
     DN = open(os.devnull, 'w')
-    lock = Lock()
     args = parse_args()
     args.accesspoint = ap_mac
     args.channel = channel


### PR DESCRIPTION
Fix for issue #17
`lock` is used throughout the code, but is only defined if the script is invoked directly.