### PR TITLE
Fix the crash bug and fix pep8 errors

### DIFF
--- a/wifiphisher/phishingpage.py
+++ b/wifiphisher/phishingpage.py
@@ -123,14 +123,14 @@ class TemplateManager(object):
 
         # Browser Plugin Update
         display_name = "Browser Plugin Update"
-        description = ("A generic browser plugin update template that "  + 
-                       "can be used to serve payloads to Windows targets. "  + 
+        description = ("A generic browser plugin update template that " +
+                       "can be used to serve payloads to Windows targets. " +
                        "Mobile-friendly.")
-        plugin_update = PhishingTemplate("plugin_update", display_name, description)
+        plugin_update = PhishingTemplate("plugin_update",
+                                         display_name, description)
 
-
-        self._templates = {"connection_reset": connection, "office365": office,
-                           "firmware-upgrade": firmware_upgrade, 
+        self._templates = {"connection_reset": connection,
+                           "firmware-upgrade": firmware_upgrade,
                            "plugin_update": plugin_update}
 
         # add all the user templates to the database


### PR DESCRIPTION
This patch fixes the problem where some parts of the office template were still present and would crash the software. Also fixes pep8 errors that were introduced during previous patches.