### PR TITLE
Removed some useless imports

### DIFF
--- a/wifiphisher.py
+++ b/wifiphisher.py
@@ -12,7 +12,6 @@ import ConfigParser
 import httplib
 import SocketServer
 import cgi
-import string
 import argparse
 import fcntl
 from threading import Thread, Lock

--- a/wifiphisher.py
+++ b/wifiphisher.py
@@ -747,7 +747,6 @@ if __name__ == "__main__":
 
     clients_APs = []
     APs = []
-    DN = open(os.devnull, 'w')
     args = parse_args()
     args.accesspoint = ap_mac
     args.channel = channel

--- a/wifiphisher.py
+++ b/wifiphisher.py
@@ -8,7 +8,6 @@ import time
 import sys
 import SimpleHTTPServer
 import BaseHTTPServer
-import ConfigParser
 import httplib
 import SocketServer
 import cgi

--- a/wifiphisher.py
+++ b/wifiphisher.py
@@ -398,6 +398,7 @@ def dhcp_conf(interface):
 
 def dhcp(dhcpconf, mon_iface):
     os.system('echo > /var/lib/misc/dnsmasq.leases')
+    dhcp = Popen(['dnsmasq', '-C', dhcpconf], stdout=PIPE, stderr=DN)
     ipprefix = get_internet_ip_prefix()
     Popen(['ifconfig', str(mon_iface), 'mtu', '1400'], stdout=DN, stderr=DN)
     if ipprefix == '19' or ipprefix == '17' or not ipprefix:

--- a/wifiphisher.py
+++ b/wifiphisher.py
@@ -272,7 +272,6 @@ def get_internet_interface():
         if 'wlan' in line and 'default via' in line:
             line = line.split()
             inet_iface = line[4]
-            ipprefix = line[2][:2] # Just checking if it's 192, 172, or 10
             return inet_iface
     return False
 

--- a/wifiphisher.py
+++ b/wifiphisher.py
@@ -72,11 +72,10 @@ class SecureHTTPServer(BaseHTTPServer.HTTPServer):
     """
     def __init__(self, server_address, HandlerClass):
         SocketServer.BaseServer.__init__(self, server_address, HandlerClass)
-        fpem = PEM
         self.socket = ssl.SSLSocket(
             socket.socket(self.address_family, self.socket_type),
-            keyfile=fpem,
-            certfile=fpem
+            keyfile=PEM,
+            certfile=PEM
         )
 
         self.server_bind()

--- a/wifiphisher.py
+++ b/wifiphisher.py
@@ -399,7 +399,6 @@ def dhcp_conf(interface):
 
 def dhcp(dhcpconf, mon_iface):
     os.system('echo > /var/lib/misc/dnsmasq.leases')
-    dhcp = Popen(['dnsmasq', '-C', dhcpconf], stdout=PIPE, stderr=DN)
     ipprefix = get_internet_ip_prefix()
     Popen(['ifconfig', str(mon_iface), 'mtu', '1400'], stdout=DN, stderr=DN)
     if ipprefix == '19' or ipprefix == '17' or not ipprefix:

--- a/wifiphisher.py
+++ b/wifiphisher.py
@@ -602,7 +602,7 @@ def APs_add(clients_APs, APs, pkt, chan_arg):
             if ap_channel != chan_arg:
                 return
 
-    except Exception as e:
+    except Exception:
         return
 
     if len(APs) == 0:

--- a/wifiphisher.py
+++ b/wifiphisher.py
@@ -266,7 +266,7 @@ def get_internet_interface():
     '''return the wifi internet connected iface'''
     inet_iface = None
     proc = Popen(['/sbin/ip', 'route'], stdout=PIPE, stderr=DN)
-    def_route = proc.communicate()[0].split('\n')#[0].split()
+    def_route = proc.communicate()[0].split('\n')
     for line in def_route:
         if 'wlan' in line and 'default via' in line:
             line = line.split()

--- a/wifiphisher.py
+++ b/wifiphisher.py
@@ -283,7 +283,6 @@ def get_internet_ip_prefix():
     for line in def_route:
         if 'wlan' in line and 'default via' in line:
             line = line.split()
-            inet_iface = line[4]
             ipprefix = line[2][:2] # Just checking if it's 192, 172, or 10
             return ipprefix
     return False


### PR DESCRIPTION
Ok I would also like to know why are we declaring ```error``` variable [here](https://github.com/yasoob/wifiphisher/blob/master/wifiphisher.py#L304-306) and [here](https://github.com/yasoob/wifiphisher/blob/master/wifiphisher.py#L468) if we are not going to use them? Perhaps I am mistaken or perhaps you want to use them but forgot? Just tell me the case and I will edit it :+1: 

