### PR TITLE
Detect AP vendor based on MAC addr & display it in on the AP list menu

### DIFF
--- a/nmap-mac-prefixes
+++ b/nmap-mac-prefixes
@@ -1,0 +1,21326 @@
+# $Id: $ generated with make-mac-prefixes.pl
+# Original data comes from http://standards.ieee.org/regauth/oui/oui.txt
+# These values are known as Organizationally Unique Identifiers (OUIs)
+# See http://standards.ieee.org/faqs/OUI.html
+# We have added a few unregistered OUIs at the end.
+E043DB Shenzhen ViewAt Technology
+2405F5 Integrated Device Technology (Malaysia) Sdn. Bhd.
+2C3033 Netgear
+847E40 Texas Instruments
+78C5E5 Texas Instruments
+D494A1 Texas Instruments
+3C3300 Shenzhen Bilian electronic
+3CD92B Hewlett Packard
+9C8E99 Hewlett Packard
+B499BA Hewlett Packard
+1CC1DE Hewlett Packard
+3C3556 Cognitec Systems GmbH
+0050BA D-Link
+00179A D-Link
+1CBDB9 D-Link International
+9094E4 D-Link International
+28107B D-Link International
+1C7EE5 D-Link International
+C4A81D D-Link International
+18622C Sagemcom Broadband SAS
+7C03D8 Sagemcom Broadband SAS
+E8F1B0 Sagemcom Broadband SAS
+00F871 DGS Denmark A/S
+D8543A Texas Instruments
+7C8EE4 Texas Instruments
+BC0DA5 Texas Instruments
+90D7EB Texas Instruments
+001832 Texas Instruments
+20BB76 COL Giovanni Paolo SpA
+2C228B CTR SRL
+348AAE Sagemcom Broadband SAS
+C83E99 Texas Instruments
+0017E5 Texas Instruments
+0017EC Texas Instruments
+FC528D Technicolor CH USA
+BCEC23 Shenzhen Chuangwei-rgb Electronics
+8CE748 Private
+F09CE9 Aerohive Networks
+C413E2 Aerohive Networks
+AC06C7 ServerNet S.r.l.
+04BF6D ZyXEL Communications
+CC46D6 Cisco Systems
+48AD08 Huawei Technologies
+2CAB00 Huawei Technologies
+00E0FC Huawei Technologies
+24DF6A Huawei Technologies
+009ACD Huawei Technologies
+0050C2 Ieee Registration Authority
+00CDFE Apple
+38F23E Microsoft Mobile Oy
+58AC78 Cisco Systems
+907F61 Chicony Electronics
+001DCE Arris Group
+001DD4 Arris Group
+001DCD Arris Group
+CCA462 Arris Group
+903EAB Arris Group
+28BC18 SourcingOverseas
+807ABF HTC
+409F87 Jide Technology (Hong Kong) Limited
+544E45 Private
+3C5AB4 Google
+001A11 Google
+D83C69 Shenzhen Tinno Mobile Technology
+74AC5F Qiku Internet Network Scientific (Shenzhen)
+18AF61 Apple
+BC83A7 Shenzhen Chuangwei-rgb Electronics
+14CFE2 Arris Group
+900DCB Arris Group
+207355 Arris Group
+C83FB4 Arris Group
+E0B70A Arris Group
+78719C Arris Group
+D40598 Arris Group
+946269 Arris Group
+8C7F3B Arris Group
+D039B3 Arris Group
+0000C5 Arris Group
+3C36E4 Arris Group
+00ACE0 Arris Group
+000347 Intel
+001175 Intel
+0013E8 Intel Corporate
+001302 Intel Corporate
+E4F89C Intel Corporate
+A402B9 Intel Corporate
+4C3488 Intel Corporate
+000D0B Buffalo.inc
+000740 Buffalo.inc
+0024A5 Buffalo.inc
+DCFB02 Buffalo.inc
+F4CE46 Hewlett Packard
+001CC4 Hewlett Packard
+0025B3 Hewlett Packard
+001871 Hewlett Packard
+000BCD Hewlett Packard
+000E7F Hewlett Packard
+000F20 Hewlett Packard
+00110A Hewlett Packard
+001321 Hewlett Packard
+001635 Hewlett Packard
+0017A4 Hewlett Packard
+000802 Hewlett Packard
+90E7C4 HTC
+00265E Hon Hai Precision Ind.
+00234E Hon Hai Precision Ind.
+00234D Hon Hai Precision Ind.
+74A78E zte
+D860B0 bioMrieux Italia
+8038BC Huawei Technologies
+D440F0 Huawei Technologies
+64A651 Huawei Technologies
+E8CD2D Huawei Technologies
+ACE215 Huawei Technologies
+EC233D Huawei Technologies
+78F5FD Huawei Technologies
+80B686 Huawei Technologies
+10C61F Huawei Technologies
+8853D4 Huawei Technologies
+0C37DC Huawei Technologies
+BC7670 Huawei Technologies
+24DBAC Huawei Technologies
+BC3AEA Guangdong Oppo Mobile Telecommunications
+E8BBA8 Guangdong Oppo Mobile Telecommunications
+0021E8 Murata Manufacturing
+006057 Murata Manufacturing
+0007D8 Hitron Technologies.
+0012F2 Brocade Communications Systems
+001BED Brocade Communications Systems
+002438 Brocade Communications Systems
+84742A zte
+681AB2 zte
+001C25 Hon Hai Precision Ind.
+E005C5 Tp-link Technologies
+A0F3C1 Tp-link Technologies
+8C210A Tp-link Technologies
+EC172F Tp-link Technologies
+EC888F Tp-link Technologies
+14CF92 Tp-link Technologies
+645601 Tp-link Technologies
+14CC20 Tp-link Technologies
+BC4699 Tp-link Technologies
+0C45BA Huawei Technologies
+847778 Cochlear Limited
+0453D5 Sysorex Global Holdings
+CC4463 Apple
+6C72E7 Apple
+0016CF Hon Hai Precision Ind.
+4437E6 Hon Hai Precision Ind.
+F4B7E2 Hon Hai Precision Ind.
+083E8E Hon Hai Precision Ind.
+485AB6 Hon Hai Precision Ind.
+CCA223 Huawei Technologies
+E8088B Huawei Technologies
+60E701 Huawei Technologies
+000883 Hewlett Packard
+C4346B Hewlett Packard
+8CDCD4 Hewlett Packard
+3464A9 Hewlett Packard
+D4C9EF Hewlett Packard
+A45D36 Hewlett Packard
+A0D3C1 Hewlett Packard
+40A8F0 Hewlett Packard
+6C3BE5 Hewlett Packard
+082E5F Hewlett Packard
+28924A Hewlett Packard
+10604B Hewlett Packard
+308D99 Hewlett Packard
+0030C1 Hewlett Packard
+FC3FDB Hewlett Packard
+4CA161 Rain Bird
+7C6193 HTC
+001217 Cisco-Linksys
+000C41 Cisco-Linksys
+000F66 Cisco-Linksys
+44E08E Cisco Spvtg
+185933 Cisco Spvtg
+E448C7 Cisco Spvtg
+24767D Cisco Spvtg
+2CABA4 Cisco Spvtg
+0002C7 Alps Electric
+04766E Alps Electric
+006B8E Shanghai Feixun Communication
+AC853D Huawei Technologies
+74882A Huawei Technologies
+78D752 Huawei Technologies
+E0247F Huawei Technologies
+00464B Huawei Technologies
+707BE8 Huawei Technologies
+548998 Huawei Technologies
+0819A6 Huawei Technologies
+3CF808 Huawei Technologies
+B41513 Huawei Technologies
+283152 Huawei Technologies
+DCD2FC Huawei Technologies
+0012D2 Texas Instruments
+080028 Texas Instruments
+6CECEB Texas Instruments
+84EB18 Texas Instruments
+D4F513 Texas Instruments
+A0F6FD Texas Instruments
+209148 Texas Instruments
+D0B5C2 Texas Instruments
+F8A45F Xiaomi Communications
+8CBEBE Xiaomi Communications
+640980 Xiaomi Communications
+98FAE3 Xiaomi Communications
+185936 Xiaomi Communications
+9C99A0 Xiaomi Communications
+0003DD Comark Interactive Solutions
+00107B Cisco Systems
+00906D Cisco Systems
+0090BF Cisco Systems
+005080 Cisco Systems
+D0E54D Pace plc
+FC8E7E Pace plc
+B4F2E8 Pace plc
+7085C6 Pace plc
+00E018 Asustek Computer
+000C6E Asustek Computer
+001BFC Asustek Computer
+001E8C Asustek Computer
+0015F2 Asustek Computer
+002354 Asustek Computer
+001FC6 Asustek Computer
+60182E ShenZhen Protruly Electronic
+F4CFE2 Cisco Systems
+501CBF Cisco Systems
+285FDB Huawei Technologies
+404D8E Huawei Technologies
+781DBA Huawei Technologies
+001E10 Huawei Technologies
+B0ADAA Avaya
+10CDAE Avaya
+50CD22 Avaya
+FCA841 Avaya
+3CB15B Avaya
+C8F406 Avaya
+2CF4C5 Avaya
+7038EE Avaya
+88F031 Cisco Systems
+508789 Cisco Systems
+381C1A Cisco Systems
+F40F1B Cisco Systems
+BC671C Cisco Systems
+A0ECF9 Cisco Systems
+D46D50 Cisco Systems
+1CE85D Cisco Systems
+C47295 Cisco Systems
+A0554F Cisco Systems
+84B802 Cisco Systems
+BCC493 Cisco Systems
+001947 Cisco Spvtg
+0022CE Cisco Spvtg
+F02929 Cisco Systems
+ECE1A9 Cisco Systems
+7C69F6 Cisco Systems
+C08C60 Cisco Systems
+C0255C Cisco Systems
+885A92 Cisco Systems
+E4C722 Cisco Systems
+C07BBC Cisco Systems
+005094 Pace plc
+0090F2 Cisco Systems
+00173B Cisco Systems
+00400B Cisco Systems
+006009 Cisco Systems
+006047 Cisco Systems
+0006C1 Cisco Systems
+00E014 Cisco Systems
+00E01E Cisco Systems
+ACF2C5 Cisco Systems
+CCC760 Apple
+087402 Apple
+285AEB Apple
+28F076 Apple
+84285A Saffron Solutions
+80A1AB Intellisis
+CC79CF Shenzhen Rf-link Elec&technologyltd
+44D884 Apple
+EC852F Apple
+286ABA Apple
+705681 Apple
+7CD1C3 Apple
+F0DCE2 Apple
+B065BD Apple
+A82066 Apple
+BC6778 Apple
+68967B Apple
+848506 Apple
+B4F0AB Apple
+10DDB1 Apple
+04F7E4 Apple
+34C059 Apple
+F0D1A9 Apple
+F82793 Apple
+ACFDEC Apple
+D0E140 Apple
+F832E4 Asustek Computer
+8C7C92 Apple
+7831C1 Apple
+F437B7 Apple
+54AE27 Apple
+6476BA Apple
+84B153 Apple
+783A84 Apple
+2CBE08 Apple
+24E314 Apple
+0010FF Cisco Systems
+34BDC8 Cisco Systems
+54A274 Cisco Systems
+5897BD Cisco Systems
+046C9D Cisco Systems
+60FEC5 Apple
+00A040 Apple
+BC3BAF Apple
+786C1C Apple
+041552 Apple
+38484C Apple
+701124 Apple
+C86F1D Apple
+685B35 Apple
+380F4A Apple
+3010E4 Apple
+04DB56 Apple
+881FA1 Apple
+04E536 Apple
+109ADD Apple
+40A6D9 Apple
+7CF05F Apple
+A4B197 Apple
+0C74C2 Apple
+403004 Apple
+4860BC Apple
+50EAD6 Apple
+28E02C Apple
+60C547 Apple
+7C11BE Apple
+003EE1 Apple
+68D93C Apple
+2CF0EE Apple
+84788B Apple
+6C94F8 Apple
+703EAC Apple
+C01ADA Apple
+34363B Apple
+C81EE7 Apple
+9CFC01 Apple
+000D93 Apple
+001CB3 Apple
+64B9E8 Apple
+34159E Apple
+58B035 Apple
+F0B479 Apple
+141357 ATP Electronics
+F44B2A Cisco Spvtg
+3C8CF8 Trendnet
+78D6B2 Toshiba
+C04A09 Zhejiang Everbright Communication Equip.
+F00D5C JinQianMao  Technology
+2C081C OVH
+30E090 Linctronix,
+70BF3E Charles River Laboratories
+D848EE Hangzhou Xueji Technology
+EC9BF3 Samsung Electro Mechanics
+88947E Fiberhome Telecommunication Technologies
+88C242 Poynt
+E8343E Beijing Infosec Technologies
+A8474A Hon Hai Precision Ind.
+C4ADF1 Gopeace
+58F496 Source Chain
+80B709 Viptela
+1C60DE Shenzhen Mercury Communication Technologies
+741865 Shanghai DareGlobal Technologies
+0084ED Private
+DCDC07 TRP Systems BV
+080A4E Planet Bingo  3rd Rock Gaming
+0C1A10 Acoustic Stream
+E4A387 Control Solutions
+DC82F6 iPort
+C49E41 G24 Power Limited
+D03E5C Huawei Technologies
+C8A9FC Goyoo Networks
+C49FF3 Mciao Technologies
+80739F Kyocera
+7C2BE1 Shenzhen Ferex Electrical
+30FFF6 HangZhou KuoHeng Technology
+5853C0 Beijing Guang Runtong Technology Development Company
+5031AD ABB Global Industries and Services Private Limited
+30A243 Shenzhen Prifox Innovation Technology
+2CA539 Parallel Wireless
+FC335F Polyera
+FCC233 Private
+645D92 Sichuan Tianyi Comheart Telecomco.
+A8C87F Roqos
+C025A2 NEC Platforms
+7853F2 Roxton
+384C90 Arris Group
+ACBC32 Apple
+94BBAE Husqvarna AB
+AC8995 AzureWave Technology
+F898B9 Huawei Technologies
+D40AA9 Arris Group
+1C497B Gemtek Technology
+2CCF58 Huawei Technologies
+54FF82 Davit Solution
+D445E8 Jiangxi Hongpai Technology
+847973 Shanghai Baud Data Communication
+906F18 Private
+881B99 Shenzhen XIN FEI JIA Electronic
+681295 Lupine Lighting Systems GmbH
+649A12 P2 Mobile Technologies Limited
+E4C2D1 Huawei Technologies
+DC3CF6 Atomic Rules
+441CA8 Hon Hai Precision Ind.
+C4047B Shenzhen Youhua Technology
+F895C7 LG Electronics (Mobile Communications)
+3C3178 Qolsys
+F4573E Fiberhome Telecommunication Technologies
+083A5C Junilab
+E8377A ZyXEL Communications
+4CAE31 ShengHai Electronics (Shenzhen)
+C80E14 AVM Audiovisuelles Marketing und Computersysteme GmbH
+F0D657 Echosens
+24693E innodisk
+E48D8C Routerboard.com
+C0DC6A Qingdao Eastsoft Communication Technology
+6459F8 Vodafone Omnitel
+082CB0 Network Instruments
+F0AB54 Mitsumi Electric
+485073 Microsoft
+3CA31A Oilfind International
+ACFD93 Weifang GoerTek Electronics
+A424DD Cambrionix
+88A2D7 Huawei Technologies
+D89A34 Beijing Shenqi Technology
+1CADD1 Bosung Electronics
+24E5AA Philips Oral Healthcare
+741F4A Hangzhou H3C Technologies, Limited
+88CBA5 Suzhou Torchstar Intelligent Technology
+A47B2C Alcatel-Lucent
+184F32 Hon Hai Precision Ind.
+20F41B Shenzhen Bilian electronic
+046169 Media Global Links
+AC562C Lava International(h.k) Limited
+3CCE15 Mercedes-Benz USA
+84DF19 Chuango Security Technology
+3C4711 Huawei Technologies
+245BF0 Liteon
+FCFEC2 Invensys Controls UK Limited
+E8F2E2 LG Innotek
+AC676F Electrocompaniet A.S.
+4CB82C Cambridge Mobile Telematics
+F0224E Esan electronic
+B0411D Ittim Technologies
+7CB25C Acacia Communications
+78EB39 Instituto Nacional de Tecnologa Industrial
+7CC95A EMC
+ECEED8 Ztlx Network Technology
+F85B9C SB Systems
+7CA237 King Slide Technology
+B0E2E5 Fiberhome Telecommunication Tech.Co.
+300EE3 Aquantia
+847303 Letv Mobile and Intelligent Information Technology (Beijing)
+B0495F Omron Healthcare
+BC6E64 Sony Mobile Communications AB
+8C8B83 Texas Instruments
+90A210 United Telecoms
+F44713 Leading Public Performance
+D4522A TangoWiFi.com
+B0ECE1 Private
+AC9B0A Sony
+407FE0 Glory Star Technics (ShenZhen) Limited
+BC5C4C Elecom
+6C5940 Shenzhen Mercury Communication Technologies
+6CA75F zte
+C8C50E Shenzhen Primestone Network Technologies.Co.
+9CBEE0 Biosoundlab
+5C5B35 Mist Systems
+E807BF Shenzhen Boomtech Industry
+E8162B Ideo Security
+709F2D zte
+5C6B4F Private
+ECE2FD SKG Electric Group(Thailand)
+88E603 Avotek
+0C4885 LG Electronics
+74E28C Microsoft
+94F19E Huizhou Maorong Intelligent Technology
+C4924C Keisokuki Center
+E4F939 Minxon Hotel Technology
+38C70A WiFiSong
+60E6BC Sino-Telecom Technology
+3CCB7C TCT mobile
+F09FC2 Ubiquiti Networks
+44D9E7 Ubiquiti Networks
+F8042E Samsung Electro Mechanics
+1CA532 Shenzhen Gongjin Electronics
+643AB1 Sichuan Tianyi Comheart Telecomco.
+486EFB Davit System Technology
+340A22 Top-access Electronics
+B008BF Vital Connect
+7CF854 Samsung Electronics
+485415 NET Rules Tecnologia Eireli
+70C76F Inno
+C48E8F Hon Hai Precision Ind.
+704E66 Shenzhen Fast Technologies
+1008B1 Hon Hai Precision Ind.
+409B0D Shenzhen Yourf Kwan Industrial
+C40880 Shenzhen Utepo Tech
+94C038 Tallac Networks
+801967 Shanghai Reallytek Information Technology 
+6836B5 DriveScale
+2CF7F1 Seeed Technology
+F88479 Yaojin Technology(Shenzhen)Co.
+4C48DA Beijing Autelan Technology
+90179B Nanomegas
+3077CB Maike Industry(Shenzhen)CO.
+88C9D0 LG Electronics
+BC6B4D Alcatel-Lucent
+3428F0 ATN International Limited
+EC3C5A Shen Zhen Heng Sheng HUI Digital Technology
+8C0551 Koubachi AG
+D88466 Extreme Networks
+E887A3 Loxley Public Company Limited
+10FACE Reacheng Communication Technology
+D8CB8A Micro-star Intl
+A8D0E3 Systech Electronics
+8463D6 Microsoft
+78B3B9 ShangHai sunup lighting
+586AB1 Hangzhou H3C Technologies, Limited
+F4EE14 Shenzhen Mercury Communication Technologies
+186571 Top Victory Electronics (Taiwan)
+F8BC41 Rosslare Enterprises Limited
+8486F3 Greenvity Communications
+205CFA Yangzhou ChangLian Network Technology
+8C18D9 Shenzhen RF Technology
+6099D1 Vuzix / Lenovo
+38B1DB Hon Hai Precision Ind.
+34F6D2 Panasonic Taiwan
+DC2F03 Step forward Group
+582136 KMB systems, s.r.o.
+00AEFA Murata Manufacturing
+5CAAFD Sonos
+8CDF9D NEC
+F8E903 D-Link International
+F0B052 Ruckus Wireless
+6828F6 Vubiq Networks
+44356F Neterix
+742EFC DirectPacket Research
+20C06D Shenzhen Spacetek Technology
+3CB792 Hitachi Maxell,, Optronics Division
+7491BD Four systems
+D43266 Fike
+948E89 Industrias Unidas SA DE CV
+9405B6 Liling FullRiver Electronics & Technology
+382C4A Asustek Computer
+74547D Cisco Spvtg
+D48F33 Microsoft
+D84A87 OI Electric
+1CA2B1 ruwido austria gmbh
+945493 Rigado
+34B7FD Guangzhou Younghead Electronic Technology
+384B76 Airtame ApS
+1C5216 Dongguan Hele Electronics
+34029B CloudBerry Technologies Private Limited
+70AF25 Nishiyama Industry
+B47C29 Shenzhen Guzidi Technology
+2C1A31 Electronics Company Limited
+6C198F D-Link International
+60C1CB Fujian Great Power PLC Equipment
+686E48 Prophet Electronic Technology
+30F7D7 Thread Technology
+3808FD Silca Spa
+7C2587 chaowifi.com
+2012D5 Scientech Materials
+DC3979 Skyport Systems
+EC1D7F zte
+AC11D3 Suzhou Hotek  Video Technology
+304225 Burg-wchter KG
+1C4840 IMS Messsysteme GmbH
+F42853 Zioncom Electronics (Shenzhen)
+3C46D8 Tp-link Technologies
+6C0273 Shenzhen Jin Yun Video Equipment
+600292 Pegatron
+2CFAA2 Alcatel-Lucent
+F0761C Compal Information (kunshan)
+F42833 Mmpc
+244F1D iRule
+BC9CC5 Beijing Huafei Technology
+505065 Takt
+D00AAB Yokogawa Digital Computer
+A4A4D3 Bluebank Communication TechnologyLtd
+74F413 Maxwell Forest
+34F0CA Shenzhen Linghangyuan Digital Technology
+84183A Ruckus Wireless
+30B5F1 Aitexin Technology
+882950 Dalian Netmoon Tech Develop
+08CD9B samtec automotive electronics & software GmbH
+28FCF6 Shenzhen Xin KingBrand enterprises
+2C54CF LG Electronics
+4C26E7 Welgate
+94D60E shenzhen yunmao information technologies
+7C6AC3 GatesAir
+D8E56D TCT Mobile Limited
+3CCD5A Technische Alternative GmbH
+B0754D Alcatel-Lucent
+604826 Newbridge Technologies Int.
+24D13F Mexus
+702C1F Wisol
+9CBD9D SkyDisk
+74C621 Zhejiang Hite Renewable Energy
+44C306 Sifrom
+54A31B Shenzhen Linkworld Technology
+5CE7BF New Singularity International Technical Development
+1CEEE8 Ilshin Elecom
+6C641A Penguin Computing
+E036E3 Stage One International
+34DE34 zte
+34466F HiTEM Engineering
+2C39C1 Ciena
+6C2C06 OOO NPP Systemotechnika-NN
+54EE75 Wistron InfoComm(Kunshan)Co.
+202564 Pegatron
+60812B Custom Control Concepts
+F86601 Suzhou Chi-tek information technology
+FC4AE9 Castlenet Technology
+BC8D0E Alcatel-Lucent
+34E42A Automatic Bar Controls
+B87CF2 Aerohive Networks
+20A787 Bointec Taiwan Limited
+6CAAB3 Ruckus Wireless
+A481EE Nokia
+54C80F Tp-link Technologies
+D42122 Sercomm
+EC1766 Research Centre Module
+7CFF62 Huizhou Super Electron Technology
+A0D12A Axpro Technology
+30C750 MIC Technology Group
+442938 NietZsche enterpriseLtd.
+D881CE AHN
+E0D31A Eques Technology, Limited
+9C3EAA EnvyLogic
+909864 Impex-Sat GmbH&amp;Co KG
+DCE578 Experimental Factory of Scientific Engineering and Special Design Department
+949F3F Optek Digital Technology company limited
+987770 Pep Digital Technology (Guangzhou)
+4411C2 Telegartner Karl Gartner GmbH
+9451BF Hyundai ESG
+4C7F62 Nokia
+841766 Weifang GoerTek Electronics
+F03FF8 R L Drake
+B0C554 D-Link International
+54D163 Max-tech
+E41218 ShenZhen Rapoo Technology
+2C8A72 HTC
+4486C1 Siemens Low Voltage & Products
+C83168 eZEX
+843838 Samsung Electro Mechanics
+F84A73 Eumtech
+880F10 Huami Information Technology
+24336C Private
+C46BB4 myIDkey
+ECE512 tado GmbH
+30918F Technicolor
+FC09F6 Guangdong Tonze Electric
+687848 Westunitis
+A8B9B3 Essys
+64B370 PowerComm Solutions
+D86595 Toy's Myth
+C45006 Samsung Electronics
+D8DD5F Balmuda
+88D962 Canopus Systems US
+24C848 mywerk system GmbH
+805719 Samsung Electronics
+B0DF3A Samsung Electronics
+2C18AE Trend Electronics
+E097F2 Atomax
+90F3B7 Kirisun Communications
+DCAD9E GreenPriz
+B4827B AKG Acoustics GmbH
+908C44 H.K Zongmu Technology
+0C473D Hitron Technologies.
+4C5E0C Routerboard.com
+9CF8DB shenzhen eyunmei technology
+644214 Swisscom Energy Solutions AG
+00E3B2 Samsung Electronics
+30D6C9 Samsung Electronics
+107BEF ZyXEL Communications
+84262B Alcatel-Lucent
+8CCDA2 ACTP
+CC720F Viscount Systems
+906717 Alphion India Private Limited
+24050F MTN Electronic
+40B6B1 Sungsam
+98FF6A Otec(shanghai)technology
+AC6BAC Jenny Science AG
+0C54A5 Pegatron
+707C18 Adata Technology
+FC4B1C Intersensor S.r.l.
+1879A2 GMJ Electric Limited
+E0C86A Shenzhen Tw-scie
+80BAE6 Neets
+3C18A0 Luxshare Precision Industry
+4CB81C SAM Electronics GmbH
+2C3731 ShenZhen Yifang Digital Technology
+041A04 WaveIP
+94E98C Alcatel-Lucent
+50206B Emerson Climate Technologies Transportation Solutions
+C8EE75 Pishion International
+CC3429 Tp-link Technologies
+407496 Afun Technology
+18C8E7 Shenzhen Hualistone Technology
+3CF748 Shenzhen Linsn Technology Development
+9C039E Beijing Winchannel Software Technology
+F8A963 Compal Information (kunshan)
+48A2B7 Kodofon JSC
+443C9C Pintsch Tiefenbach GmbH
+F81CE5 Telefonbau Behnke GmbH
+BC2D98 ThinGlobal
+7C72E4 Unikey Technologies
+8048A5 Sichuan Tianyi Comheart Telecom
+181BEB Actiontec Electronics
+CC7498 Filmetrics
+7C6AB3 IBC Technologies
+309BAD BBK Electronics
+F0321A Mita-Teknik A/S
+4CD7B6 Helmer Scientific
+746F3D Contec GmbH
+483D32 Syscor Controls &amp; Automation
+9031CD Onyx Healthcare
+A0E453 Sony Mobile Communications AB
+404A18 Addrek Smart Solutions
+E48184 Alcatel-Lucent
+C4C0AE Midori Electronic
+08FD0E Samsung Electronics
+78A873 Samsung Electronics
+54880E Samsung Electro Mechanics
+90837A General Electric Water & Process Technologies
+089758 Shenzhen Strong Rising Electronics,Ltd DongGuan Subsidiary
+B424E7 Codetek Technology
+44EE30 Budelmann Elektronik GmbH
+38DBBB Sunbow Telecom
+2493CA Voxtronic Technology Computer-Systeme GmbH
+688AB5 EDP Servicos
+407A80 Nokia
+F06130 Advantage Pharmacy Services
+D481CA iDevices
+B898F7 Gionee Communication Equipment,Ltd.ShenZhen
+C0F1C4 Pacidal
+D858D7 CZ.NIC, z.s.p.o.
+BC307D Wistron Neweb
+10B713 Private
+E8E770 Warp9 Tech Design
+78CA5E Elno
+98FFD0 Lenovo Mobile Communication Technology
+50A054 Actineon
+48EE86 UTStarcom (China)
+5056A8 Jolla
+D09D0A Linkcom
+C81479 Samsung Electronics
+54FB58 Wiseware
+A42940 Shenzhen Youhua Technology
+C0A0BB D-Link International
+28A1EB Etek Technology (shenzhen)
+4CCBF5 zte
+F0F5AE Adaptrum
+F42896 Specto Paineis Eletronicos Ltda
+1C7B21 Sony Mobile Communications AB
+BC9680 Shenzhen Gongjin Electronics
+9C2840 Discovery Technology
+F89FB8 Yazaki Energy System
+F037A1 Huike Electronics (shenzhen)
+6CD1B0 Wing Sing Electronics Hong Kong Limited
+544408 Nokia
+A4F522 Chofu Seisakusho
+7CE56B Esen Optoelectronics Technology
+CC4703 Intercon Systems
+5C3327 Spazio Italia srl
+BC8CCD Samsung Electro Mechanics
+F85BC9 M-Cube Spa
+8005DF Montage Technology Group Limited
+78E8B6 zte
+041B94 Host Mobility AB
+CC2A80 Micro-Biz intelligence solutions
+3859F8 MindMade Sp. z o.o.
+F0728C Samsung Electronics
+5C026A Applied Vision
+94350A Samsung Electronics
+7CBD06 AE Refusol
+94BA56 Shenzhen Coship Electronics
+2894AF Samhwa Telecom
+740EDB Optowiz
+00A2FF abatec group AG
+D095C7 Pantech
+D02C45 littleBits Electronics
+5027C7 Technart
+248000 Westcontrol AS
+F84A7F Innometriks
+58639A TPL Systemes
+0C9B13 Shanghai Magic Mobile TelecommunicationLtd.
+3C15EA Tescom
+B4CCE9 Prosyst
+34A3BF Terewave.
+B0CE18 Zhejiang shenghui lighting
+503CC4 Lenovo Mobile Communication Technology
+286D97 Samjin
+ACE42E SK hynix
+08EF3B MCS Logic
+98B039 Alcatel-Lucent
+806C8B Kaeser Kompressoren AG
+048C03 ThinPAD Technology (Shenzhen)CO.
+84E629 Bluwan SA
+34CD6D CommSky Technologies
+C47F51 Inventek Systems
+E8D4E0 Beijing BenyWave Technology
+54BEF7 Pegatron
+3889DC Opticon Sensors Europe
+88124E Qualcomm Atheros
+681D64 Sunwave Communications
+F4CD90 Vispiron Rotec GmbH
+400E85 Samsung Electro Mechanics
+E438F2 Advantage Controls
+24C9A1 Ruckus Wireless
+C8F386 Shenzhen Xiaoniao Technology
+E8CE06 SkyHawke Technologies
+B0808C Laser Light Engines
+C419EC Qualisys AB
+981094 Shenzhen Vsun communication technology
+082719 APS systems/electronic AG
+D4AC4E BODi rS
+B03850 Nanjing Cas-zdc IOT System
+C0DA74 Hangzhou Sunyard Technology
+34A843 Kyocera Display
+6C5779 Aclima
+40BD9E Physio-Control
+F4F5A5 Nokia
+BC79AD Samsung Electronics
+581CBD Affinegy
+649C81 Qualcomm iSkoot
+F82BC8 Jiangsu Switter
+60C397 2Wire
+3065EC Wistron (ChongQing)
+5CA3EB Lokel s.r.o.
+04DF69 Car Connectivity Consortium
+28DB81 Shanghai Guao Electronic Technology
+9CB793 Creatcomm Technology
+C4438F LG Electronics
+A0B100 ShenZhen Cando Electronics
+40560C In Home Displays
+9436E0 Sichuan Bihong Broadcast &amp; Television New Technologies
+D4D50D Southwest Microwave
+B8CD93 Penetek
+D8FEE3 D-Link International
+F8516D Denwa Technology
+1078CE Hanvit SI
+D8DA52 Apator
+107A86 U&U Engineering
+980D2E HTC
+842F75 Innokas Group
+D4BF7F Upvel
+5061D6 Indu-Sol GmbH
+68EC62 Yodo Technology
+10D542 Samsung Electronics
+A0821F Samsung Electronics
+F07F0C Leopold Kostal GmbH &Co. KG
+5C22C4 DAE EUN Eletronics
+08482C Raycore Taiwan
+F4B381 WindowMaster A/S
+74F102 Beijing Hchcom Technology
+080EA8 Velex s.r.l.
+041BBA Samsung Electronics
+5C3C27 Samsung Electronics
+0086A0 Private
+C8D10B Nokia
+60FE1E China Palms Telecom.Ltd
+841E26 Kernel-i
+349D90 Heinzmann GmbH & KG
+D4016D Tp-link Technologies
+FC1186 Logic3 plc
+50CD32 NanJing Chaoran Science & Technology
+683EEC Ereca
+3CC243 Nokia
+44619C FONsystem
+BCBAE1 Arec
+18FA6F ISC applied systems
+9C9726 Technicolor
+880905 Mtmcommunications
+C42628 Airo Wireless
+745F00 Samsung Semiconductor
+541FD5 Advantage Electronics
+90FF79 Metro Ethernet Forum
+E08177 GreenBytes
+48F230 Ubizcore
+B0C95B Beijing Symtech
+881544 Meraki
+DCA989 Macandc
+C05E6F V. Stonkaus firma Kodinis Raktas
+6CD146 Smartek d.o.o.
+E0C2B7 Masimo
+F82EDB RTW GmbH & KG
+60A44C Asustek Computer
+045FA7 Shenzhen Yichen Technology Development
+983F9F China SSJ (Suzhou) Network Technology
+F02329 Showa Denki
+6499A0 AG Elektronik AB
+A80180 Imago Technologies Gmbh
+044CEF Fujian Sanao Technology
+DC1DD4 Microstep-MIS spol. s r.o.
+E01877 Fujitsu Limited
+149448 BLU Castle
+40516C Grandex International
+D0D471 Mvtech
+34ADE4 Shanghai Chint Power Systems
+1853E0 Hanyang DigitechLtd
+C4E032 Ieee 1904.1 Working Group
+ACDBDA Shenzhen Geniatech
+A42C08 Masterwork Automodules
+60B185 ATH system
+504F94 Loxone Electronics GmbH
+88329B Samsung Electro Mechanics
+8C078C Flow Data
+8887DD DarbeeVision
+807B1E Corsair Components
+A0E25A Amicus SK, s.r.o.
+F87B62 Fastwel International, Taiwan Branch
+B49842 zte
+9C9C1D Starkey Labs
+90CC24 Synaptics
+182A7B Nintendo
+AC1702 Fibar Group sp. z o.o.
+7898FD Q9 Networks
+3C57D5 FiveCo
+4C2258 cozybit
+10EA59 Cisco Spvtg
+34FA40 Guangzhou Robustel Technologies, Limited
+181725 Cameo Communications
+E82E24 Out of the Fog Research
+1C52D6 Flat Display Technology
+40270B Mobileeco
+ACE97F IoT Tech Limited
+301518 Ubiquitous Communication
+101248 ITG
+106FEF Ad-Sol Nissin
+A036F0 Comprehensive Power
+180CAC Canon
+00DB1E Albedo Telecom SL
+74943D AgJunction
+0CDA41 Hangzhou H3C Technologies, Limited
+080C0B SysMik GmbH Dresden
+C8FB26 Cisco Spvtg
+7CC8AB Acro Associates
+C4DA26 Noblex SA
+1CC316 MileSight Technology
+C4E7BE SCSpro
+105F49 Cisco Spvtg
+0418D6 Ubiquiti Networks
+4495FA Qingdao Santong Digital TechnologyLtd
+60F2EF VisionVera International
+B01266 Futaba-Kikaku
+909DE0 Newland Design + Assoc.
+64D814 Cisco Systems
+6CE4CE Villiger Security Solutions AG
+30F33A +plugg srl
+58CF4B Lufkin Industries
+C4393A SMC Networks
+C4017C Ruckus Wireless
+D45C70 Wi-Fi Alliance
+08EBED World Elite Technology
+60BC4C EWM Hightec Welding GmbH
+F41E26 Simon-Kaloi Engineering
+840B2D Samsung Electro-mechanics
+C44567 Sambon Precison and Electronics
+D0738E Dong OH Precision
+E8718D Elsys Equipamentos Eletronicos Ltda
+3C83B5 Advance Vision Electronics
+808287 Atcom Technologyltd.
+28A192 Gerp Solution
+A08C15 Gerhard D. Wempe KG
+A02195 Samsung Electronics Digital Imaging
+8CE081 zte
+485261 Soreel
+10FBF0 KangSheng
+3C57BD Kessler Crane
+600F77 SilverPlus
+6851B7 PowerCloud Systems
+A44E2D Adaptive Wireless Solutions
+3CC12C AES
+0CCDFB Edic Systems
+3092F6 Shanghai Sunmon Communication Technogy
+2CE2A8 DeviceDesign
+B49DB4 Axion Technologies
+D8182B Conti Temic Microelectronic GmbH
+304449 Plath Gmbh
+94FD2E Shanghai Uniscope Technologies
+64A341 Wonderlan (Beijing) Technology
+8CAE4C Plugable Technologies
+D8D5B9 Rainforest Automation
+C0A0E2 Eden Innovations
+E8ABFA Shenzhen Reecam Tech.Ltd.
+58874C Lite-on Clean Energy Technology
+E85BF0 Imaging Diagnostics
+20DC93 Cheetah Hi-Tech
+7846C4 Daehap Hyper-tech
+0CD9C1 Visteon
+68AB8A RF IDeas
+70E24C SAE IT-systems GmbH & KG
+88615A Siano Mobile Silicon
+30215B Shenzhen Ostar Display Electronic
+08D42B Samsung Electronics
+DC028E zte
+DCB058 Brkert Werke GmbH
+641C67 Digibras Industria DO Brasils/a
+C8E1A7 Vertu Limited
+88D7BC DEP Company
+F49466 CountMax
+4CAB33 KST technology
+5CE0F6 NIC.br- Nucleo de Informacao e Coordenacao do Ponto BR
+00E666 Arima Communications
+F8E4FB Actiontec Electronics
+5887E2 Shenzhen Coship Electronics
+B4DFFA Litemax Electronics
+48F8B3 Cisco-Linksys
+681CA2 Rosewill
+7C092B Bekey A/S
+E892A4 LG Electronics
+D808F5 Arcadia Networks 
+84DF0C Net2grid BV
+3CB87A Private
+E425E9 Color-Chip
+F44848 Amscreen Group
+441319 WKK Technology
+088F2C Hills Sound Vision & Lighting
+3C9F81 Shenzhen Catic Bit Communications Technology
+18339D Cisco Systems
+642216 Shandong Taixin Electronic
+D43D7E Micro-Star Int'l
+64517E Long BEN (dongguan) Electronic Technology
+A816B2 LG Electronics
+18E2C2 Samsung Electronics
+0C57EB Mueller Systems
+48282F zte
+745327 Commsen, Limited
+E47185 Securifi
+881036 Panodic(ShenZhen) Electronics Limted
+18F87A i3 International
+142DF5 Amphitech
+C08ADE Ruckus Wireless
+90F72F Phillips Machine & Welding
+B45570 Borea
+5C5015 Cisco Systems
+0CD2B5 Binatone Telecommunication Pvt.
+1C62B8 Samsung Electronics
+4846F1 Uros Oy
+1CD40C Kriwan Industrie-Elektronik GmbH
+747B7A ETH
+1C7C45 Vitek Industrial Video Products
+FC94E3 Technicolor USA
+C8AE9C Shanghai TYD Elecronic Technology
+A44C11 Cisco Systems
+782544 Omnima Limited
+D4DF57 Alpinion Medical Systems
+5048EB Beijing Haihejinsheng Network Technology
+40AC8D Data Management
+54466B Shenzhen Cztic Electronic Technology
+08EDB9 Hon Hai Precision Ind.
+1C3477 Innovation Wireless
+4423AA Farmage
+A0EF84 Seine Image Int'l
+AC7A42 iConnectivity
+5869F9 Fusion Transactive
+B0C83F Jiangsu Cynray IOT
+CC14A6 Yichun MyEnergy Domain
+98D686 Chyi Lee industry
+20443A Schneider Electric Asia Pacific
+28C914 Taimag
+4C7897 Arrowhead Alarm Products
+AC0A61 Labor S.r.L.
+B482C5 Relay2
+60D1AA Vishal Telecommunications Pvt
+CCC104 Applied Technical Systems
+709BA5 Shenzhen Y&D Electronics
+EC42F0 ADL Embedded Solutions
+10BD18 Cisco Systems
+B0435D NuLEDs
+A82BD6 Shina System
+8CC7AA Radinet Communications
+20014F Linea Research
+80D18B Hangzhou I'converge Technology
+B4A4B5 Zen Eye
+489153 Weinmann Gerte fr Medizin GmbH + KG
+549D85 EnerAccess
+5CEE79 Global Digitech
+80F62E Hangzhou H3C Technologies, Limited
+9CE10E NCTech
+28F606 Syes srl
+A0C3DE Triton Electronic Systems
+AC3FA4 Taiyo Yuden
+0C130B Uniqoteq
+14CF8D Ohsung Electronics
+808698 Netronics Technologies
+2C00F7 XOS
+809393 Xapt GmbH
+00DEFB Cisco Systems
+90AC3F BrightSign
+7CACB2 Bosch Software Innovations GmbH
+0043FF Ketron S.r.l.
+745798 Trumpf Laser Gmbh + KG
+38E08E Mitsubishi Electric
+E4FA1D PAD Peripheral Advanced Design
+4C9E80 Kyokko Electric
+A826D9 HTC
+F03A55 Omega Elektronik AS
+24B88C Crenus
+98BC57 SVA Technologiesltd
+98FE03 Ericsson - North America
+F0EEBB Vipar Gmbh
+54D0ED Axim Communications
+A49005 China Greatwall Computer Shenzhen
+3055ED Trex Network
+D4A02A Cisco Systems
+0463E0 Nome Oy
+BCA4E1 Nabto
+900A3A PSG Plastic Service GmbH
+FC5B26 MikroBits
+5CC213 Fr. Sauter AG
+581D91 Advanced Mobile Telecom
+9CB008 Ubiquitous Computing Technology
+00376D Murata Manufacturing
+E0EF25 Lintes Technology
+CCEED9 Vahle Deto Gmbh
+645EBE Yahoo! Japan
+CCC50A Shenzhen Dajiahao Technology
+D01AA7 UniPrint
+B08E1A URadio Systems
+40605A Hawkeye Tech
+E05DA6 Detlef Fink Elektronik & Softwareentwicklung
+0C7523 Beijing Gehua Catv Network
+BC2C55 Bear Flag Design
+04F4BC Xena Networks
+608C2B Hanson Technology
+EC1120 FloDesign Wind Turbine
+D0F73B Helmut Mauell GmbH
+C495A2 Shenzhen Weijiu Industry AND Trade Development
+0C9E91 Sankosha
+F48771 Infoblox
+04F021 Compex Systems Pte
+8823FE TTTech Computertechnik AG
+98AAD7 Blue Wave Networking
+20107A Gemtek Technology
+502267 PixeLINK
+9092B4 Diehl BGT Defence GmbH & KG
+806007 RIM
+38A851 Moog
+90185E Apex Tool Group GmbH & OHG
+14825B Hefei Radio Communication Technology
+7CE9D3 Hon Hai Precision Ind.
+8CC8CD Samsung Electronics
+649EF3 Cisco Systems
+34D09B MobilMAX Technology
+087572 Obelux Oy
+9C1FDD Accupix
+506441 Greenlee
+80946C Tokyo Radar
+00FA3B Cloos Electronic Gmbh
+28CD1C Espotel Oy
+D824BD Cisco Systems
+D878E5 Kuhn SA
+C49300 8Devices
+4C3910 Newtek Electronics
+5866BA Hangzhou H3C Technologies, Limited
+5808FA Fiber Optic & telecommunication
+7C94B2 Philips Healthcare Pcci
+200505 Radmax Communication Private Limited
+5848C0 Coflec
+C8F704 Building Block Video
+C8AF40 marco Systemanalyse und Entwicklung GmbH
+AC319D Shenzhen TG-NET Botone Technology
+08D09F Cisco Systems
+D0DFC7 Samsung Electronics
+B81413 Keen High Holding(HK)
+2037BC Kuipers Electronic Engineering BV
+A887ED ARC Wireless
+983571 Sub10 Systems
+B05CE5 Nokia
+4813F3 BBK Electronics
+CC6BF1 Sound Masking
+B82CA0 Honeywell HomMed
+94AE61 Alcatel Lucent
+7CA61D MHL
+5CCEAD Cdyne
+9CA3BA Sakura Internet
+709756 Happyelectronics
+D4206D HTC
+1866E3 Veros Systems
+00B338 Kontron Design Manufacturing Services (M) Sdn. Bhd
+94DE0E SmartOptics AS
+A429B7 bluesky
+700514 LG Electronics
+7C6B33 Tenyu Tech
+CCB8F1 Eagle Kingdom Technologies Limited
+DC2E6A HCT.
+34255D Shenzhen Loadcom Technology
+1897FF TechFaith Wireless Technology Limited
+0CDFA4 Samsung Electronics
+8C8E76 taskit GmbH
+B4D8DE iota Computing
+54CDA7 Fujian Shenzhou Electronic
+1000FD LaonPeople
+603553 Buwon Technology
+B89BC9 SMC Networks
+48022A B-Link Electronic Limited
+48A6D2 GJsun Optical Science and Tech
+186D99 Adanis
+047D7B Quanta Computer
+D44B5E Taiyo Yuden
+B40C25 Palo Alto Networks
+40BF17 Digistar Telecom. SA
+E4AFA1 Hes-so
+58920D Kinetic Avionics Limited
+207600 Actiontec Electronics
+84D32A Ieee 1905.1
+F8E7B5 tech Tecnologia Ltda
+0462D7 Alstom Hydro France
+CCC8D7 Cias Elettronica srl
+64AE0C Cisco Systems
+A446FA AmTRAN Video
+2804E0 Fermax Electronicau.
+FC01CD Fundacion Tekniker
+88E7A6 iKnowledge Integration
+98E79A Foxconn(NanJing) Communication
+54F5B6 Oriental Pacific International Limited
+34A55D Technosoft International SRL
+D0C282 Cisco Systems
+449CB5 Alcomp
+E4D53D Hon Hai Precision Ind.
+24E6BA JSC Zavod im. Kozitsky
+8C8A6E Estun Automation Technoloy
+E0ED1A vastriver Technology
+C83B45 JRI-Maxant
+685E6B PowerRay
+4C32D9 M Rutty Holdings
+50A733 Ruckus Wireless
+603FC5 COX
+182B05 8D Technologies
+54A9D4 Minibar Systems
+4861A3 Concern Axion JSC
+D89685 GoPro
+08A12B ShenZhen EZL Technology
+94319B Alphatronics BV
+08FC52 OpenXS BV
+205B5E Shenzhen Wonhe Technology
+3CC99E Huiyang Technology
+C8A1BA Neul
+AC02EF Comsis
+C43A9F Siconix
+0418B6 Private
+D4024A Delphian Systems
+84248D Zebra Technologies
+24EC99 Askey Computer
+9463D1 Samsung Electronics
+B8621F Cisco Systems
+B45CA4 Thing-talk Wireless Communication Technologies Limited
+AC8ACD Roger D.wensker, G.wensker sp.j.
+984246 SOL Industry PTE.
+28A574 Miller Electric Mfg.
+3826CD Andtek
+C436DA Rusteletech
+00FC70 Intrepid Control Systems
+A4EE57 Seiko Epson
+D0AFB6 Linktop Technology
+444F5E Pan Studios
+0C3956 Observator instruments
+A49981 FuJian Elite Power Tech
+B83A7B Worldplay (Canada)
+783F15 EasySYNC
+F4B549 Yeastar Technology
+88B168 Delta Control GmbH
+20B399 Enterasys
+18B79E Invoxia
+147411 RIM
+5C56ED 3pleplay Electronics Private Limited
+0838A5 Funkwerk plettac electronic GmbH
+BCCD45 Voismart
+78028F Adaptive Spectrum and Signal Alignment (assia)
+D4A425 Smax Technology
+98F8DB Marini Impianti Industriali s.r.l.
+140708 Private
+24C9DE Genoray
+605464 Eyedro Green Solutions
+54055F Alcatel Lucent
+405539 Cisco Systems
+B8BEBF Cisco Systems
+38FEC5 Ellips
+24C86E Chaney Instrument
+D4D898 Korea CNO Tech
+04180F Samsung Electronics
+5070E5 He Shan World Fair Electronics Technology Limited
+28EE2C Frontline Test Equipment
+802275 Beijing Beny Wave Technology
+BC8199 Basic
+000726 Shenzhen Gongjin Electronics
+24470E PentronicAB
+A4DB2E Kingspan Environmental
+F44EFD Actions Semiconductor,Ltd.(Cayman Islands)
+34BCA6 Beijing Ding Qing Technology
+D4C1FC Nokia
+48DCFB Nokia
+CC051B Samsung Electronics
+688470 eSSys
+3CBDD8 LG Electronics
+F08BFE Costel.
+5435DF Symeo GmbH
+F43D80 FAG Industrial Services GmbH
+D4F0B4 Napco Security Technologies
+40B3FC Logital Limited 
+D05FCE Hitachi Data Systems
+8C82A8 Insigma Technology
+3C2763 SLE quality engineering GmbH & KG
+A44B15 Sun Cupid Technology (HK)
+508ACB Shenzhen Maxmade Technology
+7032D5 Athena Wireless Communications
+7CF0BA Linkwell Telesystems Pvt
+CCC62B Tri-Systems
+ACF97E Elesys
+4C7367 Genius Bytes Software Solutions GmbH
+DC2B66 InfoBLOCK S.A. de C.V.
+14F0C5 Xtremio
+C027B9 Beijing National Railway Research & Design Institute  of Signal & Communication
+70A41C Advanced Wireless Dynamics S.L.
+285132 Shenzhen Prayfly Technology
+4C3B74 Vogtec(h.k.)
+509772 Westinghouse Digital
+D85D84 CAx soft GmbH
+78A683 Precidata
+BC6784 Environics Oy
+B4E0CD Fusion-io
+50AF73 Shenzhen Bitland Information Technology
+488E42 Digalog Gmbh
+286046 Lantech Communications Global
+A424B3 FlatFrog Laboratories AB
+A4856B Q Electronics
+84EA99 Vieworks
+DCCBA8 Explora Technologies
+58EECE Icon Time Systems
+90004E Hon Hai Precision Ind.
+A41BC0 Fastec Imaging
+E01F0A Xslent Energy Technologies.
+F40321 BeNeXt
+00B033 OAO Izhevskiy radiozavod
+707EDE Nastec
+CCBE71 OptiLogix BV
+D8B12A Panasonic Mobile Communications
+7CDD90 Shenzhen Ogemray Technology
+C07E40 Shenzhen XDK Communication Equipment
+E44F29 MA Lighting Technology GmbH
+6CAB4D Digital Payment Technologies
+60A10A Samsung Electronics
+60DA23 Estech
+C0F8DA Hon Hai Precision Ind.
+28F358 2C - Trifonov
+304C7E Panasonic Electric Works Automation Controls Techno
+64D1A3 Sitecom Europe BV
+3831AC WEG
+2C7ECF Onzo
+10E3C7 Seohwa Telecom
+E84040 Cisco Systems
+0C8112 Private
+3822D6 H3C Technologies, Limited
+7C7D41 Jinmuyu Electronics
+4C1480 Noregon Systems
+8C71F8 Samsung Electronics
+A07591 Samsung Electronics
+60F673 Terumo
+E48AD5 RF Window
+24F0FF GHT
+4C07C9 Computer Office
+40F4EC Cisco Systems
+2872F0 Athena
+9C807D Syscable Korea
+180B52 Nanotron Technologies GmbH
+64DE1C Kingnetic Pte
+540496 Gigawave
+C8C126 ZPM Industria e Comercio Ltda
+041D10 Dream Ware
+88DD79 Voltaire
+4468AB Juin Company, Limited
+902E87 LabJack
+C8208E Storagedata
+00B342 MacroSAN Technologies
+4CB9C8 Conet
+0474A1 Aligera Equipamentos Digitais Ltda
+1064E2 ADFweb.com s.r.l.
+CC34D7 Gewiss
+B4CFDB Shenzhen Jiuzhou Electric
+C46354 U-Raku
+20FEDB M2M SolutionS.
+405FBE RIM
+E05B70 Innovid,
+043604 Gyeyoung I&T
+50CE75 Measy Electronics
+34F968 Atek Products
+D0D0FD Cisco Systems
+A45C27 Nintendo
+706417 Orbis Tecnologia Electrica
+64FC8C Zonar Systems
+28ED58 JAG Jakob AG
+9873C4 Sage Electronic Engineering
+B8797E Secure Meters (UK) Limited
+2005E8 OOO InProMedia
+E0D10A Katoudenkikougyousyo
+1C0656 IDY
+C44B44 Omniprint
+6015C7 IdaTech
+188ED5 TP Vision Belgium N.V. - innovation site Brugge
+E81132 Samsung Electronics
+8CE7B3 Sonardyne International
+0034F1 Radicom Research
+A8B0AE Leoni
+60893C Thermo Fisher Scientific P.O.A.
+5C17D3 LGE
+347877 O-NET Communications(Shenzhen) Limited
+70A191 Trendsetter Medical
+A49B13 Burroughs Payment Systems
+58BC27 Cisco Systems
+34D2C4 Rena Gmbh Print Systeme
+4C0F6E Hon Hai Precision Ind.
+E0A670 Nokia
+E061B2 Hangzhou Zenointel Technology
+4491DB Shanghai Huaqin Telecom Technology
+14D76E Conch Electronic
+1078D2 Elitegroup Computer System
+CC6B98 Minetec Wireless Technologies
+C4CD45 Beijing Boomsense Technology
+D0BB80 SHL Telemedicine International
+1C83B0 Linked IP GmbH
+F065DD Primax Electronics
+706582 Suzhou Hanming Technologies
+94C7AF Raylios Technology
+6854F5 enLighted
+008C10 Black Box
+20A2E7 Lee-Dickens
+8CDD8D Wifly-City System
+EC98C1 Beijing Risbo Network Technology
+ECC38A Accuenergy (canada)
+D48FAA Sogecam Industrial
+38A95F Actifio
+A0DDE5 Sharp
+94A7BC BodyMedia
+6C9B02 Nokia
+84DB2F Sierra Wireless
+A45055 busware.de
+2CD2E7 Nokia
+C89383 Embedded Automation
+D49E6D Wuhan Zhongyuan Huadian Science & Technology,
+94F720 Tianjin Deviser Electronics Instrument
+5C6D20 Hon Hai Precision Ind.
+E02A82 Universal Global Scientific Industrial
+EC2368 IntelliVoice
+B45253 Seagate Technology
+04DD4C Velocytech
+B4C810 Umpi Elettronica
+38580C Panaccess Systems GmbH
+24AF54 Nexgen Mediatech
+F0F9F7 IES GmbH & KG
+CC0CDA Miljovakt AS
+C01242 Alpha Security Products
+90507B Advanced Panmobil Systems Gmbh & KG
+00B5D6 Omnibit
+F893F3 Volans
+7C3E9D Patech
+4C60D5 airPointe of New Hampshire
+48F8E1 Alcatel Lucent WT
+D45297 nSTREAMS Technologies
+78EC22 Shanghai Qihui Telecom Technology
+F8D756 Simm Tronic Limited 
+E087B1 Nata-Info
+A8B1D4 Cisco Systems
+4CBAA3 Bison Electronics
+EC7C74 Justone Technologies
+3C1A79 Huayuan Technology
+30E48E Vodafone UK
+08512E Orion Diagnostica Oy
+9CF61A UTC Fire and Security
+80A1D7 Shanghai DareGlobal Technologies
+C802A6 Beijing Newmine Technology
+C84C75 Cisco Systems
+68EBAE Samsung Electronics
+284C53 Intune Networks
+102D96 Looxcie
+3037A6 Cisco Systems
+ACEA6A Genix Infocomm
+7C2064 Alcatel Lucent IPD
+5C35DA There Oy
+005218 Wuxi Keboda ElectronLtd
+C09134 ProCurve Networking by HP
+F07BCB Hon Hai Precision Ind.
+08F2F4 Net One Partners
+68EFBD Cisco Systems
+5CFF35 Wistron
+183BD2 BYD Precision Manufacture Company
+F45595 Hengbao
+C08B6F S I Sistemas Inteligentes Eletrnicos Ltda
+BCA9D6 Cyber-Rain
+0CDDEF Nokia
+80C63F Remec Broadband Wireless 
+F09CBB RaonThink
+FCE23F Clay Paky SPA
+B0E39D CAT System
+78A6BD Daeyeon Control&instrument
+481249 Luxcom Technologies
+B43DB2 Degreane Horizon
+C4823F Fujian Newland Auto-ID Tech.
+F4C795 WEY Elektronik AG
+087695 Auto Industrial
+ACCE8F HWA YAO Technologies
+042F56 Atocs (shenzhen)
+084E1C H2A Systems
+A4B121 Arantia 2010 S.L.
+9889ED Anadem Information
+147373 Tubitak Uekae
+982D56 Resolution Audio
+00A2DA Inat Gmbh
+6C3E9C KE Knestel Elektronik GmbH
+F89D0D Control Technology
+1010B6 McCain
+081FF3 Cisco Systems
+5CE286 Nortel Networks
+2CCD27 Precor
+AC44F2 Revolabs
+6C5E7A Ubiquitous Internet Telecom
+D828C9 General Electric Consumer and Industrial
+C86C1E Display Systems
+EC6C9F Chengdu Volans Technology
+CCCC4E Sun Fountainhead USA. 
+60D30A Quatius Limited
+BC9DA5 Dascom Europe Gmbh
+60D0A9 Samsung Electronics
+942E63 Finscur
+C8D2C1 Jetlun (Shenzhen)
+F0BCC8 MaxID (Pty)
+1886AC Nokia Danmark A/S
+406186 Micro-star Int'l
+74E537 Radspin
+C417FE Hon Hai Precision Ind.
+7C08D9 Shanghai B-Star Technology
+448E81 VIG
+2046F9 Advanced Network Devices (dba:AND)
+6CD68A LG Electronics
+681FD8 Advanced Telemetry
+0C8230 Shenzhen Magnus Technologies
+049F81 Netscout Systems
+50934F Gradual Tecnologia Ltda.
+34EF8B NTT Communications
+38E98C Reco
+F02408 Talaris (Sweden) AB
+A06986 Wellav Technologies
+F02FD8 Bi2-Vision
+C86CB6 Optcom
+C45976 Fugoo Coorporation
+C8979F Nokia
+B0C8AD People Power Company
+A8F274 Samsung Electronics
+A870A5 UniComm
+80177D Nortel Networks
+E8DAAA VideoHome Technology
+647D81 Yokota Industrial
+8891DD Racktivity
+C4198B Dominion Voting Systems
+C83A35 Tenda Technology
+F4ACC1 Cisco Systems
+584CEE Digital One Technologies, Limited
+E064BB DigiView S.r.l.
+4C63EB Application Solutions (Electronics and Vision)
+C01E9B Pixavi AS
+64168D Cisco Systems
+24D2CC SmartDrive Systems
+7C6C8F AMS Neve
+C4E17C U2S
+A8C222 TM-Research
+50252B Nethra Imaging Incorporated
+A4DA3F Bionics
+9C4E8E ALT Systems
+448312 Star-Net
+687924 ELS-GmbH & KG
+38BB23 OzVision America
+003A99 Cisco Systems
+04C05B Tigo Energy
+5C1437 Thyssenkrupp Aufzugswerke GmbH
+9C55B4 I.S.E. S.r.l.
+DC2C26 Iton Technology Limited
+4CC452 Shang Hai Tyd. Electon Technology
+F0C24C Zhejiang FeiYue Digital Technology
+08184C A. S. Thomas
+5CE223 Delphin Technology AG
+FC6198 NEC Personal Products
+F871FE The Goldman Sachs Group
+D8C3FB Detracom
+201257 Most Lucky Trading
+2021A5 LG Electronics
+D49C28 JayBird
+A03A75 PSS Belgium N.V.
+746B82 Movek
+0C8411 A.O. Smith Water Products
+F8E968 Egker Kft.
+E8DFF2 PRF
+006440 Cisco Systems
+D0E40B Wearable
+AC867E Create New Technology (HK) Limited Company
+58F67B Xia Men UnionCore Technology
+A02EF3 United Integrated Services
+A8CE90 CVC
+00271F Mipro Electronics
+00271A Geenovo Technology
+002714 Grainmustards,
+002717 CE Digital(Zhenjiang)Co.
+002708 Nordiag ASA
+002701 Incostartec Gmbh
+002702 SolarEdge Technologies
+0026FB AirDio Wireless
+0026F5 Xrplus
+002632 Instrumentation Technologies d.d.
+00262D Wistron
+00262C IKT Advanced Technologies s.r.o.
+002626 Geophysical Survey Systems
+00261F SAE Magnetics (H.K.)
+002620 Isgus Gmbh
+00261A Femtocomm System Technology
+002613 Engel Axil S.L.
+00260D Mercury Systems
+0025D8 Korea Maintenance
+0025CC Mobile Communications Korea Incorporated
+0025C5 Star Link Communication Pvt.
+0025C6 kasercorp
+0025C0 ZillionTV
+0025B4 Cisco Systems
+0025B9 Cypress Solutions
+0025AD Manufacturing Resources International
+002600 Teac Australia
+002607 Enabling Technology
+0025FB Tunstall Healthcare A/S
+0025FA J&M Analytik AG
+0025F6 netTALK.com
+0025EF I-TEC
+0025E9 i-mate Development
+0025DF Private
+002690 I DO IT
+00268A Terrier SC
+002689 General Dynamics Robotic Systems
+002684 Kisan System
+002683 Ajoho Enterprise
+00267D A-Max Technology Macao Commercial Offshore Company Limited
+002677 Deif A/S
+002671 Autovision
+00266A Essensium NV
+0026EF Technology Advancement Group
+0026E9 SP
+0026E2 LG Electronics
+0026DC Optical Systems Design
+0026D6 Ningbo Andy Optoelectronic
+0026CF Deka R&D
+0026D0 Semihalf
+0026CA Cisco Systems
+0026C9 Proventix Systems
+0026C3 Insightek
+002664 Core System Japan
+002658 T-Platforms (Cyprus) Limited
+002645 Circontrol
+00263F Lios Technology Gmbh
+002639 T.M. Electronics
+0026BD Jtec Card & Communication
+0026B3 Thales Communications
+0026AD Arada Systems
+0026A9 Strong Technologies
+0026A3 FQ Ingenieria Electronica
+00269C Itus Japan
+002696 Noolix
+002484 Bang and Olufsen Medicom a/s
+002486 DesignArt Networks
+00247F Nortel Networks
+002478 Mag Tech Electronics Limited
+002471 Fusion MultiSystems dba Fusion-io
+002473 3com Europe
+002465 Elentec
+002460 Giaval Science Development
+00245B Raidon Technology
+00244E RadChips
+002447 Kaztek Systems
+002442 Axona Limited
+00243D Emerson Appliance Motors and Controls
+002528 Daido Signal
+002523 OCP
+00251E Rotel Technologies
+002519 Viaas
+002514 PC Worth Int'l
+00250D GZT Telkom-Telmor sp. z o.o.
+002506 A.I. Antitaccheggio Italia SRL
+002508 Maquet Cardiopulmonary AG
+00257A Camco Produktions- und Vertriebs-gmbh Fr  Beschallungs- und Beleuchtungsanlagen
+00257F CallTechSolution
+002573 ST Electronics (Info-Security) Pte
+002567 Samsung Electronics
+00256E Van Breda
+00256D Broadband Forum
+002560 Ibridge Networks & Communications
+00255B CoachComm
+0024E2 Hasegawa Electric
+0024DB Alcohol Monitoring Systems
+0024CF Inscape Data
+0024C8 Broadband Solutions Group
+0024C3 Cisco Systems
+0024C0 NTI Comodo
+0024B6 Seagate Technology
+0024BB Central
+0024B1 Coulomb Technologies
+0024AA Dycor Technologies
+0024A3 Sonim Technologies
+00249E ADC-Elektronik GmbH
+00248B Hybus
+002492 Motorola, Broadband Solutions Group
+002497 Cisco Systems
+002554 Pixel8 Networks
+00254D Singapore Technologies Electronics Limited
+00254E Vertex Wireless
+002548 Nokia Danmark A/S
+002537 Runcom Technologies
+00253E Sensus Metering Systems
+002541 Maquet Critical Care AB
+00252D Kiryung Electronics
+0025A6 Central Network Solution
+0025A1 Enalasys
+00259A CEStronics GmbH
+002593 DatNet Informatikai Kft.
+002594 Eurodesign BG
+00258E The Weather Channel
+00258A Pole/Zero
+002589 Hills Industries Limited
+002584 Cisco Systems
+002501 JSC Supertel
+0024FA Hilger u. Kern Gmbh
+0024F3 Nintendo
+0024F5 NDS Surgical Imaging
+0024EE Wynmax
+0024E7 Plaster Networks
+0023F2 TVLogic
+0023E8 Demco
+0023E1 Cavena Image Products AB
+0023DC Benein
+0023DB saxnet gmbh
+0023C9 Sichuan Tianyi Information Science & Technology Stock
+0023CE Kita Denshi
+0023D5 Warema Electronic Gmbh
+002421 Micro-star Int'l
+002414 Cisco Systems
+002415 Magnetic Autocontrol GmbH
+00240F Ishii Tool & Engineering
+002408 Pacific Biosciences
+002402 Op-Tection GmbH
+0023FC Ultra Stereo Labs
+0023CF Cummins-allison
+0023C2 Samsung Electronics.
+0023B6 Securite Communications / Honeywell
+0023BC EQ-SYS GmbH
+0023AA HFR
+0023A9 Beijing Detianquan Electromechanical Equipment
+002341 Siemens AB, Infrastructure & Cities, Building Technologies Division, IC BT SSP SP BA PR
+00233C Alflex
+00233B C-Matic Systems
+002335 Linkflex
+00232D SandForce
+002328 Alcon Telecommunications
+002321 Avitech International
+0022F8 Pima Electronic Systems
+00231F Guangda Electronic & Telecommunication Technology Development
+0022E6 Intelligent Data
+0022E0 Atlantic Software Technologies S.r.L.
+0022DF Tamuz Monitors
+0022DA Anatek
+0022D3 Hub-Tech
+0022CD Ared Technology
+0022C4 epro GmbH
+0022C9 Lenord, Bauer & GmbH
+0022BF SieAmp Group of Companies
+0022B9 Analogix Seminconductor
+0022BA Huth Elektronik Systeme Gmbh
+00239D Mapower Electronics
+002397 Westell Technologies
+002392 Proteus Industries
+00238D Techno Design
+002389 Hangzhou H3C Technologies
+002388 V.T. Telematica
+002383 InMage Systems
+00237C Neotion
+002324 G-pro Computer
+002431 Uni-v
+00241B iWOW Communications Pte
+002422 Knapp Logistik Automation GmbH
+002427 SSI Computer
+002373 GridIron Systems
+002367 UniControls a.s.
+00236E Burster GmbH & KG
+00236D ResMed
+002360 Lookit Technology
+00235B Gulfstream
+002316 Kisan Electronics
+00230F Hirsch Electronics
+00230A Arburg Gmbh & KG
+002309 Janam Technologies
+002303 Lite-on IT
+0022FC Nokia Danmark A/S
+0022F2 SunPower
+0022ED TSI Power
+00228D GBS Laboratories
+002287 Titan Wireless
+002288 Sagrad
+002281 Daintree Networks
+00227A Telecom Design
+00226B Cisco-Linksys
+002261 Frontier Silicon
+002266 Nokia Danmark A/S
+00225D Digicable Network India Pvt.
+00225C Multimedia & Communication Technology
+00216F SymCom
+002169 Prologix
+002162 Nortel
+002156 Cisco Systems
+002150 Eyeview Electronics
+00214A Pixel Velocity
+0021A3 Micromint
+002199 Vacon Plc
+002195 GWD Media Limited
+002194 Ping Communication
+00218F Avantgarde Acoustic Lautsprechersysteme GmbH
+002188 EMC
+002182 SandLinks Systems
+002175 Pacific Satellite International
+00222A SoundEar A/S
+00221E Media Devices
+002225 Thales Avionics
+002218 Verivue
+002212 CAI Networks
+00220B National Source Coding Center
+002205 WeLink Solutions
+002206 Cyberdyne
+0021FE Nokia Danmark A/S
+0022B3 Sei
+0022AC Hangzhou Siyuan Tech.
+0022A7 Tyco Electronics AMP GmbH
+0022A0 Delphi
+00229A Lastar
+002299 SeaMicro
+002294 Kyocera
+0021FA A4SP Technologies
+0021F4 INRange Systems
+0021ED Telegesis
+0021E7 Informatics Services
+0021DB Santachi Video Technology (Shenzhen)
+0021E1 Nortel Networks
+0021D5 X2E GmbH
+0021DA Automation Products Group
+0021CE NTC-Metrotek
+0021C8 Lohuis Networks
+0021C2 GL Communications
+0021BB Riken Keiki
+0021B5 Galvanic
+0021AF Radio Frequency Systems
+0021B6 Triacta Power Technologies
+0021A9 Mobilink Telecom
+0021A8 Telephonics
+00210D Samsin Innotec
+002141 Radlive
+002137 Bay Controls
+00212D Scimolex
+002133 Building
+002121 VRmagic GmbH
+002126 Shenzhen Torch Equipment
+002257 3com Europe
+00224E SEEnergy
+002247 DAC Engineering
+00223D JumpGen Systems
+002237 Shinhint Group
+002238 Logiplus
+002231 SMT&C
+00222B Nucomm
+001EF6 Cisco Systems
+001EEA Sensor Switch
+001EEF Cantronic International Limited
+001EDE BYD Company Limited
+001EE3 T&W Electronics (ShenZhen)
+001EDD Wasko
+001ED9 Mitsubishi Precision
+001ED4 Doble Engineering
+001ED3 Dot Technology Int'l
+001ECD Kyland Technology
+001EC6 Obvius Holdings
+001F9D Cisco Systems
+001FA2 Datron World Communications
+001F91 DBS Lodging Technologies
+001F96 Aprotechltd
+001F90 Actiontec Electronics
+001F8F Shanghai Bellmann Digital Source
+001F85 Apriva ISS
+001F87 Skydigital
+001F86 digEcor
+001F80 Lucas Holding bv
+001F3E RP-Technik e.K.
+001F42 Etherstack plc
+001F41 Ruckus Wireless
+001F39 Construcciones y Auxiliar de Ferrocarriles
+001F2B Orange Logic
+001F32 Nintendo
+001F2C Starbridge Networks
+001F26 Cisco Systems
+001F1F Edimax Technology
+001F1A Prominvest
+001EC1 3com Europe
+001EBA High Density Devices AS
+001EB3 Primex Wireless
+001EB4 Unifat Technology
+001EAE Continental Automotive Systems
+001EA3 Nokia Danmark A/S
+001EA8 Datang Mobile Communications Equipment
+001E9C Fidustron
+001E95 Sigmalink
+001E96 Sepura Plc
+001E90 Elitegroup Computer Systems
+001E8B Infra Access Korea
+001FEF Shinsei Industries
+001FE8 Kurusugawa Electronics Industry
+001FDC Mobile Safe Track
+001FE3 LG Electronics
+001FD7 Telerad SA
+001FCC Samsung Electronics
+001FCB NIW Solutions
+001FCD Samsung Electronics
+001F77 Heol Design
+001F73 Teraview Technology
+001F6D Cisco Systems
+001F61 Talent Communication Networks
+001F66 Planar
+001F5A Beckwith Electric
+001F53 Gemac Gesellschaft Fr Mikroelektronikanwendung Chemnitz mbH
+001F4E ConMed Linvatec
+001F54 Lorex Technology
+001F47 MCS Logic
+001FD2 Commtech Technology Macao Commercial Offshore
+001FBF Fulhua Microelectronics Taiwan Branch
+001FBA BoYoung Tech. & Marketing
+001FAC Goodmill Systems
+00211A LInTech
+002113 Padtec S/A
+002114 Hylab Technology
+00210E Orpak Systems L.T.D.
+00210A byd:sign
+002104 Gigaset Communications GmbH
+001FFB Green Packet Bhd
+001FF6 PS Audio International
+001F19 Ben-ri Electronica
+001F13 S.& A.S.
+001F0F Select Engineered Systems
+001F09 Jastec
+001EFD Microbit 2.0 AB
+001F02 Pixelmetrix Pte
+001EF0 Gigafin Networks
+001D2C Wavetrend Technologies (Pty) Limited
+001D27 Nac-intercom
+001D18 Power Innovation GmbH
+001D13 NextGTV
+001D0C MobileCompia
+001D06 HM Electronics
+001D05 Eaton
+001E62 Siemon
+001E5D Holosys d.o.o.
+001E56 Bally Wulff Entertainment GmbH
+001E50 Battistoni Research
+001E4A Cisco Systems
+001E40 Shanghai DareGlobal Technologies 
+001D85 Call Direct Cellular Solutions
+001D80 Beijing Huahuan Eletronics
+001D68 Thomson Telecom Belgium
+001D6F Chainzone Technology
+001D76 Eyeheight
+001D7B Ice Energy
+001D75 Radioscape PLC
+001D63 Miele & Cie. KG
+001D5C Tom Communication Industrial
+001D55 Zantaz
+001DC8 Navionics Research, dba Scadametrics
+001DC1 Audinate
+001DBC Nintendo
+001DBB Dynamic System Electronics
+001DAB SwissQual License AG
+001E86 MEL
+001E7F CBM of America
+001E7A Cisco Systems
+001E79 Cisco Systems
+001E75 LG Electronics
+001E6F Magna-Power Electronics
+001E70 Cobham Defence Communications
+001E69 Thomson
+001D56 Kramer Electronics
+001D50 Spinetix SA
+001D4B Grid Connect
+001D46 Cisco Systems
+001D3F Mitron
+001D39 Moohadigital
+001D3A mh acoustics
+001D33 Maverick Systems
+001E09 Zefatek
+001E04 Hanson Research
+001DFD Nokia Danmark A/S
+001DF7 R. Stahl Schaltgerte Gmbh
+001DF8 Webpro Vision Technology
+001DF1 Intego Systems
+001DEA Commtest Instruments
+001DDB C-BEL
+001DE5 Cisco Systems
+001DA4 Hangzhou System Technology
+001D9F Matt   R.p.traczynscy Sp.J.
+001D98 Nokia Danmark A/S
+001D92 Micro-star Int'l
+001D91 Digitize
+001D8C La Crosse Technology
+001E39 Comsys Communication
+001E34 CryptoMetrics
+001E33 Inventec
+001E2D Stim
+001E26 Digifriends
+001E21 Qisda
+001E1A Best Source Taiwan
+001E14 Cisco Systems
+001E0A Syba Tech Limited
+001C61 Galaxy  Microsystems LImited
+001C55 Shenzhen Kaifa Technology
+001C5A Advanced Relay
+001C44 Bosch Security Systems BV
+001C4B Gener8
+001C38 Bio-Rad Laboratories
+001C3D WaveStorm
+001C3F International Police Technologies
+001C3E ECKey
+001C31 Mobile XP Technology
+001C2C Synapse
+001CF9 Cisco Systems
+001CF3 EVS Broadcast Equipment
+001CF4 Media Technology Systems
+001CED Environnement SA
+001CE3 Optimedical Systems
+001CDC Custom Computer Services
+001CD7 Harman/Becker Automotive Systems GmbH
+001CD0 Circleone
+001BF5 Tellink Sistemas de Telecomunicacin S.L.
+001BEE Nokia Danmark A/S
+001BF0 Value Platforms Limited
+001BE8 Ultratronik GmbH
+001BE1 ViaLogy
+001BDC Vencer
+001BD5 Cisco Systems
+001BCE Measurement Devices
+001C94 LI-COR Biosciences
+001C8E Alcatel-Lucent IPD
+001C8D Mesa Imaging
+001C88 Transystem
+001C7E Toshiba
+001C83 New Level Telecom
+001C7A Perfectone Netware Company
+001C7B Castlenet Technology
+001C79 Cohesive Financial Technologies
+001C74 Syswan Technologies
+001C6D Kyohritsu Electronic Industry
+001C68 Anhui Sun Create Electronics
+001CC9 Kaise Electronic Technology
+001CCA Shanghai Gaozhi Science & Technology Development
+001CBD Ezze Mobile Tech.
+001CB8 CBC
+001CAD Wuhan Telecommunication Devices
+001CAE WiChorus
+001CA7 International Quartz Limited
+001CA0 Production Resource Group
+001C9B Feig Electronic Gmbh
+001B69 Equaline
+001B64 IsaacLandKorea
+001B5D Vololink
+001B56 Tehuti Networks
+001B51 Vector Technology
+001B45 ABB AS, Division Automation Products
+001B4A W&W Communications
+001B43 Beijing DG Telecommunications equipment
+001B3E Curtis
+001B37 Computec Oy
+001B32 QLogic
+001B2B Cisco Systems
+001BC9 FSN Display
+001BC2 Integrated Control Technology Limitied
+001BBC Silver Peak Systems
+001BBD FMC Kongsberg Subsea AS
+001BB3 Condalo GmbH
+001BB8 Blueway Electronic;ltd
+001BAC Curtiss Wright Controls Embedded Computing
+001BB1 Wistron Neweb
+001BB2 Intellect International NV
+001BA5 MyungMin Systems
+001BA0 Awox
+001B99 KS System GmbH
+001C14 VMware
+001C1B Hyperstone GmbH
+001C0F Cisco Systems
+001C08 Echo360
+001C02 Pano Logic
+001C01 ABB Oy Drives
+001C03 Betty TV Technology AG
+001B92 l-acoustics
+001B8D Electronic Computer Systems
+001B88 Divinet Access Technologies
+001B83 Finsoft
+001B7C A & R Cambridge
+001B76 Ripcode
+001B75 Hypermedia Systems
+001B70 IRI Ubiteq
+001A16 Nokia Danmark A/S
+001A18 Advanced Simulation Technology
+001A0A Adaptive Micro-Ware
+001A05 Optibase
+001A03 Angel Electronics
+0019FE Shenzhen Seecomm Technology
+0019F9 TDK-Lambda
+0019ED Axesstel
+0019F4 Convergens Oy
+001A79 Telecomunication Technologies
+001A99 Smarty (HZ) Information Electronics
+001A9B Adec & Parter AG
+001A8A Samsung Electronics
+001A8F Nortel
+001A94 Votronic GmbH
+001A83 Pegasus Technologies
+001A7E LN Srithai Comm
+001AF1 Embedded Artists AB
+001AF6 Woven Systems
+001AEC Keumbee Electronics
+001AE0 Mythology Tech Express
+001AE5 Mvox Technologies
+001AD2 Eletronica Nitron Ltda
+001AD9 International Broadband Electric Communications
+001ACB Autocom Products
+001ACD Tidel Engineering LP
+001A46 Digital Multimedia Technology
+001A3A Dongahelecomm
+001A3F intelbras
+001A41 Inocova
+001A2E Ziova Coporation
+001A33 ASI Communications
+001A29 Johnson Outdoors Marine Electronics
+001A1D PChome Online
+001A24 Galaxy Telecom Technologies
+0019A5 RadarFind
+0019AC GSP Systems
+0019B1 Arrow7
+00199E Nifty
+0019A0 Nihon Data Systens
+001994 Jorjin Technologies
+00198F Alcatel Bell N.V.
+0019E1 Nortel
+0019E8 Cisco Systems
+0019DA Welltrans O&E Technology 
+0019DC Enensys Technologies
+0019C9 S&C Electric Company
+0019CE Progressive Gaming International
+0019D5 IP Innovations
+0019C4 Infocrypt
+0019BF Citiway technology
+0019BD New Media Life
+0019B8 Boundary Devices
+001B26 RON-Telecom ZAO
+001B1C Coherent
+001B1A e-trees Japan
+001B15 Voxtel
+001B09 Matrix Telecom Pvt.
+001B0E InoTec GmbH Organisationssysteme
+001B07 Mendocino Software
+001B02 EDLtd
+001AFB Joby
+001A74 Procare International
+001A6D Cisco Systems
+001A68 Weltec Enterprise
+001A61 PacStar
+001A54 Hip Shing Electronics
+001A59 Ircona
+001A4D Giga-byte Technology
+001A52 Meshlinx Wireless
+001AC6 Micro Control Designs
+001ABC U4EA Technologies
+001AC1 3Com
+001AB0 Signal Networks Pvt.,
+001AB5 Home Network System
+001AA9 Fujian Star-net Communication
+00183C Encore Software Limited
+001841 High Tech Computer
+001843 Dawevision
+001837 Universal Abit
+001826 Cale Access AB
+00182B Softier
+001818 Cisco Systems
+00181A AVerMedia Information
+00181F Palmmicro Communications
+001804 E-tek Digital Technology Limited
+001807 Fanstel
+00180C Optelian Access Networks
+0017FF Playline
+0017F1 Renu Electronics Pvt
+0017F3 Harris Corparation
+0017F8 Motech Industries
+0017D4 Monsoon Multimedia
+0017D9 AAI
+0017E0 Cisco Systems
+001920 Kume Electric
+001925 Intelicis
+001912 Welcat
+001914 Winix
+001919 Astel
+00190D Ieee 1394c
+001901 F1media
+001906 Cisco Systems
+0018F5 Shenzhen Streaming Video Technology Company Limited
+0018F7 Kameleon Technologies
+0018FC Altec Electronic AG
+001981 Vivox
+001983 CCT R&D Limited
+001988 Wi2Wi
+001975 Beijing Huisen networks technology
+00197C Riedel Communications GmbH
+001969 Nortel
+001970 Z-Com
+001964 Doorking
+00195F Valemount Networks
+001953 Chainleader Communications
+001958 Bluetooth SIG
+00195A Jenaer Antriebstechnik GmbH
+0018F0 Joytoto
+0018E9 Numata
+0018E4 Yiguang
+0018DD Silicondust Engineering
+0018D8 Arch Meter
+0018D1 Siemens Home & Office Comm. Devices
+0018D6 Swirlnet A/S
+0018CC Axiohm SAS
+0018C7 Real Time Automation
+00186C Neonode AB
+001878 Mackware GmbH
+001867 Datalogic ADC
+00185B Network Chemistry
+001862 Seagate Technology
+00184F 8 Ways Technology
+001854 Argard
+001856 EyeFi
+001848 Vecima Networks
+001945 RF COncepts
+00194C Fujian Stelcom information & Technology
+001940 Rackable Systems
+001934 Trendon Touch Technology
+001939 Gigamips
+001931 Balluff GmbH
+0018BB Eliwell Controls srl
+0018B9 Cisco Systems
+0018B4 Dawon Media
+0018AD Nidec Sankyo
+0018A8 AnNeal Technology
+00189C Weldex
+0018A1 Tiqit Computers
+001897 Jess-link Products
+001892 ads-tec GmbH
+001890 RadioCOM, s.r.o.
+001884 Fon Technology S.L.
+00187D Armorlink shanghai
+00187F Zodianet
+0016D1 ZAT a.s.
+0016C3 BA Systems
+0016CA Nortel
+0016BE Infranet
+0016B7 Seoul Commtech
+0016B2 DriveCam
+0016B0 VK
+0016AB Dansensor A/S
+0016A6 Dovado FZ-LLC
+0017C8 Kyocera Document Solutions
+0017CA Qisda
+0017CF iMCA-GmbH
+0017C3 KTF Technologies
+0017B7 Tonze Technology
+0017BC Touchtunes Music
+0017B5 Peerless Systems
+0017B0 Nokia Danmark A/S
+001723 Summit Data Communications
+00171C NT MicroSystems
+001710 Casa Systems
+001715 Qstik
+001717 Leica Geosystems AG
+00170B Contela
+001706 Techfaith Wireless Communication Technology Limited.
+0016FA ECI Telecom
+0016FF Wamin Optocomm Mfg
+001774 Elesta GmbH
+001779 QuickTel
+00177B Azalea Networks
+001764 ATMedia GmbH
+001766 Accense Technology
+00175F Xenolink Communications
+001751 Online
+001753 nFore Technology
+001758 ThruVision
+001745 Innotz
+00174C Millipore
+00179F Apricorn
+0017A9 Sentivision
+001793 Tigi
+00178C Independent Witness
+00178E Gunnebo Cash Automation AB
+001780 Applied Biosystems
+001787 Brother, Brother & Sons ApS
+00176B Kiyon
+00BAC0 Biometric Access Company
+001673 Bury GmbH & KG
+001671 Symphox Information
+001665 Cellon France
+00166A TPS
+00165E Precision I/O
+001657 Aegate
+001659 Z.m.p. Radwag
+001658 Fusiontech Technologies
+001652 Hoatech Technologies
+001646 Cisco Systems
+00164B Quorion Data Systems GmbH
+001740 Bluberi Gaming Technologies
+001736 iiTron
+00172F NeuLion Incorporated
+001728 Selex Communications
+00172A Proware Technology(By Unifosa)
+00169A Quadrics
+0016A1 3Leaf Networks
+001693 PowerLink Technology
+001695 AVC Technology (International) Limited
+00168E Vimicro
+001682 Pro Dex
+001687 Chubb CSC-Vendor AP
+00167B Haver&Boecker
+0016F3 Cast Information
+0016EE Royaldigital
+0016E7 Dynamix Promotions Limited
+0016EC Elitegroup Computer Systems
+0016DB Samsung Electronics
+0016E0 3Com
+0016D6 TDA Tech
+00151E Ethernet Powerlink Standardization Group (epsg)
+001525 Chamberlain Access Solutions
+001519 StoreAge Networking Technologies
+001518 Shenzhen 10MOONS Technology Development
+001514 Hu Zhou Nava Networks&electronics
+00150E Openbrain Technologies
+00150F mingjong
+00150D Hoana Medical
+001508 Global Target Enterprise
+0014FC Extandon
+001501 LexBox
+0014F5 OSI Security Devices
+0014E9 Nortech International
+0014EE Western Digital Technologies
+0014DF HI-P Tech
+0014E4 infinias
+0014D3 Sepsa
+0014D8 bio-logic SA
+0014D2 Kyuden Technosystems
+0015E0 Ericsson
+0015DC KT&C
+0015D5 Nicevt
+0015D7 Reti
+0015D6 OSLiNK Sp. z o.o.
+0015C4 Flovel
+0015C9 Gumstix
+0015BD Group 4 Technology
+0015B6 ShinMaywa Industries
+001581 Makus
+00156B Perfisans Networks
+001570 Zebra Technologies
+00155D Microsoft
+00155F GreenPeak Technologies
+001564 Behringer Spezielle Studiotechnik Gmbh
+00155E Morgan Stanley
+001558 Foxconn
+001551 RadioPulse
+001549 Dixtal Biomedica Ind. Com. Ltda
+00154C Saunders Electronics
+00154A Wanshih Electronic
+00153D Elim Product
+001544 coM.s.a.t. AG
+001531 Kocom
+001538 RFID
+00152A Nokia GmbH
+00161D Innovative Wireless Technologies
+00161C e:cue
+00160C LPL  Development S.A. DE C.V
+001611 Altecon Srl
+001612 Otsuka Electronics
+001605 Yorkville Sound
+0015F9 Cisco Systems
+001600 CelleBrite Mobile Synchronization
+0015ED Fulcrum Microsystems
+0015E1 Picochip
+0015E6 Mobile Technika
+0015B1 Ambient
+0015AC Capelon AB
+0015A7 Robatech AG
+0015A0 Nokia Danmark A/S
+001599 Samsung Electronics
+00159B Nortel
+001594 Bixolon
+00158D Jennic
+001588 Salutica Allied Solutions Sdn Bhd
+0014CC Zetec
+0014D1 Trendnet
+0014C0 Symstream Technology Group
+0014C5 Alive Technologies
+0014B9 Mstar Semiconductor
+0014AF Datasym POS
+0014A8 Cisco Systems
+001641 Universal Global Scientific Industrial
+00163C Rebox
+00162E Space Shuttle Hi-Tech
+001629 Nivus GmbH
+001622 BBH Systems Gmbh
+001616 Browan Communication
+00161B Micronet
+00135B PanelLink Cinema
+001362 ShinHeung Precision
+001351 Niles Audio
+001345 Eaton
+00134A Engim
+00133E MetaSwitch
+00132B Phoenix Digital
+001332 Beijing Topsec Network Security Technology
+001337 Orient Power Home Network
+001338 Fresenius-vial
+00137A Netvox Technology
+001381 Chips & Systems
+001386 ABB/Totalflow
+001374 Atheros Communications
+00136E Techmetro
+001373 BLwave Electronics
+001367 Narayon.
+001361 Biospace
+001357 Soyal Technology
+001326 ECM Systems
+001325 Cortina Systems
+00131B BeCell Innovations
+00131C LiteTouch
+001309 Ocean Broadband Networks
+00130E Focusrite Audio Engineering Limited
+0012FC Planet System
+0012FB Samsung Electronics
+0012F6 MDK
+0012F1 Ifotec
+00143E AirLink Communications
+001437 GSTeletech
+001430 ViPowER
+00142B Edata Communication
+001424 Merry Electrics
+00141F SunKwang Electronics
+00141A Deicy
+001413 Trebing & Himstedt Prozeautomation GmbH & KG
+001415 Intec Automation
+001414 Jumpnode Systems
+00140E Nortel
+001405 OpenIB
+00140B First International Computer
+0013FE Grandtec Electronic
+0013F9 Cavera Systems
+0013F2 Klas
+0013EC Netsnapper Technologies Sarl
+0013E1 Iprobe AB
+0013E2 GeoVision
+0013D5 RuggedCom
+0013DC Ibtek
+0013D0 t+ Medical
+0013CB Zenitel Norway AS
+0013C6 OpenGear
+0013C5 Lightron Fiber-optic Devices
+0013BB Smartvue
+0013BF Media System Planning
+0013B5 Wavesat
+0013AE Radiance Technologies
+0013A2 MaxStream
+00139B ioIMAGE
+00139C Exavera Technologies
+001396 Acbel Polytech
+00138A Qingdao Goertek Electronics
+001389 Redes de Telefona Mvil
+00149C HF Company
+0014A3 Vitelec BV
+001497 Zhiyuan Eletronics
+001496 Phonic
+001490 ASP
+001489 B15402100 - Jandei
+001484 Cermate Technologies
+00147F Thomson Telecom Belgium
+00147A Eubus GmbH
+001473 Bookham
+001467 ArrowSpan
+001460 Kyocera Wireless
+00145B SeekerNet
+00145A Neratec Solutions AG
+001459 Moram
+001454 Symwave
+00144F Oracle 
+001443 Consultronics Europe
+00144A Taiwan Thick-Film Ind.
+0011C4 Terminales de Telecomunicacion Terrestre
+0011C9 MTT
+0011BF Aesys
+0011B8 Liebherr - Elektronik GmbH
+0011AC Simtec Electronics
+0011B1 BlueExpert Technology
+0011B2 2001 Technology
+0011A0 Vtech Engineering Canada
+0011A5 Fortuna Electronic
+001276 CG Power Systems Ireland Limited
+00126F Rayson Technology
+001270 Nges Denro Systems
+00126A Optoelectronics
+001263 Data Voice Technologies GmbH
+00125E Caen
+00125D CyberNet
+001259 Thermo Electron Karlsruhe
+001254 Spectra Technologies Holdings Company
+001253 AudioDev AB
+00129D First International Computer do Brasil
+001291 KWS Computersysteme GmbH
+001296 Addlogix
+00128F Montilio
+001282 Qovia
+001289 Advance Sterilization Products
+00127D MobileAria
+0011F4 woori-net
+0011EE Estari
+0011ED 802 Global
+0011E8 Tixi.Com
+0011DB Land-Cellular
+0011DC Glunz & Jensen
+0011E1 Arcelik A.S
+0011CE Ubisense Limited
+0011D5 Hangzhou Sunyard System Engineering
+001246 T.O.M Technology.
+00124D Inducon BV
+001241 a2i marketing center
+00123A Posystech
+001234 Camille Bauer
+00122A VTech Telecommunications
+00122E Signal Technology - Aisd
+001233 JRC Tokki
+00119F Nokia Danmark A/S
+001199 2wcom Systems GmbH
+00118F Eutech Instruments PTE.
+001188 Enterasys
+001183 Datalogic ADC
+00117C e-zy.net
+001176 Intellambda Systems
+0012C0 HotLava Systems
+0012B5 Vialta
+0012BC Echolab
+0012B6 Santa Barbara Infrared
+0012B0 Efore Oyj   (Plc)
+0012A4 ThingMagic
+0012A9 3Com
+0012A3 Trust International
+001224 NexQL
+001229 BroadEasy Technologies
+00121D Netfabric
+001211 Protechna Herbst GmbH & KG
+001218 Aruze
+001205 Terrasat Communications
+00120A Emerson Climate Technologies GmbH
+0011FE Keiyo System Research
+0011F8 Airaya
+0012EC Movacolor
+0012E5 Time America
+0012E0 Codan Limited
+0012DF Novomatic AG
+0012D9 Cisco Systems
+0012C6 TGC America
+0012CD Asem SpA
+000FE9 GW Technologies
+000FDD Sordin AB
+000FE2 Hangzhou H3C Technologies
+000FD6 Sarotech
+002654 3Com
+000FD0 Astri
+000FCF DataWind Research
+000FC3 PalmPalm Technology
+001144 Assurance Technology
+00113E JL
+001131 Unatech.
+001137 Aichi Electric
+00112D iPulse Systems
+111111 Private
+001123 Appointech
+00111D Hectrix Limited
+000F6C Addi-data Gmbh
+000F6B GateWare Communications GmbH
+000F5F Nicety Technologies (NTS)
+000F59 Phonak Communications AG
+000F5A Peribit Networks
+000F53 Solarflare Communications
+000F47 Robox SPA
+000F4C Elextech
+001170 GSC SRL
+001169 EMS Satcom
+001164 Acard Technology
+00115F ITX Security
+00115A Ivoclar Vivadent AG
+001159 Matisse Networks
+001153 Trident Tek
+001150 Belkin
+001151 Mykotronx
+00114A Kayaba Industry
+001110 Maxanna Technology
+001117 Cesnet
+001104 Telexy
+00110B Franklin Technology Systems
+001100 Schneider Electric
+000FFE G-pro Computer
+000FEF Thales e-Transactions GmbH
+000FF0 Sunray
+000FF5 GN&S company
+000FCA A-jin Techline
+000FBD MRV Communications (Networks)
+000FBE e-w/you
+000FB7 Cavium
+000FA4 Sprecher Automation GmbH
+000FAB Kyushu Electronics Systems
+000F9D DisplayLink (UK)
+000F98 Avamax
+000F8B Orion MultiSystems
+000F8C Gigawavetech Pte
+000F91 Aerotelecom
+000F7E Ablerex Electronics
+000F85 Addo-japan
+000F72 Sandburst
+000F79 Bluetooth Interest Group
+000F19 Boston Scientific
+000F0D Hunt Electronic
+000F06 Nortel Networks
+000F01 Digitalks
+000EFA Optoway Technology Incorporation
+000EF4 Kasda Networks
+000EF3 Smarthome
+000EEE Muco Industrie BV
+000EE7 AAC Electronics
+000F38 Netstar
+000F40 Optical Internetworking Forum
+000F33 Duali
+000F2C Uplogix
+000F26 WorldAccxx 
+000F25 AimValley
+000F13 Nisca
+000F14 Mindray
+000EE1 ExtremeSpeed
+000EDB XiNCOM
+000EE2 Custom Engineering
+000ED5 Copan Systems
+000EC9 Yoko Technology
+000ED0 Privaris
+000ED7 Cisco Systems
+000EC4 Iskra Transmission d.d.
+000EC3 Logic Controls
+000EB6 Riverbed Technology
+000EBD Burdick, a Quinton Compny
+000EB1 Newcotech
+000DAA S.A.Tehnology
+000DA0 Nedap N.V.
+000D9F RF Micro Devices
+000D9A Infotec
+000D8D Prosoft Technology
+000D8E Koden Electronics
+000D87 Elitegroup Computer System (ECS)
+000D84 Makus
+000D83 Sanmina-SCI Hungary 
+000D76 Hokuto Denshi
+000D7D Afco Systems
+000E51 tecna elettronica srl
+000E4C Bermai
+000E4B atrium c and
+000E3E Sun Optronics
+000E45 Beijing Newtry Electronic Technology
+000E39 Cisco Systems
+000E32 Kontron Medical
+000E2B Safari Technologies
+000E2C Netcodec
+000E1F TCL Networks Equipment
+000E26 Gincom Technology
+000E1A JPS Communications
+000E19 LogicaCMG
+000E13 Accu-Sort Systems
+000E0F Ermme
+000E05 Wireless Matrix
+000E06 Team Simoco
+000E0B Netac Technology
+000DF8 Orga Kartensysteme Gmbh
+000DFF Chenming Mold Industry
+000DEC Cisco Systems
+000DF3 Asmax Solutions
+000DE6 Youngbo Engineering
+000DE5 Samsung Thales
+000DE0 Icpdas
+000DD3 Samwoo Telecommunication
+000DD4 Symantec
+000DD9 Anton Paar GmbH
+000DCD Groupe Txcom
+000EAA Scalent Systems
+000E9E Topfield
+000EA3 Cncr-it,ltd,hangzhou P.r.china
+000EA4 Certance
+000E92 Open Telecom
+000E97 Ultracker Technology
+000E91 Navico Auckland
+000E8B Astarte Technology
+000E84 Cisco Systems
+000D6A Redwood Technologies
+000D71 boca systems
+000D5E NEC Personal Products
+000D63 Dent Instruments
+000D64 Comag Handels AG
+000D57 Fujitsu I-Network Systems Limited.
+000D52 Comart system
+000D51 Divr Systems
+000D47 Collex
+000DC1 SafeWeb
+000DC6 DigiRose Technology
+000DBA Oc Document Technologies GmbH
+000DB4 Netasq
+000DB3 SDO Communication Corperation
+000DAE Samsung Heavy Industries
+000DA6 Universal Switching
+000E78 Amtelco
+000E70 in2 Networks
+000E6B Janitza electronics GmbH
+000E64 Elphel
+000E5D Triple Play Technologies A/S
+000E5E Raisecom Technology
+000E58 Sonos
+000BE2 Lumenera
+000BE7 Comflux Technology
+000BD6 Paxton Access
+000BD2 Remopro Technology
+000BC6 ISAC
+000BCB Fagor Automation , S. Coop
+000BBF Cisco Systems
+000BBA Harmonic
+000BB3 RiT technologies
+000C38 TelcoBridges
+000C3F Cogent Defence & Security Networks,
+000C30 Cisco Systems
+000C26 Weintek Labs.
+000C2E Openet information technology(shenzhen)
+000C25 Allied Telesis Labs
+000C1F Glimmerglass Networks
+000C24 Anator
+000C1B Oracom
+000C19 Telio Communications GmbH
+000C7A DaTARIUS Technologies GmbH
+000C67 OYO Electric
+000C4F UDTech Japan
+000C54 Pedestal Networks
+000C5B Hanwang Technology
+000C60 ACM Systems
+000C62 ABB AB, Cewe-Control 
+000C48 QoStek
+000C4D Curtiss-Wright Controls Avionics & Electronics
+000C14 Diagnostic Instruments
+000C07 Iftest AG
+000C06 Nixvue Systems  Pte
+000C08 Humex Technologies
+000C0D Communications & Power Industries / Satcom Division
+000BF5 Shanghai Sibo Telecom Technology
+000BFA Exemys SRL
+000C01 Abatron AG
+000BEE inc.jet, Incorporated
+000CE6 Meru Networks
+000CEB Cnmp Networks
+000CE2 Rolls-Royce
+000CEC Spectracom
+000CD7 Nallatech
+000CDE ABB Stotz-kontakt Gmbh
+000CD2 Schaffner EMV AG
+000CD8 M. K. Juchheim GmbH
+000CC6 Ka-Ro electronics GmbH
+000CCB Design Combus
+000CC5 Nextlink
+000CB3 Round
+000CB8 Medion AG
+000CBF Holy Stone Ent.
+000A07 WebWayOne
+000CA1 Sigmacom
+000CA6 Mintera
+000CA8 Garuda Networks
+000CAD BTU International
+000C95 PrimeNet
+000C9A Hitech Electronics
+000C8E Mentor Engineering
+000C93 Xeline
+000C7F synertronixx GmbH
+000C82 Network Technologies
+000C87 AMD
+000C73 Telson Electronics
+000D1D High-tek Harness ENT.
+000D1E Control Techniques
+000D0C MDI Security Systems
+000D11 Dentsply - Gendex
+000D05 cybernet manufacturing
+000CF9 Xylem Water Solutions
+000CFE Grand Electronic
+000CF2 Gamesa Elica
+000D43 DRS Tactical Systems
+000D37 Wiplug
+000D3E Aplux Communications
+000D3D Hammerhead Systems
+000D30 IceFyre Semiconductor
+000D2B Racal Instruments
+000D24 Sentec E&E
+000D18 Mega-Trend Electronics
+000BA4 Shiron Satellite Communications (1996)
+000BA9 CloudShield Technologies
+000BA3 Siemens AG
+000B91 Aglaia Gesellschaft fr Bildverarbeitung und Kommunikation mbH
+000B96 Innotrac Diagnostics Oy
+000B9D TwinMOS Technologies
+000B8A Miteq
+000B7E Saginomiya Seisakusho
+000B83 Datawatt
+000AAD Stargames
+000AB2 Fresnel Wireless Systems
+000AB4 Etic Telecommunications
+000AB9 Astera Technologies
+000AA1 V V S Limited
+000AA6 Hochiki
+000A8E Invacom
+000A9F Pannaway Technologies
+000A99 Calamp Wireless Networks
+000A93 W2 Networks
+000A7F Teradon Industries
+000A86 Lenze
+000A8B Cisco Systems
+000B15 Platypus Technology
+000B10 11wave Technonlogy
+000B09 Ifoundry Systems Singapore
+000B04 Volktek
+000AFD Kentec Electronics
+000B02 Dallmeier electronic
+000AF1 Clarity Design
+000AF6 Emerson Climate Technologies Retail Solutions
+000AEB Shenzhen Tp-Link Technology;
+000AE4 Wistron
+000AE6 Elitegroup Computer System (ECS)
+000A0E Invivo Research
+000A13 Honeywell Video Systems
+000A04 3Com
+0009FD Ubinetics Limited
+0009F4 Alcon Laboratories
+0009E7 ADC Techonology
+0009EE Meikyo Electric
+0009F3 Well Communication
+0009E2 Sinbon Electronics
+0009DB eSpace
+000B6B Wistron Neweb
+000B70 Load Technology
+000B72 Lawo AG
+000B77 Cogent Systems
+000B71 Litchfield Communications
+000B5F Cisco Systems
+000B64 Kieback & Peter GmbH & KG
+000B5B Rincon Research
+000B56 Cybernetics
+000B4E VertexRSI, General Dynamics SatCOM Technologies
+000B53 Initium
+000A35 Xilinx
+000A3A J-three International Holding
+000A3C Enerpoint
+000A41 Cisco Systems
+000A48 Albatron Technology
+000A2E Maple Networks
+000A26 Ceia
+000A28 Motorola
+000A21 Integra Telecom
+000A1A Imerge
+000A15 Silicon Data
+000B42 commax
+000B47 Advanced Energy
+000B34 ShangHai Broadband TechnologiesLTD
+000B36 Productivity Systems
+000B28 Quatech
+000B2F bplan GmbH
+000B1C Sibco bv
+000B21 G-Star Communications
+000B23 Siemens Subscriber Networks
+000A7A Kyoritsu Electric
+000A6E Harmonic
+000A73 Scientific Atlanta
+000A60 Autostar Technology Pte
+000A67 OngCorp
+000A6C Walchem
+000A5B Power-One as
+000A59 HW server
+000A54 Laguna Hills
+000A4D Noritz
+000ADF Gennum
+000AD8 IPCserv Technology
+000ACC Winnow Networks
+000AD1 MWS
+000AD3 Initech
+000AC0 Fuyoh Video Industry
+000AC5 Color Kinetics
+00097B Cisco Systems
+000982 Loewe Opta GmbH
+000976 Datasoft Isdn Systems Gmbh
+000969 Meret Optical Communications
+000963 Dominion Lasercom
+00096A Cloverleaf Communications
+00096F Beijing Zhongqing Elegant Tech.,Limited
+00095D Dialogue Technology
+00095F Telebyte
+000958 Intelnet
+00094C Communication Weaver
+000951 Apogee Imaging Systems
+00094B FillFactory NV
+0009AE Okano Electric
+0009AD Hyundai Syscomm
+0009B4 Kisan Telecom
+0009A8 Eastmode Pte
+00099B Western Telematic
+00099C Naval Research Laboratory
+0009A1 Telewise Communications
+000995 Castle Technology
+000989 VividLogic
+00098E ipcas GmbH
+00097C Cisco Systems
+0009C8 Sinagawa Tsushin Keisou Service
+0009CF iAd GmbH
+0009D4 Transtech Networks
+0009BB MathStar
+0009C0 6wind
+000807 Access Devices Limited
+000801 HighSpeed Surfing
+000808 PPT Vision
+0007F7 Galtronics
+0007FE Rigaku
+0007F8 ITDevices
+0007EB Cisco Systems
+0007F1 TeraBurst Networks
+0007E5 Coup
+0007DF Vbrick Systems
+0007DE eCopilt AB
+0007CF Anoto AB
+0007D2 Logopak Systeme GmbH & KG
+0008AA Karam
+0008A4 Cisco Systems
+000898 Gigabit Optics
+00089D UHD-Elektronik
+000890 Avilinks SA
+000889 Echostar Technologies
+000884 Index Braille AB
+000877 Liebert-Hiross Spa
+08006B Accel Technologies
+000871 Northdata
+00087D Cisco Systems
+000876 SDSystem
+0008E6 Littlefeet
+0008D9 Mitadenshi
+0008D4 IneoQuest Technologies
+0008CD With-Net
+0008D3 Hercules TechnologiesS.
+0008C3 Contex A/S
+0008BD Tepg-us
+0008BC Ilevo AB
+0008B7 HIT Incorporated
+0008B0 BKtel communications GmbH
+00086A Securiton Gmbh
+000864 Fasy
+00085E PCO AG
+000851 Canadian Bank Note Company
+000852 Davolink
+000857 Polaris Networks
+00081B Windigo Systems
+000822 InPro Comm
+00082E Multitone Electronics PLC
+00081C @pos.com
+000828 Koei Engineering
+000816 Bluelon ApS
+000815 Cats
+00091A Macat Optics & Electronics
+000919 MDS Gateways
+000913 SystemK
+00090C Mayekawa Mfg.
+000907 Chrysalis Development
+000900 TMT
+0008F8 UTC CCS
+0008F3 Wany
+0008EC Optical Zonu
+0008E0 ATO Technology
+0008E5 IDK
+000945 Palmmicro Communications
+00093E C&I Technologies
+000932 Omnilux
+000939 ShibaSoku
+000926 Yoda Communications
+00092B iQstor Networks
+00092C Hitpoint
+00091F A&D
+000751 m-u-t AG
+000750 Cisco Systems
+000746 Turck
+00074A Carl Valentin GmbH
+00073A Inventel Systemes
+000734 ONStor
+000739 Scotty Group Austria Gmbh
+00072D CNSystems
+000727 Zi (HK)
+000717 Wieland Electric GmbH
+00071E Tri-M Engineering / Nupak Dev.
+000723 Elcon Systemtechnik Gmbh
+00071D Satelsa Sistemas Y Aplicaciones De Telecomunicaciones
+000632 Mesco Engineering GmbH
+000625 The Linksys Group
+00062C Bivio Networks
+000624 Gentner Communications
+00061B Notebook Development Lab.  Lenovo Japan
+000622 Chung Fu Chen Yeh Enterprise
+00061C Hoshino Metal Industries
+000621 Hinox,
+00060B Artesyn Embedded Technologies
+000611 Zeus Wireless
+000615 Kimoto Electric
+000605 Inncom International
+0005E3 LightSand Communications
+0005EF Adoir Digital Technology
+0005F6 Young Chang
+0005E9 Unicess Network
+0005F0 Satec
+0005FC Schenck Pegasus
+0005E0 Empirix
+0005D6 L-3 Linkabit
+0005C4 Telect
+0005D0 Solinet Systems
+0005CA Hitron Technology
+0005BD Roax BV
+0005BE Kongsberg Seatex AS
+0005C3 Pacific Instruments
+00059D Daniel Computing Systems
+000796 LSI Systems
+000790 Tri-M Technologies (s) Limited
+000784 Cisco Systems
+000789 Dongwon Systems
+000783 SynCom Network
+00078A Mentor Data System
+00077A Infoware System
+00076D Flexlight Networks
+000769 Italiana Macchi SpA
+000773 Ascom Powerline Communications
+00075D Celleritas
+000763 Sunniwell Cyber Tech.
+000756 Juyoung Telecom
+0007C9 Technol Seven
+00047B Schlumberger
+0007C3 Thomson
+0007BD Radionet
+0007B0 Office Details
+0007B7 Samurai Ind. Prods Eletronicos Ltda
+0007B6 Telecom Technology
+0007A3 Ositis Software
+0007A9 Novasonics
+0007AC Eolring
+00079C Golden Electronics Technology
+0006AB W-Link Systems
+0006A5 Pinon
+0006A1 Celsian Technologies
+000694 Mobillian
+00069B AVT Audio Video Technologies GmbH
+00068E HID
+000688 Telways Communication
+000682 Convedia
+000681 Goepel Electronic GmbH
+000655 Yipee
+00D05F Valcom
+000674 Spectrum Control
+000678 Marantz Brand Company
+000661 NIA Home Technologies
+000668 Vicon Industries
+000667 Tripp Lite
+00066E Delta Electronics
+00064E Broad Net Technology
+00064F Pro-nets Technology
+000642 Genetel Systems
+00063E Opthos
+000648 Seedsware
+000638 Sungjin C&C
+00070B Novabase SGPS
+000710 Adax
+000700 Zettamedia Korea
+0006F9 Mitsui Zosen Systems Research
+000703 Csee Transport
+000706 Sanritz
+0006E8 Optical Network Testing
+0006EE Shenyang Neu-era Information & Technology Stock
+0006E2 Ceemax Technology
+0006D8 Maple Optical Systems
+0006D4 Interactive Objects
+0006CE Dateno
+0006B7 Telem Gmbh
+0006BE Baumer Optronic GmbH
+0006B8 Bandspeed
+0006BD Bntechnology
+0006C2 Smartmatic
+0006C7 Rfnet Technologies Pte (S)
+0006B1 Sonicwall
+000475 3 Com
+00046F Digitel S/A Industria Eletronica
+000468 Vivity
+00045C Mobiwave Pte
+000463 Bosch Security Systems
+000462 Dakos Data & Communication
+000455 Antara.net
+000456 Cambium Networks Limited
+000450 DMD Computers SRL
+000446 Cyzentech
+00044B Nvidia
+0005AD Topspin Communications
+0005B1 ASB Technology BV
+0005B7 Arbor Technology
+0005A3 QEI
+000597 Eagle Traffic Control Systems
+000591 Active Silicon
+00058A Netcom
+000590 Swissvoice
+00057E Eckelmann Steuerungstechnik GmbH
+000578 Private
+000584 AbsoluteValue Systems
+00052E Cinta Networks
+00053A Willowglen Services Pte
+000528 New Focus
+000527 SJ Tek
+000521 Control Microsystems
+000515 Nuark
+00051B Magic Control Technology
+000511 Complementary Technologies
+00050B Sicom Systems
+000501 Cisco Systems
+000505 Systems Integration Solutions
+000504 Naray Information & Communication Enterprise
+0004FB Commtech
+000574 Cisco Systems
+000567 Etymonic Design
+00056E National Enhance Technology
+00056D Pacific
+000561 nac Image Technology
+00055B Charles Industries
+000554 Rangestar Wireless
+000555 Japan Cash Machine
+000547 Starent Networks
+00054E Philips
+000540 Fast
+000541 Advanced Systems
+000534 Northstar Engineering
+0004F4 Infinite Electronics
+0004EE Lincoln Electric Company
+0004E8 IER
+008086 Computer Generation
+0004DE Cisco Systems
+0004E4 Daeryung Ind.
+0004D7 Omitec Instrumentation
+0004D8 IPWireless
+0004D2 Adcon Telemetry GmbH
+0004D1 Drew Technologies
+0004CB Tdsoft Communication
+0004BF VersaLogic
+0004C5 ASE Technologies
+00043F ESTeem Wireless Modems
+000439 Rosco Entertainment Technology
+000433 Cyberboard A/S
+00042C Minet
+000427 Cisco Systems
+000426 Autosys
+000420 Slim Devices
+000413 Snom Technology AG
+000418 TeltronicU.
+000412 WaveSmith Networks
+00040C Kanno Works
+000370 NXTV
+000405 ACN Technologies
+000406 Fa. Metabox AG
+0003FB Enegate
+0003FC Intertex Data AB
+0003EF Oneline AG
+0003F6 Allegro Networks
+0003EA Mega System Technologies
+0003E9 Akara Canada
+0003E4 Cisco Systems
+0003D8 iMPath Networks
+0003D5 Advanced Communications
+0003CC Momentum Computer
+0003D1 Takaya
+0003C5 Mobotix AG
+0003BE Netility
+0003B9 Hualong Telecom
+0003B7 Zaccess Systems
+0003B3 IA Link Systems
+0003A7 Unixtar Technology
+0003AE Allied Advanced Manufacturing Pte
+0003A0 Cisco Systems
+000398 Wisi
+00039B NetChip Technology
+000394 Connect One
+00038D PCS Revenue Control Systems
+000385 Actelis Networks
+000388 Fastfame Technology
+00037F Atheros Communications
+0004B8 Kumahira
+0004B2 Essegi SRL
+0004AE Sullair
+0004AB Comverse Network Systems
+00049F Freescale Semiconductor
+0004A4 NetEnabled
+00049E Wirelink
+000498 Mahi Networks
+000491 Technovision
+00048C Nayna Networks
+000492 Hive Internet
+000485 PicoLight
+000307 Secure Works
+000300 Barracuda Networks
+0002F8 Seakr Engineering
+00D024 Cognex
+0002F4 Pctel
+0002FB Baumuller Aulugen-Systemtechnik GmbH
+0002E9 CS Systemes De Securite - C3S
+0002DD Bromax Communications
+0002E2 NDC Infared Engineering
+0002DA ExiO Communications
+0002D6 Nice Systems
+0002CA EndPoints
+0002CF ZyGate Communications
+0001CD ARtem
+0001D2 inXtron
+0001C9 Cisco Systems
+0001C7 Cisco Systems
+0001C2 ARK Research
+0001BE Gigalink
+0001BC Brains
+0001AC Sitara Networks
+0001A9 BMW AG
+0001B0 Fulltek Technology
+000179 Wireless Technology
+000185 Hitachi Aloka Medical
+00018C Mega Vision
+000192 Texas Digital Systems
+00019E ESS Technology
+001095 Thomson
+000278 Samsung Electro-Mechanics
+00025A Catena Networks
+000271 Zhone Technologies
+00026C Philips CFT
+00026A Cocess Telecom
+000266 Thermalogic
+00025F Nortel Networks
+000256 Alpha Processor
+000251 Soma Networks
+00024A Cisco Systems
+00024D Mannesman Dematic Colby
+000245 Lampus
+00023E Selta Telematica S.p.a
+00023B Ericsson
+000237 Cosmo Research
+000234 Imperial Technology
+000228 Necsom
+000224 C-cor
+00020D Micronpc.com
+000220 Canon Finetech
+000378 Humax
+00036C Cisco Systems
+000373 Aselsan A.S
+000368 Embedone
+000366 ASM Pacific Technology
+000365 Kira Information & Communications
+000360 PAC Interactive Technology
+00035D Bosung Hi-Net
+00031A Beijing Broad Telecom
+000359 DigitalSis
+000354 Fiber Logic Communications
+000352 Colubris Networks
+00034E Pos Data Company
+000342 Nortel Networks
+0002C3 Arelnet
+0002BE Totsu Engineering
+0002BA Cisco Systems
+0002B2 Cablevision
+0002B5 Avnet
+0002AE Scannex Electronics
+0002A7 Vivace Networks
+0002A2 Hilscher GmbH
+000297 C-COR.net
+00028E Rapid 5 Networks
+000293 Solid Data Systems
+0001FA Horoscas
+000284 Areva T&D
+00027D Cisco Systems
+00033F BigBand Networks
+000336 Zetes Technologies
+00033B Tami Tech
+000328 Mace Group
+00032F Global Sun Technology
+000320 Xpeed
+000323 Cornet Technology
+00029F L-3 Communication Aviation Recorders
+00031F Condev
+000317 Merlin Systems
+00030E Core Communications
+000313 Access Media SPA
+0001A5 Nextcomm
+0001A1 Mag-Tek
+000195 Sena Technologies
+00017D ThermoQuest
+000189 Refraction Technology
+00308B Brix Networks
+00014F Adtran
+00015A Digital Video Broadcasting
+000166 TC Group A/S
+00016D CarrierComm
+00015F Digital Design Gmbh
+000214 Dtvro
+000210 Fenecom
+000208 Unify Networks
+000201 IFM Electronic gmbh
+0001F5 Erim
+0001FD Digital Voice Systems
+0001E5 Supernet
+0001E8 Force10 Networks
+0001D9 Sigma
+0001E0 Fast Systems
+0001D5 Haedong Info & Comm
+000118 EZ Digital
+000124 Acer Incorporated
+000101 Private
+00010D Coreco
+000114 Kanda Tsushin Kogyo
+000111 iDigm
+000105 Beckhoff Automation GmbH
+00029C 3com
+00B009 Grass Valley, A Belden Brand
+00B0B3 Xstreamis PLC
+00B09D Point Grey Research
+00B094 Alaris
+00B048 Marconi Communications
+00B0C7 Tellabs Operations
+003060 Powerfile
+00301C Altvater Airdata Systems
+003015 CP Clare
+0030E6 Draeger Medical Systems
+003091 Taiwan First Line ELEC.
+003080 Cisco Systems
+0030AD Shanghai Communication
+00305B Toko
+003024 Cisco Systems
+00301F Optical Networks
+0030D9 Datacore Software
+00D0FF Cisco Systems
+003058 API Motion
+0030C6 Control Solutions
+003036 RMP Elektroniksysteme Gmbh
+00308A Nicotra Sistemi S.P.A
+00302C Sylantro Systems
+003006 Superpower Computer
+003079 CQOS
+003059 Kontron Compact Computers AG
+0030B9 Ectel
+00303A Maatel
+0030A3 Cisco Systems
+003040 Cisco Systems
+003064 Adlink Technology
+003097 AB Regin
+0030EB Turbonet Communications
+0030C8 GAD LINE
+0030C9 LuxN
+00B01E Rantic Labs
+00B064 Cisco Systems
+0030A2 Lightner Engineering
+0030DE Wago Kontakttechnik Gmbh
+00309E Workbit
+003057 QTelNet
+00305C Smar Laboratories
+003082 Taihan Electric Wire
+0030AE Times N System
+00300D MMC Technology
+003075 Adtech
+0030E7 CNF Mobile Solutions
+003019 Cisco Systems
+003052 Elastic Networks
+003011 HMS Industrial Networks
+00304A Fraunhofer Ipms
+003014 Divio
+003029 Opicom
+0030BD Belkin Components
+0030BA Ac&t System
+00301D Skystream
+003049 Bryant Technology
+003041 Saejin T &
+00308C Quantum
+00D04F Bitronics
+00D0EF IGT
+00D022 Incredible Technologies
+00D0C8 Prevas A/S
+00D052 Ascend Communications
+00D0B1 Omega Electronics SA
+00D0C1 Harmonic Data Systems
+00D0F0 Convision Technology Gmbh
+00D00E Pluris
+00D055 Kathrein-werke KG
+00D095 Alcatel-Lucent, Enterprise Business Group
+00D000 Ferran Scientific
+00D005 ZHS Zeitmanagementsysteme
+00D019 Dainippon Screen Corporate
+00D053 Connected Systems
+00D097 Cisco Systems
+00016A Alitec
+000176 Orient Silver Enterprises
+000158 Electro Industries/Gauge Tech
+00012D Komodo Technology
+000139 Point Multimedia Systems
+000140 Sendtek
+00014C Berkeley Process Control
+000135 KDC
+00013C TIW Systems
+000148 X-traWeb
+000120 Oscilloquartz
+000127 Open Networks
+00309C Timing Applications
+003086 Transistor Devices
+0030B5 Tadiran Microwave Networks
+003070 1Net
+003044 CradlePoint
+00307E Redflex Communication Systems
+00307A Advanced Technology & Systems
+0030B7 Teletrol Systems
+0030B3 San Valley Systems
+00303B PowerCom Technology
+0030BC Optronic AG
+003071 Cisco Systems
+009003 Aplio
+0090D7 NetBoost
+009093 Nanao
+0090B4 Willowbrook Technologies
+009083 Turbo Communication
+0090BD Omnia Communications
+009094 Osprey Technologies
+0090DD Miharu Communications
+009028 Nippon Signal
+00908C Etrend Electronics
+00905D Netcom Sicherheitstechnik Gmbh
+009068 DVT
+009030 Honeywell-dating
+0090D3 Giesecke & Devrient Gmbh
+005081 Murata Machinery
+0050CB Jetter
+00500E Chromatis Networks
+0050FD Visioncomm
+0050FE Pctvnet ASA
+0050AB Naltec
+005006 TAC AB
+0050BF Metalligence Technology
+005089 Safety Management Systems
+005066 AtecoM GmbH advanced telecomunication modules
+0050D9 Engetron-engenharia Eletronica IND. e COM. Ltda
+005043 Marvell Semiconductor
+005018 AMIT
+005059 iBAHN
+00506A Edeva
+00502E Cambex
+005070 Chaintech Computer
+00503B Mediafire
+005084 ATL Products
+005055 Doms A/S
+00504B Barconet N.V.
+005046 Menicx International
+00502C Soyo Computer
+005060 Tandberg Telecom AS
+0050DD Serra Soldadura
+00503F Anchor Games
+0050EE TEK Digitel
+005004 3com
+005072 Corvis
+005012 CBL - Gmbh
+0050E8 Nomadix
+0050F2 Microsoft
+005052 Tiara Networks
+005064 CAE Electronics
+0050B4 Satchwell Control Systems
+3C39E7 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+885D90 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+0050B2 Brodel Gmbh
+78C2C0 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+C88ED1 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+E4956E Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+64FB81 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+00D081 RTD Embedded Technologies
+00D011 Prism Video
+00D09B Spectel
+00D031 Industrial Logic
+00D021 Regent Electronics
+00D0DF Kuzumi Electronics
+00D0B4 Katsujima
+00D079 Cisco Systems
+00D0E2 MRT Micro
+00D039 Utilicom
+00504F Olencom Electronics
+0050A0 Delta Computer Systems
+005007 Siemens Telecommunication Systems Limited
+005015 Bright Star Engineering
+005031 Aeroflex Laboratories
+0050DF AirFiber
+0050F3 Global NET Information
+005038 Dain Telecom
+00D0E1 Avionitek Israel
+00D01B Mimaki Engineering
+00D06E Trendview Recorders
+00D075 Alaris Medical Systems
+00509D THE Industree
+00501E Grass Valley, A Belden Brand
+00502B Genrad
+00500A Iris Technologies
+00D027 Applied Automation
+00D0F6 Alcatel Canada
+00D0F1 Sega Enterprises
+00D009 Hsing TECH. Enterprise
+00D080 Exabyte
+00D084 Nexcomm Systems
+00D0B2 Xiotech
+00D0E6 Ibond
+00D099 Elcard Wireless Systems Oy
+0090AF J. Morita MFG.
+009088 Baxall Security
+0090E0 Systran
+00903E N.V. Philips Industrial Activities
+0090B9 Beran Instruments
+00901A Unisphere Solutions
+0090AE Italtel
+009082 Force Institute
+00906A Turnstone Systems
+0001FE Digital Equipment
+009077 Advanced Fibre Communications
+0090B2 Avici Systems
+009095 Universal Avionics
+009012 Globespan Semiconductor
+0090B6 Fibex Systems
+0090F4 Lightning Instrumentation
+00904F ABB Power T&D Company
+00905A Dearborn Group
+009066 Troika Networks
+00907A Spectralink
+0090F0 Harmonic Video Systems
+001047 Echo Eletric
+00100C ITO
+0010D0 Witcom
+001006 Thales Contact Solutions
+0010D6 Exelis
+001076 Eurem Gmbh
+00103F Tollgrade Communications
+001034 GNP Computers
+001012 Processor Systems (I) PVT
+0010C8 Communications Electronics Security Group
+0010D1 Top Layer Networks
+0010F0 Rittal-werk Rudolf LOH Gmbh
+00106A Digital Microwave
+001030 Eion
+0010A4 Xircom
+001050 Rion
+00109C M-system
+001064 DNPG
+001020 Hand Held Products
+00106E Tadiran COM.
+00105B NET Insight AB
+001002 Actia
+0010A0 Innovex Technologies
+001074 Aten International
+001057 Rebel.com
+0010E0 Oracle 
+0010BC Aastra Telecom
+001033 Accesslan Communications
+0004AC IBM
+0010B4 Atmosphere Networks
+0010F9 Unique Systems
+001038 Micro Research Institute
+00100A Williams Communications Group
+001080 Metawave Communications
+0010AB Koito Electric Industries
+00903C Atlantic Network Systems
+0090CE Tetra Gmbh
+0090E3 Avex Electronics
+00900B Lanner Electronics
+0090C8 Waverider Communications (canada)
+0090B7 Digital Lightwave
+009037 Acucomm
+009059 Telecom Device K.K.
+00E003 Nokia Wireless Business Commun
+00E0F3 WebSprint Communications
+00E013 Eastern Electronic
+001063 Starguide Digital Networks
+0010A7 Unex Technology
+001039 Vectron Systems AG
+0010C3 Csi-control Systems
+00107F Crestron Electronics
+00102C Lasat Networks A/S
+0010B7 Coyote Technologies
+006064 Netcomm Limited
+0060CB Hitachi Zosen
+006090 Artiza Networks
+0060A9 Gesytec MBH
+0060F2 Lasergraphics
+006031 HRK Systems
+0060A6 Particle Measuring Systems
+006082 Novalink Technologies
+006012 Power Computing
+00604D MMC Networks
+006048 EMC
+00600F Westell
+0060E5 Fuji Automation
+006010 Network Machines
+006044 Litton/poly-scientific
+00609B Astro-med
+0060BE Webtronics
+006052 Peripherals Enterprise
+00E03F Jaton
+00E0EB Digicom Systems, Incorporated
+00E00E Avalon Imaging Systems
+00E0CD Saab Sensis
+00E0CB Reson
+00E048 SDL Communications
+00E083 Jato Technologies
+00E03D Focon Electronic Systems A/S
+00E0FA TRL Technology
+00E02C AST Computer
+00E00B Rooftop Communications
+00E067 eac Automation-consulting Gmbh
+00E058 Phase ONE Denmark A/S
+00E089 ION Networks
+00E03B Prominet
+006017 Tokimec
+0060E6 Shomiti Systems Incorporated
+006053 Toyoda Machine Works
+0060A0 Switched Network Technologies
+006019 Roche Diagnostics
+006033 Acuity Imaging
+0060EE Apollo
+006022 Vicom Systems
+006013 Netstal Maschinen AG
+0060F4 Advanced Computer Solutions
+006011 Crystal Semiconductor
+00600E Wavenet International
+0060C0 Nera Networks AS
+00E062 Host Engineering
+00E033 E.E.P.D. GmbH
+00E079 A.t.n.r.
+00E09C MII
+00E075 Verilink
+00E07A Mikrodidakt AB
+00E03E Alfatech
+00E09A Positron
+0060D7 Ecole Polytechnique Federale DE Lausanne (epfl)
+006087 Kansai Electric
+00E029 Standard Microsystems
+00606B Synclayer
+006073 Redcreek Communications
+006039 SanCom Technology
+0060A5 Performance Telecom
+0060B3 Z-com
+006089 Xata
+00603C Hagiwara Sys-com
+00602E Cyclades
+006075 Pentek
+00601C Telxon
+006016 Clariion
+0060AD MegaChips
+0060B6 Land Computer
+006055 Cornell University
+006015 Net2net
+00A01D Red Lion Controls
+00A071 Video Lottery Technologies
+00A052 Stanilite Electronics
+00A0EA Ethercom
+00A0B8 Symbios Logic
+00A02E Brand Communications
+00A0E2 Keisokugiken
+00A0C5 ZyXEL Communications
+00A058 Glory
+00E093 Ackfin Networks
+00E0E3 Sk-elektronik Gmbh
+00E066 ProMax Systems
+00E0DB ViaVideo Communications
+00E0DF Keymile Gmbh
+00E00D Radiant Systems
+00E008 Amazing Controls!
+00E086 Emerson Network Power, Avocent Division
+00E0E1 G2 Networks
+00E042 Pacom Systems
+00E08E Utstarcom
+00E095 Advanced-vision Technolgies
+006006 Sotec
+00603D 3CX
+006029 Cary Peripherals
+006043 iDirect
+0060D1 Cascade Communications
+0060CD VideoServer
+006094 IBM
+0060D9 Transys Networks
+0060AA Intelligent Devices (idi)
+00605A Celcore
+006065 Bernecker & Rainer Industrie-elektronic Gmbh
+00E07B BAY Networks
+00E077 Webgear
+00E0D2 Versanet Communications
+00E04E Sanyo Denki
+00E0DD Zenith Electronics
+00E0D0 Netspeed
+00E02A Tandberg Television AS
+00E05B West END Systems
+00E051 Talx
+00A0F0 Toronto Microelectronics
+00A049 Digitech Industries
+00A027 Firepower Systems
+00A0FF Tellabs Operations
+00A001 DRS Signal Solutions
+00A0F1 MTI
+00A046 Scitex
+00A0D9 Convex Computer
+00A0B5 3H Technology
+00A0AC Gilat Satellite Networks
+00A057 Lancom Systems Gmbh
+00A086 Amber Wave Systems
+00A083 Asimmphony Turkey
+00A091 Applicom International
+00A004 Netpower
+00A081 Alcatel Data Networks
+00A0D5 Sierra Wireless
+00200F Ebrains
+0020C7 Akai Professional M.I.
+0020EB Cincinnati Microwave
+0020E3 MCD Kencom
+002013 Diversified Technology
+0020C1 SAXA
+002087 Memotec
+0020F9 Paralink Networks
+00A0F9 Bintec Communications Gmbh
+00A0BC Viasat, Incorporated
+00A003 Siemens Switzerland, I B T HVP
+00A09E Ictv
+00A026 Teldat
+00201A MRV Communications
+002023 T.C. Technologies
+0020F3 Raynet
+002039 Scinets
+002038 VME Microsystems International
+00203E LogiCan Technologies
+002055 Altech
+0020D9 Panasonic Technologies,/mieco-us
+002080 Synergy (uk)
+002026 Amkly Systems
+00203D Honeywell ECC
+002019 Ohler Gmbh
+002057 Titze Datentechnik Gmbh
+0020BE LAN Access
+002022 NMS Communications
+0020AA Ericsson Television Limited
+00208E Chevin Software ENG.
+00203B Wisdm
+002044 Genitech
+0020F5 Pandatel AG
+002021 Algorithms Software PVT.
+002074 Sungwoon Systems
+0020CE Logical Design Group
+002082 Oneac
+0020BF Aehr Test Systems
+0020F1 Altos India Limited
+00205D Nanomatic OY
+0020E1 Alamar Electronics
+0020CC Digital Services
+00202C Welltronix
+0020B3 Tattile SRL 
+00A048 Questech
+00A0C4 Cristie Electronics
+00A089 Xpoint Technologies
+00A0D1 Inventec
+00A0AE Nucom Systems
+00A02B Transitions Research
+00A0A1 Epic Data
+00A0C3 Unicomputer Gmbh
+00A042 Spur Products
+00C007 Pinnacle Data Systems
+00C0F8 About Computing
+00C06F Komatsu
+00C08E Network Information Technology
+00C05A Semaphore Communications
+00C0EB SEH Computertechnik Gmbh
+00C0C7 Sparktrum Microsystems
+00C0D8 Universal Data Systems
+00C068 HME Clear-Com
+0040DB Advanced Technical Solutions
+00405B Funasset Limited
+00401B Printer Systems
+0040EB Martin Marietta
+0040CD Tera Microsystems
+0040E5 Sybus
+0040F9 Combinet
+004039 Optec Daiichi Denko
+0040FE Symplex Communications
+0020F0 Universal Microelectronics
+0020EF USC
+002016 Showa Electric Wire & Cable
+00201F Best Power Technology
+002045 ION Networks
+0020B6 Agile Networks
+00208A Sonix Communications
+00204C Mitron Computer PTE
+002002 Seritech Enterprise
+00204B Autocomputer
+0020AF 3com
+002048 Marconi Communications
+002008 Cable & Computer Technology
+00C023 Tutankhamon Electronics
+00C0F3 Network Communications
+00C043 Stratacom
+00C0B3 Comstat Datacomm
+00C0B5 Corporate Network Systems
+00403E Raster OPS
+0040AE Delta Controls
+0040C6 Fibernet Research
+004092 ASP Computer Products
+004054 Connection Machines Services
+0040D8 Ocean Office Automation
+0040C0 Vista Controls
+004088 Mobius Technologies
+00803B APT Communications
+0080BA Specialix (asia) PTE
+00BB01 Octothorpe
+00C01F S.e.r.c.e.l.
+00C094 VMX
+00C075 Xante
+00C0F9 Artesyn Embedded Technologies
+00C039 Teridian Semiconductor
+00C077 Daewoo Telecom
+00C02F Okuma
+00C0F1 Shinko Electric
+00C0DE Zcomm
+0040AF Digital Products
+00404F Space & Naval Warfare Systems
+00407B Scientific Atlanta
+00404E Fluent
+00C0F7 Engage Communication
+00C030 Integrated Engineering B. V.
+00C04A Group 2000 AG
+00C0A6 Exicom Australia
+00C053 Aspect Software
+00C0CF Imatran Voima OY
+00C029 Nexans Deutschland GmbH - ANS
+00C0A4 Unigraf OY
+00C060 ID Scandinavia AS
+00C082 Moore Products
+00C008 Seco SRL
+00C0BB Forval Creative
+00C0E0 DSC Communication
+00C05E Vari-lite
+00C031 Design Research Systems
+00C07C Hightech Information
+00C0AE Towercom DBA PC House
+00C0D6 J1 Systems
+00C0AA Silicon Valley Computer
+00C04E Comtrol
+00C00A Micro Craft
+00C02A Ohkura Electric
+00C0F2 Transition Networks
+00C01D Grand Junction Networks
+00C0AD Marben Communication Systems
+00C024 Eden Sistemas DE Computacao SA
+00C0E9 OAK Solutions
+00C0C5 SID Informatica
+00C001 Diatek Patient Managment
+00C07E Kubota Electronic
+008012 Integrated Measurement Systems
+008039 Alcatel STC Australia
+008023 Integrated Business Networks
+0080CA Netcom Research Incorporated
+00804D Cyclone Microsystems
+0080D6 Nuvotech
+0080ED IQ Technologies
+0080C1 Lanex
+008049 Nissin Electric
+00807C Fibercom
+008079 Microbus Designs
+0080DE Gipsi
+008004 Antlow Communications
+008078 Practical Peripherals
+008040 John Fluke Manufacturing
+0000F8 Digital Equipment
+0080CE Broadcast Television Systems
+00801A Bell Atlantic
+00803F Tatung Company
+0080D4 Chase Research
+0080CB Falco Data Products
+008075 Parsytec Gmbh
+0080EB Compcontrol
+008099 Eaton Industries GmbH
+0080E4 Northwest Digital Systems
+008041 VEB Kombinat Robotron
+0080C8 D-link Systems
+008036 Reflex Manufacturing Systems
+0040F0 MicroBrain
+0040A7 Itautec Philco
+0040D3 Kimpsion International
+004065 GTE Spacenet
+0040CB Lanwan Technologies
+004041 Fujikura
+004053 Ampro Computers
+008032 Access
+0080CF Embedded Performance
+008031 Basys
+00803A Varityper
+00807E Southern Pacific
+008029 Eagle Technology
+00802F National Instruments
+008051 Fibermux
+0080FD Exsceed Corpration
+004008 A Plus Info
+0040E9 Accord Systems
+0040B5 Video Technology Computers
+004012 Windata
+00401C AST Research
+004067 Omnibyte
+004035 Opcom
+0040EA Plain Tree Systems
+0040EF Hypercom
+004093 Paxdata Networks
+0040EC Mikasa System Engineering
+0080B9 Arche Technoligies
+0080A7 Honeywell International
+0040DA Telspec
+004083 TDA Industria DE Produtos
+0040C8 Milan Technology
+0040BC Algorithmics
+00402F Xlnt Designs
+00405D Star-tek
+00405F AFE Computers
+004043 Nokia Siemens Networks GmbH & KG.
+00800D Vosswinkel F.U.
+0080D1 Kimtron
+00805D Canstar
+008094 Alfa Laval Automation AB
+008047 In-net
+008064 Wyse Technology
+0080C5 Novellco DE Mexico
+0080AC Imlogix, Division OF Genesys
+00808C NetScout Systems
+000052 Intrusion.com
+0000BD Mitsubishi Cable Company
+000037 Oxford Metrics Limited
+00003F Syntrex
+08007C Vitalink Communications
+080076 PC LAN Technologies
+080072 Xerox Univ Grant Program
+080070 Mitsubishi Electric
+080068 Ridge Computers
+080062 General Dynamics
+080057 Evans & Sutherland
+000010 Sytek
+000033 Egan Machinery Company
+000080 Cray Communications A/S
+0000FD High Level Hardware
+08008C Network Research
+080089 Kinetics
+080087 Xyplex
+080084 Tomen Electronics
+00000D Fibronics
+00004F Logicraft
+000015 Datapoint
+0000C7 Arix
+00001C Bell Technologies
+00001A Advanced Micro Devices
+000082 Lectra Systemes SA
+0000DA Atex
+0000DB British Telecommunications plc
+0000C1 Madge
+0000F6 Applied Microsystems
+080023 Panasonic Communications
+080022 NBI
+080019 General Electric
+08004D Corvus Systems
+08003E Codex
+080033 Bausch & Lomb
+08002F Prime Computer
+080032 Tigan Incorporated
+08002E Metaphor Computer Systems
+0000D2 SBE
+00006B Silicon Graphics/mips
+0000CC Densan
+0000CE Megadata
+0000EF KTI
+00000F NEXT
+0000C6 EON Systems
+0000D5 Micrognosis International
+000078 Labtam Limited
+0000EB Matsushita COMM. IND.
+00009C Rolm Mil-spec Computers
+000032 Marconi plc
+000069 Concord Communications
+00008B Infotron
+0000BE THE NTI Group
+00004C NEC
+00003B i Controls
+0000FE Annapolis Micro Systems
+080013 Exxon
+02BB01 Octothorpe
+0000A6 Network General
+00DD06 Ungermann-bass
+00DD0B Ungermann-bass
+000007 Xerox
+080014 Excelan
+08000F Mitel
+0000D7 Dartmouth College
+00DD00 Ungermann-bass
+08000A Nestar Systems Incorporated
+08001C Kdd-kokusai Debnsin Denwa
+02AA3C Olivetti Telecomm SPA (olteco)
+08001D Able Communications
+080018 Pirelli Focom Networks
+080015 STC Business Systems
+00DD03 Ungermann-bass
+00801F Krupp Atlas Electronik Gmbh
+00408E Tattile SRL 
+00800F Standard Microsystems
+080065 Genrad
+002275 Belkin International
+149182 Belkin International
+70106F Hewlett Packard Enterprise
+988B5D Sagemcom Broadband SAS
+94FEF4 Sagemcom Broadband SAS
+C8CD72 Sagemcom Broadband SAS
+E8BE81 Sagemcom Broadband SAS
+28FAA0 vivo Mobile Communication
+3CA348 vivo Mobile Communication
+F42981 vivo Mobile Communication
+C4282D Embedded Intellect
+002348 Sagemcom Broadband SAS
+B870F4 Compal Information (kunshan)
+000FB0 Compal Electronics
+1C7508 Compal Information (kunshan)
+8C0EE3 Guangdong Oppo Mobile Telecommunications
+A44F29 Ieee Registration Authority
+800A80 Ieee Registration Authority
+141FBA Ieee Registration Authority
+A0BB3E Ieee Registration Authority
+884AEA Texas Instruments
+3829DD ONvocal
+F81897 2Wire
+ECF4BB Dell
+D067E5 Dell
+18A99B Dell
+F8DB88 Dell
+18FB7B Dell
+001495 2Wire
+74E6E2 Dell
+109836 Dell
+44A842 Dell
+34E6D7 Dell
+000BDB Dell
+001143 Dell
+00188B Dell
+D4BED9 Dell
+002650 2Wire
+00217C 2Wire
+001FB3 2Wire
+640F28 2Wire
+001AA0 Dell
+002170 Dell
+0026B9 Dell
+A4BADB Dell
+001E4F Dell
+5CF9DD Dell
+907AF1 Wally
+28101B MagnaCom
+00065B Dell
+448723 Hoya Service
+806C1B Motorola Mobility, a Lenovo Company
+A470D6 Motorola Mobility, a Lenovo Company
+3407FB Ericsson AB
+001B21 Intel Corporate
+001B77 Intel Corporate
+18FF0F Intel Corporate
+58A839 Intel Corporate
+A434D9 Intel Corporate
+00215D Intel Corporate
+001676 Intel Corporate
+984FEE Intel Corporate
+E82AEA Intel Corporate
+605718 Intel Corporate
+C4D987 Intel Corporate
+B4B676 Intel Corporate
+8C705A Intel Corporate
+9C4E36 Intel Corporate
+541473 Wingtech Group (HongKongLimited
+14144B Fujian Star-net Communication
+001C50 TCL Technoly Electronics (Huizhou)
+00AA01 Intel
+5C36B8 TCL King Electrical Appliances (Huizhou)
+009027 Intel
+A08869 Intel Corporate
+00C2C6 Intel Corporate
+B88A60 Intel Corporate
+00A0C9 Intel
+7C7A91 Intel Corporate
+AC7BA1 Intel Corporate
+AC7289 Intel Corporate
+606C66 Intel Corporate
+4C8093 Intel Corporate
+BC7737 Intel Corporate
+A088B4 Intel Corporate
+00270E Intel Corporate
+001DE0 Intel Corporate
+0024D6 Intel Corporate
+D8FC93 Intel Corporate
+E8B1FC Intel Corporate
+186472 Aruba Networks
+00246C Aruba Networks
+64D954 Taicang T&W Electronics
+74C63B AzureWave Technology
+CC1FC4 InVue
+A0D37A Intel Corporate
+985FD3 Microsoft
+00D0AC Commscope
+0025D3 AzureWave Technology
+742F68 AzureWave Technology
+DC85DE AzureWave Technology
+E0B9A5 AzureWave Technology
+E04136 MitraStar Technology
+E0B2F1 Fn-link Technology Limited
+0026FC AcSiP Technology
+B8616F Accton Technology
+0010B5 Accton Technology
+00A02F ADB Broadband Italia
+6487D7 ADB Broadband Italia
+00E098 AboCom
+F0A225 Private
+0000B1 Alpha Micro
+001577 Allied Telesis
+ACE010 Liteon Technology
+000BA2 Sumitomo Electric Industries
+EC086B Tp-link Technologies
+00159A Arris Group
+00192C Arris Group
+2421AB Sony Mobile Communications AB
+001FA7 Sony Computer Entertainment
+A8E3EE Sony Computer Entertainment
+6C23B9 Sony Mobile Communications AB
+58170C Sony Mobile Communications AB
+B8F934 Sony Mobile Communications AB
+205476 Sony Mobile Communications AB
+303926 Sony Mobile Communications AB
+00EB2D Sony Mobile Communications AB
+709E29 Sony
+FC0FE6 Sony
+B00594 Liteon Technology
+40F02F Liteon Technology
+E8617E Liteon Technology
+28E347 Liteon Technology
+18CF5E Liteon Technology
+D0DF9A Liteon Technology
+90B134 Arris Group
+3C438E Arris Group
+E86D52 Arris Group
+0015D0 Arris Group
+001315 Sony Computer Entertainment
+0013A9 Sony
+00219E Sony Mobile Communications AB
+001E45 Sony Mobile Communications AB
+001813 Sony Mobile Communications AB
+00080E Arris Group
+0050E3 Arris Group
+94CCB9 Arris Group
+40B7F3 Arris Group
+20E564 Arris Group
+F87B7A Arris Group
+0023A3 Arris Group
+64ED57 Arris Group
+0023EE Arris Group
+002143 Arris Group
+5856E8 Arris Group
+0025F1 Arris Group
+0023AF Arris Group
+001ADE Arris Group
+001E46 Arris Group
+0018C0 Arris Group
+001A66 Arris Group
+002163 Askey Computer
+E839DF Askey Computer
+00138F Asiarock Technology Limited
+2CB05D Netgear
+00146C Netgear
+1C69A5 BlackBerry RTS
+003067 Biostar Microtech Int'l
+246511 AVM GmbH
+002308 Arcadyan Technology
+880355 Arcadyan Technology
+A42B8C Netgear
+04A151 Netgear
+28C68E Netgear
+5CDC96 Arcadyan Technology
+504A6E Netgear
+D0D04B Huawei Technologies
+001D00 Brivo Systems
+0010E7 Breezecom
+5C9656 AzureWave Technology
+0881F4 Juniper Networks
+A8D0E5 Juniper Networks
+648788 Juniper Networks
+28C0DA Juniper Networks
+80711F Juniper Networks
+00239C Juniper Networks
+001DB5 Juniper Networks
+7C4CA5 BSkyB
+902106 BSkyB
+A4C7DE Cambridge Industries(Group)
+343759 zte
+00402A Canoga Perkins
+382DE8 Samsung Electronics
+D087E2 Samsung Electronics
+205531 Samsung Electronics
+5440AD Samsung Electronics
+842E27 Samsung Electronics
+50F0D3 Samsung Electronics
+84119E Samsung Electronics
+08ECA9 Samsung Electronics
+10D38A Samsung Electronics
+382DD1 Samsung Electronics
+E0CBEE Samsung Electronics
+64B853 Samsung Electronics
+988389 Samsung Electronics
+244B03 Samsung Electronics
+FC8F90 Samsung Electronics
+1816C9 Samsung Electronics
+F4428F Samsung Electronics
+188331 Samsung Electronics
+8455A5 Samsung Electronics
+A87C01 Samsung Electronics
+C01173 Samsung Electronics
+BCE63F Samsung Electronics
+B857D8 Samsung Electronics
+94B10A Samsung Electronics
+E458B8 Samsung Electronics
+088C2C Samsung Electronics
+B86CE8 Samsung Electronics
+9C65B0 Samsung Electronics
+C8A823 Samsung Electronics
+C44202 Samsung Electronics
+D059E4 Samsung Electronics
+64B310 Samsung Electronics
+78ABBB Samsung Electronics
+000B3B devolo AG
+001D20 Comtrend
+6C38A1 Ubee Interactive
+0009E1 Gemtek Technology
+001999 Fujitsu Technology Solutions GmbH
+140C76 Freebox SAS
+0024D4 Freebox SAS
+A089E4 Skyworth Digital Technology(Shenzhen)
+001A9A Skyworth Digital Technology(Shenzhen)
+AC3A7A Roku
+CC6DA0 Roku
+000D4B Roku
+0C6F9C Shaw Communications
+1801E3 Bittium Wireless
+C0AC54 Sagemcom Broadband SAS
+40F201 Sagemcom Broadband SAS
+C891F9 Sagemcom Broadband SAS
+4CFF12 Fuze Entertainment
+0059AC KPN.
+AC9A22 NXP Semiconductors
+006037 NXP Semiconductors
+546009 Google
+A47733 Google
+94EB2C Google
+28BC56 EMAC
+287CDB Hefei  Toycloud Technology
+D0B33F Shenzhen Tinno Mobile Technology
+00738D Shenzhen Tinno Mobile Technology
+A8CA7B Huawei Technologies
+ACCF85 Huawei Technologies
+0CD746 Apple
+440010 Apple
+2435CC Zhongshan Scinan Internet of Things
+2C27D7 Hewlett Packard
+000F3D D-Link
+001195 D-Link
+0015E9 D-Link
+0CFD37 Suse Linux Gmbh
+2CFF65 Oki Electric Industry
+001CF0 D-Link
+00265A D-Link
+ACF1DF D-Link International
+FC7516 D-Link International
+E0D7BA Texas Instruments
+B8FFFE Texas Instruments
+78DEE4 Texas Instruments
+00182F Texas Instruments
+001834 Texas Instruments
+0017E3 Texas Instruments
+0017EA Texas Instruments
+001783 Texas Instruments
+7C18CD E-tron
+C8665D Aerohive Networks
+3897D6 Hangzhou H3C Technologies, Limited
+C8478C Beken
+E498D6 Apple
+606944 Apple
+08952A Technicolor CH USA
+001977 Aerohive Networks
+4018B1 Aerohive Networks
+8896B6 Global Fire Equipment
+188796 HTC
+945330 Hon Hai Precision Ind.
+00242C Hon Hai Precision Ind.
+00242B Hon Hai Precision Ind.
+D87988 Hon Hai Precision Ind.
+AC2A0C CSR Zhuzhou Institute
+601971 Arris Group
+F4CA24 FreeBit
+001DD1 Arris Group
+001DD6 Arris Group
+000A57 Hewlett Packard
+643150 Hewlett Packard
+002376 HTC
+0007E9 Intel
+B46D83 Intel Corporate
+E4FAFD Intel Corporate
+DC5360 Intel Corporate
+780CB8 Intel Corporate
+484520 Intel Corporate
+004026 Buffalo.inc
+0002A5 Hewlett Packard
+A02BB8 Hewlett Packard
+6CC217 Hewlett Packard
+3863BB Hewlett Packard
+CC3E5F Hewlett Packard
+7446A0 Hewlett Packard
+443192 Hewlett Packard
+FC15B4 Hewlett Packard
+EC9A74 Hewlett Packard
+80C16E Hewlett Packard
+D07E28 Hewlett Packard
+7403BD Buffalo.inc
+101F74 Hewlett Packard
+001A4B Hewlett Packard
+001F29 Hewlett Packard
+00215A Hewlett Packard
+000F61 Hewlett Packard
+001185 Hewlett Packard
+001279 Hewlett Packard
+001708 Hewlett Packard
+306023 Arris Group
+ACB313 Arris Group
+14ABF0 Arris Group
+0CF893 Arris Group
+8461A0 Arris Group
+E83381 Arris Group
+44E137 Arris Group
+1C1B68 Arris Group
+2832C5 Humax
+EC4D47 Huawei Technologies
+88CF98 Huawei Technologies
+6CE3B6 Nera Telecommunications
+8030DC Texas Instruments
+CC78AB Texas Instruments
+A4D578 Texas Instruments
+942CB3 Humax
+0452F3 Apple
+241EEB Apple
+F431C3 Apple
+C4F57C Brocade Communications Systems
+8C7CFF Brocade Communications Systems
+000CDB Brocade Communications Systems
+006069 Brocade Communications Systems
+C87B5B zte
+98F537 zte
+001E73 zte
+0019C6 zte
+0015EB zte
+A051C6 Avaya
+24D921 Avaya
+848371 Avaya
+7052C5 Avaya
+001B4F Avaya
+F0EBD0 Shanghai Feixun Communication
+D8490B Huawei Technologies
+888603 Huawei Technologies
+F8E811 Huawei Technologies
+E09796 Huawei Technologies
+CCCC81 Huawei Technologies
+101B54 Huawei Technologies
+7054F5 Huawei Technologies
+00197E Hon Hai Precision Ind.
+78DD08 Hon Hai Precision Ind.
+9CD21E Hon Hai Precision Ind.
+8096CA Hon Hai Precision Ind.
+D07AB5 Huawei Technologies
+C40528 Huawei Technologies
+3CDFBD Huawei Technologies
+14B968 Huawei Technologies
+80717A Huawei Technologies
+F49FF3 Huawei Technologies
+2C5BB8 Guangdong Oppo Mobile Telecommunications
+B0AA36 Guangdong Oppo Mobile Telecommunications
+784B87 Murata Manufacturing
+28A183 Alps Electric
+5CF8A1 Murata Manufacturing
+6021C0 Murata Manufacturing
+84DBAC Huawei Technologies
+C07009 Huawei Technologies
+E0191D Huawei Technologies
+B8BC1B Huawei Technologies
+241FA0 Huawei Technologies
+50A72B Huawei Technologies
+C85195 Huawei Technologies
+00F81C Huawei Technologies
+F4559C Huawei Technologies
+283CE4 Huawei Technologies
+64A5C3 Apple
+001D0F Tp-link Technologies
+5C63BF Tp-link Technologies
+B0487A Tp-link Technologies
+388345 Tp-link Technologies
+14E6E4 Tp-link Technologies
+647002 Tp-link Technologies
+6466B3 Tp-link Technologies
+6CE873 Tp-link Technologies
+08E84F Huawei Technologies
+04BD70 Huawei Technologies
+18C58A Huawei Technologies
+405FC2 Texas Instruments
+20CD39 Texas Instruments
+D8DDFD Texas Instruments
+544A16 Texas Instruments
+EC1127 Texas Instruments
+247189 Texas Instruments
+987BF3 Texas Instruments
+04C06F Huawei Technologies
+5C4CA9 Huawei Technologies
+4C5499 Huawei Technologies
+00259E Huawei Technologies
+001882 Huawei Technologies
+D4EA0E Avaya
+B4475E Avaya
+90FB5B Avaya
+14F65A Xiaomi Communications
+0C1DAF Xiaomi Communications
+28E31F Xiaomi Communications
+F0B429 Xiaomi Communications
+00906F Cisco Systems
+0090A6 Cisco Systems
+0090AB Cisco Systems
+7426AC Cisco Systems
+B000B4 Cisco Systems
+2834A2 Cisco Systems
+641225 Cisco Systems
+544A00 Cisco Systems
+5067AE Cisco Systems
+BC16F5 Cisco Systems
+6899CD Cisco Systems
+F44E05 Cisco Systems
+0CF5A4 Cisco Systems
+5CFC66 Cisco Systems
+D0A5A6 Cisco Systems
+3C5EC3 Cisco Systems
+64F69D Cisco Systems
+74A2E6 Cisco Systems
+204C9E Cisco Systems
+A055DE Pace plc
+0026D9 Pace plc
+00112F Asustek Computer
+0011D8 Asustek Computer
+001731 Asustek Computer
+0018F3 Asustek Computer
+485B39 Asustek Computer
+F46D04 Asustek Computer
+3085A9 Asustek Computer
+00900C Cisco Systems
+001079 Cisco Systems
+00102F Cisco Systems
+000E08 Cisco-Linksys
+00602F Cisco Systems
+006070 Cisco Systems
+006083 Cisco Systems
+00067C Cisco Systems
+C8D719 Cisco-Linksys
+CC08E0 Apple
+5855CA Apple
+8C7B9D Apple
+88C663 Apple
+C82A14 Apple
+9803D8 Apple
+8C5877 Apple
+3451C9 Apple
+E0B9BA Apple
+D023DB Apple
+B88D12 Apple
+B817C2 Apple
+68A86D Apple
+78A3E4 Apple
+54781A Cisco Systems
+58971E Cisco Systems
+CCD539 Cisco Systems
+20BBC0 Cisco Systems
+4C4E35 Cisco Systems
+7CAD74 Cisco Systems
+10F311 Cisco Systems
+08CC68 Cisco Systems
+D0C789 Cisco Systems
+F84F57 Cisco Systems
+34DBFD Cisco Systems
+5CA48A Cisco Systems
+AC7A4D Alps Electric
+FC62B9 Alps Electric
+0010A6 Cisco Systems
+E86549 Cisco Systems
+84B517 Cisco Systems
+046273 Cisco Systems
+9C57AD Cisco Systems
+00223A Cisco Spvtg
+001839 Cisco-Linksys
+001EE5 Cisco-Linksys
+38C85C Cisco Spvtg
+F45FD4 Cisco Spvtg
+002306 Alps Electric
+001E3D Alps Electric
+0019C1 Alps Electric
+BC926B Apple
+0050E4 Apple
+003065 Apple
+000A27 Apple
+001451 Apple
+0019E3 Apple
+002312 Apple
+002332 Apple
+002436 Apple
+00254B Apple
+0026BB Apple
+E80688 Apple
+985AEB Apple
+2078F0 Apple
+78D75F Apple
+E0ACCB Apple
+98E0D9 Apple
+C0CECD Apple
+70E72C Apple
+D03311 Apple
+847D50 Holley Metering Limited
+6C4A39 Bita
+C8B5B7 Apple
+A8BBCF Apple
+90B21F Apple
+B8E856 Apple
+1499E2 Apple
+04214C Insight Energy Ventures
+B418D1 Apple
+80006E Apple
+60D9C7 Apple
+C8F650 Apple
+1C1AC0 Apple
+E06678 Apple
+5C8D4E Apple
+64A3CB Apple
+44FB42 Apple
+F41BA1 Apple
+3CE072 Apple
+E88D28 Apple
+CC785F Apple
+AC3C0B Apple
+88CB87 Apple
+EC3586 Apple
+F0C1F1 Apple
+F4F951 Apple
+18AF8F Apple
+C0F2FB Apple
+00F76F Apple
+AC87A3 Apple
+48437C Apple
+34A395 Apple
+9CF387 Apple
+A85B78 Apple
+908D6C Apple
+0C1539 Apple
+BC4CC4 Apple
+0CBC9F Apple
+A45E60 Apple
+680927 Apple
+60FACD Apple
+1CABA7 Apple
+8CFABA Apple
+5C95AE Apple
+E0C97A Apple
+BC52B7 Apple
+14109F Apple
+542696 Apple
+D8D1CB Apple
+4C8ECC Silkan SA
+3CEF8C Zhejiang Dahua Technology
+64BC0C LG Electronics
+98F428 zte
+7C5A67 JNC Systems
+5C4979 AVM Audiovisuelles Marketing und Computersysteme GmbH
+C4BBEA Pakedge Device and Software
+84100D Motorola Mobility, a Lenovo Company
+D88B4C KingTing Tech.
+E81363 Comstock RD
+6C9354 Yaojin Technology (Shenzhen)
+4054E4 Wearsafe Labs
+8CE2DA Circle Media
+74D7CA Panasonic Automotive
+1CCDE5 Shanghai Wind Technologies
+20896F Fiberhome Telecommunication Technologies
+D494E8 Huawei Technologies
+B078F0 Beijing HuaqinWorld Technology
+3029BE Shanghai MRDcom
+7011AE Music Life
+ECB870 Beijing Heweinet Technology
+3095E3 Shanghai Simcom Limited
+401B5F Weifang GoerTek Electronics
+BC307E Wistron Neweb
+4040A7 Sony Mobile Communications AB
+54BE53 zte
+588BF3 ZyXEL Communications
+A01E0B Minix Technology Limited
+D48304 Shenzhen Fast Technologies
+385F66 Cisco Spvtg
+544E90 Apple
+28C87A Pace plc
+58FC73 Arria Live Media
+2C1BC8 Hunan Topview Network System
+5CADCF Apple
+006D52 Apple
+D888CE RF Technology
+D4F4BE Palo Alto Networks
+B88687 Liteon Technology
+68F956 Objetivos y Servicio de Valor Aadido
+C07CD1 Pegatron
+58B633 Ruckus Wireless
+AC60B6 Ericsson AB
+F4E926 Tianjin Zanpu Technology
+D03742 Yulong Computer Telecommunication Scientific(shenzhen)Co.
+04C23E HTC
+2CFCE4 Ctek Sweden AB
+A8A795 Hon Hai Precision Ind.
+10868C Arris Group
+C0B713 Beijing Xiaoyuer Technology
+DCA3AC RBcloudtech
+44656A Mega Video Electronic(HK) Industry
+0C9160 Hui Zhou Gaoshengda Technology
+ECA9FA Guangdong Genius Technology
+300C23 zte
+EC1F72 Samsung Electro Mechanics
+445F8C Intercel Group Limited
+A48D3B Vizio
+1005B1 Arris Group
+0C756C Anaren Microwave
+5C5188 Motorola Mobility, a Lenovo Company
+A039F7 LG Electronics (Mobile Communications)
+689AB7 Atelier Vision
+640DE6 Petra Systems
+283713 Shenzhen 3Nod Digital Technology
+7CAB25 Mesmo Technology
+74042B Lenovo Mobile Communication (Wuhan) Company Limited
+4455B1 Huawei Technologies
+A45602 fenglian Technology
+D06A1F BSE
+A88038 ShenZhen MovingComm Technology, Limited
+805067 W & D Technology
+402814 RFI Engineering
+102C83 Ximea
+D468BA Shenzhen Sundray Technologies Company Limited
+A47B85 Ultimedia,
+A8D828 Bayer HealthCare
+CC37AB Edgecore Networks Corportation
+F80D60 Canon
+E02CB2 Lenovo Mobile Communication (Wuhan) Company Limited
+DC15DB Ge Ruili Intelligent Technology ( Beijing
+E8508B Samsung Electro Mechanics
+30F335 Huawei Technologies
+E89120 Motorola Mobility, a Lenovo Company
+546172 Zodiac Aerospace SAS
+AC620D Jabil Circuit (Wuxi)
+54CD10 Panasonic Mobile Communications
+A4A1E4 Innotube
+706879 Saijo Denki International
+343D98 JinQianMao Technology
+5804CB Tianjin Huisun Technology
+1CB72C Asustek Computer
+40B89A Hon Hai Precision Ind.
+40B837 Sony Mobile Communications AB
+287610 IgniteNet
+68A378 Freebox SAS
+746A3A Aperi
+1844E6 zte
+A8D409 USA 111
+3089D3 Hongkong Ucloudlink Network Technology Limited
+4CB76D Novi Security
+906CAC Fortinet
+00323A so-logic
+64DB81 Syszone
+FC6FB7 Pace plc
+C4BAA3 Beijing Winicssec Technologies
+A013CB Fiberhome Telecommunication Technologies
+20635F Abeeway
+E00370 ShenZhen Continental Wireless Technology
+709C8F Nero AG
+807459 K's
+CC9635 LVS
+700136 Fatek Automation
+E03560 Challenger Supply Holdings
+0CB5DE Alcatel Lucent
+04C9D9 EchoStar Technologies
+E4CE70 Health & Life
+EC5A86 Yulong Computer Telecommunication Scientific (Shenzhen)
+802AA8 Ubiquiti Networks
+F87AEF Rosonix Technology
+10E878 Alcatel-Lucent
+BC6010 Qingdao Hisense Communications
+C43ABE Sony Mobile Communications AB
+18B169 Sonicwall
+D4684D Ruckus Wireless
+1CC72D Shenzhen Huapu Digital
+38D82F zte
+C8D779 Qingdao Haier TelecomLtd
+A0C562 Pace plc
+2CA2B4 Fortify Technologies
+D87495 zte
+8C873B Leica Camera AG
+28E476 Pi-Coral
+9C685B Octonion SA
+ACABBF AthenTek
+5C41E7 Wiatec International
+DC0914 Talk-A-Phone
+142971 Nemoa Electronics (hk)
+C0BDD1 Samsung Electro Mechanics
+346895 Hon Hai Precision Ind.
+B47356 Hangzhou Treebear Networking
+D88D5C Elentec
+50ADD5 Dynalec
+28D98A Hangzhou Konke Technology
+BC4DFB Hitron Technologies.
+6C25B9 BBK Electronics
+7429AF Hon Hai Precision Ind.
+40EACE Founder Broadband Network Service
+10C67E Shenzhen Juchin Technology
+3C4937 Assmann Electronic Gmbh
+904506 Tokyo Boeki Medisys
+80A85D Osterhout Design Group
+9C6C15 Microsoft
+EC74BA Hirschmann Automation and Control GmbH
+683C7D Magic Intelligence Technology Limited
+18A3E8 Fiberhome Telecommunication Tech.Co.
+60128B Canon
+ECBAFE Giroptic
+E8447E Bitdefender SRL
+84C3E8 Vaillant GmbH
+B88EC6 Stateless Networks
+146B72 Shenzhen Fortune Ship Technology
+40A5EF Shenzhen Four Seas Global Link Network Technology
+7C7A53 Phytrex Technology
+4886E8 Microsoft
+78FC14 B Communications
+88E161 Art Beijing Science and Technology Development
+B4A9FE Ghia Technology (shenzhen)
+700FC7 Shenzhen Ikinloop Technology
+EC8009 NovaSparks
+64002D Powerlinq
+486B2C BBK Electronics
+101218 Korins
+EC0EC4 Hon Hai Precision Ind.
+B04515 mira fitness
+307512 Sony Mobile Communications AB
+A49D49 Ketra
+C09879 Acer
+1C9ECB Beijing Nari Smartchip Microelectronics Company Limited
+D48DD9 Meld Technology
+2C3796 Cybo
+9470D2 Winfirm Technology
+2C2997 Microsoft
+4CE2F1 sclak srl
+344DEA zte
+908C09 Total Phase
+1C7E51 3bumen.com
+E41D2D Mellanox Technologies
+60C798 Verifone
+380E7B V.P.S. Thai
+38F33F Tatsuno
+28A5EE Shenzhen Sdgi Catv
+94CE31 CTS Limited
+4CBB58 Chicony Electronics
+C40006 Lipi Data Systems
+789CE7 Shenzhen Aikede Technology
+64899A LG Electronics
+5C2ED2 ABC(XiSheng) Electronics
+D8F710 Libre Wireless Technologies
+68F728 Lcfc(hefei) Electronics Technology
+DCEC06 Heimi Network Technology
+8870EF SC Professional Trading
+102F6B Microsoft
+ACB74F Metel S.r.o.
+CCF538 3isysnetworks
+04DEDB Rockport Networks
+68F06D Along Industrial, Limited
+54F876 ABB AG
+4857DD Facebook
+84930C InCoax Networks Europe AB
+D47B35 NEO Monitors AS
+D8FB11 Axacore
+C8D019 Shanghai Tigercel Communication Technology
+18A958 Provision Thai
+D8DECE Isung
+2053CA Risk Technology
+142BD6 Guangdong Appscomm
+C8BA94 Samsung Electro Mechanics
+B025AA Private
+408256 Continental Automotive GmbH
+D866EE Boxin Communication
+3C189F Nokia
+2829CC Corsa Technology Incorporated
+FC790B Hitachi High Technologies America
+28E6E9 SIS Sat Internet Services GmbH
+BC4E5D ZhongMiao Technology
+08F728 Globo Multimedia Sp. z o.o. Sp.k.
+60A8FE Nokia Solutions and Networks
+70720D Lenovo Mobile Communication Technology
+8401A7 Greyware Automation Products
+C4C9EC Gugaoo   HK Limited
+F406A5 Hangzhou Bianfeng Networking Technology
+4C3909 HPL Electric & Power Private Limited
+7CFE4E Shenzhen Safe vision Technology
+54EF92 Shenzhen Elink Technology
+800E24 ForgetBox
+FCE186 A3M
+CCB691 Necmagnuscommunications
+40167E Asustek Computer
+C89F1D Shenzhen Communication Technologies
+983713 PT.Navicom Indonesia
+ACA919 TrekStor GmbH
+84850A Hella Sonnen- und Wetterschutztechnik GmbH
+183009 Woojin Industrial Systems
+6081F9 Helium Systems
+34C5D0 Hagleitner Hygiene International GmbH
+74DBD1 Ebay
+3431C4 AVM GmbH
+DC537C Compal Broadband Networks
+A00627 Nexpa System
+303335 Boosty
+18D5B6 SMG Holdings
+C8FF77 Dyson Limited
+C03D46 Shanghai Mochui Network Technology
+DCF110 Nokia
+54DF00 Ulterius Technologies
+E01D38 Beijing HuaqinWorld Technology
+D80CCF C.g.v.s.
+143DF2 Beijing Shidai Hongyuan Network Communication
+B0D59D Shenzhen Zowee Technology
+C4913A Shenzhen Sanland Electronic
+60B617 Fiberhome Telecommunication Tech.Co.
+A46032 MRV Communications (Networks)
+205A00 Coval
+0C2026 noax Technologies AG
+240A11 TCT Mobile Limited
+880FB6 Jabil Circuits India Pvt,-ehtp Unit
+C4626B ZPT Vigantice
+74F85D Berkeley Nucleonics
+08D833 Shenzhen RF Technology
+48EE07 Silver Palm Technologies
+9CFBF1 Mesomatic Gmbh &KG
+94C014 Sorter Sp. j. Konrad Grzeszczyk MichaA, Ziomek
+1027BE Tvip
+2087AC AES motomation
+A824EB ZAO NPO Introtest
+447E76 Trek Technology (S) Pte
+E8FC60 Elcom Innovations Private Limited
+1CFCBB Realfiction ApS
+B0EC8F GMX SAS
+C40E45 ACK Networks
+5C254C Avire Global Pte
+7C1A03 8Locations
+481842 Shanghai Winaas Equipment
+E817FC Nifty
+D09C30 Foster Electric Company, Limited
+78FEE2 Shanghai Diveo Technology
+386C9B Ivy Biomedical
+E44C6C Shenzhen Guo Wei Electronic
+008B43 Rftech
+2C957F zte
+242642 Sharp
+282246 Beijing Sinoix Communication
+FC1607 Taian Technology(Wuxi)
+CC89FD Nokia
+E86183 Black Diamond Advanced Technology
+C4824E Changzhou Uchip Electronics
+24A87D Panasonic Automotive Systems Asia Pacific(Thailand)Co.
+78EC74 Kyland-USA
+28C825 DellKing Industrial
+64E892 Morio Denki
+086DF2 Shenzhen Mimowave Technology
+64EB8C Seiko Epson
+48D0CF Universal Electronics
+AC3613 Samsung Electronics
+DCC793 Nokia
+E03F49 Asustek Computer
+D8EE78 Moog Protokraft
+F4B6E5 TerraSem
+28BB59 Rnet Technologies
+7C8D91 Shanghai Hongzhuo Information Technology
+A881F1 Bmeye
+241148 Entropix
+30B5C2 Tp-link Technologies
+F85C45 IC Nexus
+88F7C7 Technicolor USA
+04DB8A Suntech International
+083F76 Intellian Technologies
+0CC47A Super Micro Computer
+D0634D Meiko Maschinenbau GmbH &amp; KG
+24DBED Samsung Electronics
+88C626 Logitech - Ultimate Ears
+889CA6 BTB Korea
+F025B7 Samsung Electro Mechanics
+B0DA00 Cera Electronique
+447098 Ming Hong Technology (shen Zhen) Limited
+54E2E0 Pace plc
+00EEBD HTC
+48B5A7 Glory Horse Industries
+DC5E36 Paterson Technology
+50E0C7 TurControlSystme AG
+9CD643 D-Link International
+28FC51 The Electric Controller and Manufacturing
+34A5E1 Sensorist ApS
+A4E9A3 Honest Technology
+C4E92F AB Sciex
+9C216A Tp-link Technologies
+F862AA xn systems
+A4059E STA Infinity LLP
+6C15F9 Nautronix Limited
+680AD7 Yancheng Kecheng Optoelectronic Technology
+BC8893 Villbau
+643F5F Exablaze
+E8F226 Millson Custom Solutions
+7060DE LaVision GmbH
+FCFE77 Hitachi Reftechno
+24E271 Qingdao Hisense Communications
+70533F Alfa Instrumentos Eletronicos Ltda.
+448A5B Micro-Star INT'L
+68193F Digital Airways
+5CD61F Qardio
+902083 General Engine Management Systems
+14B126 Industrial Software
+C03580 A&R Tech
+1446E4 Avistel
+907990 Benchmark Electronics Romania SRL
+C49380 Speedytel technology
+B4A82B Histar Digital Electronics
+60A9B0 Merchandising Technologies
+007DFA Volkswagen Group of America
+6024C1 Jiangsu Zhongxun Electronic Technology
+6C5AB5 TCL Technoly Electronics (Huizhou)
+88789C Game Technologies SA
+18AA45 Fon Technology
+0073E0 Samsung Electronics
+549359 Shenzhen Twowing Technologies
+BC4486 Samsung Electronics
+284430 GenesisTechnical Systems (UK)
+9843DA Intertech
+8056F2 Hon Hai Precision Ind.
+285767 Echostar Technologies
+B07908 Cummings Engineering
+04CB1D Traka plc
+B87AC9 Siemens
+B0989F LG CNS
+3C300C Dewar Electronics
+78B5D2 Ever Treasure Industrial Limited
+A409CB Alfred Kaercher GmbH &amp; KG
+C445EC Shanghai Yali Electron
+380B40 Samsung Electronics
+E8611F Dawning Information Industry
+0CA694 Sunitec Enterprise
+146080 zte
+986CF5 zte
+78491D The Will-Burt Company
+74D435 Giga-byte Technology
+840F45 Shanghai GMT Digital Technologies
+58A2B5 LG Electronics
+D8270C MaxTronic International
+E80410 Private
+8C088B Remote Solution
+A47760 Nokia
+24A495 Thales Canada
+70188B Hon Hai Precision Ind.
+3C77E6 Hon Hai Precision Ind.
+5CDD70 Hangzhou H3C Technologies, Limited
+883612 SRC Computers
+E0A198 Noja Power Switchgear
+CC7B35 zte
+04D437 ZNV
+CCF407 Eukrea Electromatique Sarl
+BC2BD7 Revogi Innovation
+3C404F Guangdong Pisen Electronics
+24ECD6 CSG Science & Technology,Ltd.Hefei
+102279 ZeroDesktop
+CC4AE1 fourtec -Fourier Technologies
+A4895B ARK Infosolutions PVT
+38EC11 Novatek Microelectronics
+A8CCC5 Saab AB (publ)
+988E4A Noxus(beijing) Technology
+1C4158 Gemalto M2M GmbH
+ACD657 Shaanxi Guolian Digital TV Technology
+541B5D Techno-Innov
+78CB33 DHC Software
+507691 Tekpea
+C421C8 Kyocera
+A4C0C7 ShenZhen Hitom Communication TechnologyLTD
+EC2257 JiangSu NanJing University Electronic Information Technology
+0C84DC Hon Hai Precision Ind.
+341A4C Shenzhen Weibu Electronics
+A09BBD Total Aviation Solutions
+E8481F Advanced Automotive Antennas
+18D6CF Kurth Electronic GmbH
+E07F88 Evidence Network SIA
+1C7CC7 Coriant GmbH
+542CEA Protectron
+00C5DB Datatech Sistemas Digitales Avanzados SL
+109AB9 Tosibox Oy
+F842FB Yasuda Joho
+887398 K2E Tekpoint
+68EE96 Cisco Spvtg
+FC6018 Zhejiang Kangtai Electric
+303EAD Sonavox Canada
+444A65 Silverflare
+50A0BF Alba Fiber Systems
+3C977E IPS Technology Limited
+F02405 Opus High Technology
+D8B04C Jinan USR IOT Technology
+646EEA Iskratel d.o.o.
+043D98 ChongQing QingJia Electronics
+E8BB3D Sino Prime-Tech Limited
+E492FB Samsung Electronics
+98CDB4 Virident Systems
+54E3B0 JVL Industri Elektronik
+640B4A Digital Telecom Technology Limited
+F42012 Cuciniale GmbH
+4C21D0 Sony Mobile Communications AB
+18104E Cedint-upm
+2C7B84 OOO Petr Telegin
+540536 Vivago Oy
+2CE6CC Ruckus Wireless
+E0FAEC Platan sp. z o.o. sp. k.
+F08EDB VeloCloud Networks
+B8DC87 IAI
+7C6FF8 Shenzhen Acto Digital Video Technology
+8C4B59 3D Imaging & Simulations
+A4FB8D Hangzhou Dunchong TechnologyLtd
+0075E1 Ampt
+CC04B4 Select Comfort
+284FCE Liaoning Wontel Science and Technology Development
+1449E0 Samsung Electro Mechanics
+0CC81F Summer Infant
+D86960 Steinsvik
+442AFF E3 Technology
+E440E2 Samsung Electronics
+0C9301 PT. Prasimax Inovasi Teknologi
+1CAF05 Samsung Electronics
+60699B isepos GmbH
+B830A8 Road-Track Telematics Development
+542160 Resolution Products
+88462A Telechips
+A897DC IBM
+E8DE27 Tp-link Technologies
+FC229C Han Kyung I Net
+148692 Tp-link Technologies
+1832A2 Laon Technology
+6854ED Alcatel-Lucent - Nuage
+985C93 SBG Systems SAS
+64E599 EFM Networks
+F499AC Weber Schraubautomaten Gmbh
+8CC7D0 zhejiang ebang communication
+B8AE6E Nintendo
+70820E as electronics GmbH
+DC2BCA Zera GmbH
+508D6F Chahoo Limited
+68831A Pandora Mobility
+D4223F Lenovo Mobile Communication Technology
+0868D0 Japan System Design
+103DEA HFC Technology (Beijing)
+E8E875 iS5 Communications
+2C7B5A Milper
+185AE8 Zenotech.Co.
+E0AEED Loenk
+D4EE07 Hiwifi
+908260 Ieee 1904.1 Working Group
+FCAD0F QTS Networks
+984C04 Zhangzhou Keneng Electrical Equipment
+CC047C G-WAY Microwave
+44F849 Union Pacific Railroad
+1CFA68 Tp-link Technologies
+D0BE2C Cnslink
+281878 Microsoft
+E457A8 Stuart Manufacturing
+2481AA KSH International
+789966 Musilab Electronics (DongGuan)Co.
+D8B02E Guangzhou Zonerich Business Machine
+EC2C49 University of Tokyo
+CC5D57 Information  System Research Institute
+1C37BF Cloudium Systems
+249504 SFR
+308999 Guangdong East Power,
+D4A499 InView Technology
+AC4122 Eclipse Electronic Systems
+A073FC Rancore Technologies Private Limited
+846223 Shenzhen Coship Electronics
+A4E991 Sistemas Audiovisuales Itelsis S.L.
+84F493 OMS spol. s.r.o.
+386793 Asia Optical
+BCD177 Tp-link Technologies
+C8B373 Cisco-Linksys
+983071 Daikyung Vascom
+0C0400 Jantar d.o.o.
+C04301 Epec Oy
+687CD5 Y Soft
+E07C62 Whistle Labs
+FC4499 Swarco LEA d.o.o.
+0C8484 Zenovia Electronics
+5CF370 CC&C Technologies
+A01C05 Nimax Telecom
+F80DEA ZyCast Technology
+7C0507 Pegatron
+1800DB Fitbit
+50A715 Aboundi
+FC35E6 Visteon
+D866C6 Shenzhen Daystar Technology
+1836FC Elecsys International
+F48139 Canon
+D40BB9 Solid Semecs bv.
+748E08 Bestek
+B8C855 Shanghai Gbcom Communication Technology
+54A619 Alcatel-Lucent Shanghai Bell
+C47DFE A.N. Solutions GmbH
+E031D0 SZ Telstar
+70C6AC Bosch Automotive Aftermarket
+2C69BA RF Controls
+DC5726 Power-One
+2C245F Babolat VS
+D464F7 Chengdu Usee Digital Technology
+A47ACF Vibicom Communications
+CC3C3F SA.S.S. Datentechnik AG
+905692 Autotalks
+0C2AE7 Beijing General Research Institute of Mining and Metallurgy
+4439C4 Universal Global Scientific Industrial
+DCD52A Sunny Heart Limited
+C4C755 Beijing HuaqinWorld Technology
+9C79AC Suntec Software(Shanghai)
+6488FF Sichuan Changhong Electric
+F8DFA8 zte
+ACA430 Peerless AV
+B4AB2C MtM Technology
+74372F Tongfang Shenzhen Cloudcomputing Technology
+BC51FE Swann communications
+789ED0 Samsung Electronics
+D40FB2 Applied Micro Electronics AME bv
+74FE48 Advantech
+7054D2 Pegatron
+D0B498 Robert Bosch Automotive Electronics
+80B95C Elftech
+E85AA7 LLC Emzior
+242FFA Toshiba Global Commerce Solutions
+A0BAB8 Pixon Imaging
+9CE1D6 Junger Audio-Studiotechnik GmbH
+E4E409 Leifheit AG
+004D32 Andon Health
+8C04FF Technicolor USA
+C46DF1 DataGravity
+28D244 Lcfc(hefei) Electronics Technology
+ACE87E Bytemark Computer Consulting
+60CDC5 Taiwan Carol Electronics.
+1489FD Samsung Electronics
+60C5A8 Beijing LT Honway Technology
+B4DF3B Chromlech
+A46E79 DFT SystemLtd
+94DE80 Giga-byte Technology
+C88A83 Dongguan HuaHong Electronics
+0CC655 Wuxi YSTen Technology
+D410CF Huanshun Network Science and Technology
+B80415 Bayan Audio
+84C8B1 Incognito Software Systems
+645A04 Chicony Electronics
+5C89D4 Beijing Banner Electric
+984CD3 Mantis Deposition
+8C4CDC Planex Communications
+10683F LG Electronics
+D063B4 SolidRun
+2C3BFD Netstor Technology
+F073AE Peak-system Technik
+684CA8 Shenzhen Herotel Tech.
+F4472A Nanjing Rousing Sci. and Tech. Industrial
+185253 Pixord
+A41731 Hon Hai Precision Ind.
+FCA9B0 Miartech (shanghai)
+80D733 QSR Automations
+8C3330 EmFirst
+8C0C90 Ruckus Wireless
+08E5DA Nanjing Fujitsu Computer Products
+5884E4 IP500 Alliance e.V.
+04E9E5 Pjrc.com
+703811 Invensys Rail
+ACE64B Shenzhen Baojia Battery Technology
+303294 W-IE-NE-R Plein & Baus GmbH
+EC473C Redwire
+5481AD Eagle Research
+7C822D Nortec
+745FAE TSL PPL
+8462A6 EuroCB (Phils)
+80FA5B Clevo
+E4F365 Time-O-Matic
+18550F Cisco Spvtg
+1C9179 Integrated System Technologies
+38F597 home2net GmbH
+386645 Oosic Technology
+D0DFB2 Genie Networks Limited
+808B5C Shenzhen Runhuicheng Technology
+04586F Sichuan Whayer information industry
+449B78 The Now Factory
+D052A8 Physical Graph
+EC43F6 ZyXEL Communications
+34F62D Sharp
+C4EBE3 Rrcn SAS
+4C1A95 Novakon
+C04A00 Tp-link Technologies
+9C3178 Foshan Huadian Intelligent Communications Teachnologies
+48BE2D Symanitron
+38E595 Shenzhen Gongjin Electronics
+B86091 Onnet Technologies and Innovations
+201A06 Compal Information (kunshan)
+D4CA6E u-blox AG
+C011A6 Fort-Telecom
+B8DAF1 Strahlenschutz- Entwicklungs- und Ausruestungsgesellschaft mbH
+1C11E1 Wartsila Finland Oy
+50465D Asustek Computer
+74BFA1 Hyunteck
+FCF528 ZyXEL Communications
+F8AA8A Axview Technology (Shenzhen)
+60F494 Hon Hai Precision Ind.
+5894CF Vertex Standard LMR
+2C5AA3 Promate Electronicltd
+9852B1 Samsung Electronics
+B4009C CableWorld
+803FD6 bytes at work AG
+645FFF Nicolet Neuro
+741E93 Fiberhome Telecommunication Tech.Co.
+2829D9 GlobalBeiMing technology (Beijing)Co.
+189A67 CSE-Servelec Limited
+38A5B6 Shenzhen Megmeet Electrical
+E43FA2 Wuxi DSP Technologies
+00FD4C Nevatec
+E09DB8 Planex Communications
+6045BD Microsoft
+9C54CA Zhengzhou Vcom Science and Technology
+388AB7 ITC Networks
+BCC23A Thomson Video Networks
+00BF15 Genetec
+20F85E Delta Electronics
+68CE4E L-3 Communications Infrared Products
+68B6FC Hitron Technologies.
+7C160D Saia-Burgess Controls AG
+A4D18F Shenzhen Skyee Optical Fiber Communication Technology 
+0C565C HyBroad Vision (Hong Kong) Technology
+647C34 Ubee Interactive
+649FF7 Kone OYj
+B86B23 Toshiba
+4C068A Basler Electric Company
+E0A30F Pevco
+5C1737 I-View Now
+049C62 BMT Medical Technology s.r.o.
+C4BA99 I+ME Actia Informatik und Mikro-Elektronik GmbH
+0C2A69 electric imp, incorporated
+BC811F Ingate Systems
+34E0CF zte
+801DAA Avaya
+6C40C6 Nimbus Data Systems
+503F56 Syncmold Enterprise
+D04CC1 Sintrones Technology
+DC9FA4 Nokia
+44C39B OOO Rubezh NPO
+58C232 NEC
+D8C691 Hichan Technology
+8CFDF0 Qualcomm Incorporated
+7C02BC Hansung Electronics
+1848D8 Fastback Networks
+C819F7 Samsung Electronics
+702393 fos4X GmbH
+C4731E Samsung Eletronics
+D8AFF1 Panasonic Appliances Company
+58ECE1 Newport
+14358B Mediabridge Products
+34996F VPI Engineering
+241064 Shenzhen Ecsino Tecnical
+10D1DC Instar Deutschland Gmbh
+844BF5 Hon Hai Precision Ind.
+D8160A Nippon Electro-Sensory Devices
+58696C Fujian Ruijie Networks
+F45433 Rockwell Automation
+EC9327 Memmert Gmbh + KG
+1C43EC Japan Circuit
+BC28D6 Rowley Associates Limited
+F05F5A Getriebebau Nord Gmbh and KG
+009569 LSD Science and Technology
+34C803 Nokia
+5011EB SilverNet
+5CD41B Uczoon Technology
+783CE3 Kai-EE
+0868EA Eito Electronics
+5C4A26 Enguity Technology
+289EDF Danfoss Turbocor Compressors
+E840F2 Pegatron
+50053D CyWee Group
+4C64D9 Guangdong Leawin Group
+7CB03E Osram Gmbh
+14B1C8 InfiniWing
+C0493D Maitrise Technologique
+34A7BA Fischer International Systems
+ACD364 ABB SPA, ABB Sace DIV.
+38F8B7 V2com Participacoes
+B48255 Research Products
+C84544 Shanghai Enlogic Electric Technology
+2C750F Shanghai Dongzhou-Lawton Communication Technology
+B40418 Smartchip Integrated
+F4EA67 Cisco Systems
+D0AEEC Alpha Networks
+3C98BF Quest Controls
+D05785 Pantech
+045C06 Zmodo Technology
+504A5E Masimo
+4CC94F Alcatel-Lucent
+38BF33 NEC Casio Mobile Communications
+A041A7 NL Ministry of Defense
+342F6E Anywire
+E86D6E Voestalpine Signaling Fareham
+F8D462 Pumatronix Equipamentos Eletronicos Ltda.
+5453ED Sony
+940070 Nokia
+6C3A84 Shenzhen Aero-Startech.Ltd
+C0143D Hon Hai Precision Ind.
+442B03 Cisco Systems
+781C5A Sharp
+E4C6E6 Mophie
+502D1D Nokia
+BCEA2B CityCom GmbH
+944444 LG Innotek
+E4C806 Ceiec Electric Technology
+18B591 I-Storm
+A45630 Cisco Systems
+CCFE3C Samsung Electronics
+002AAF LARsys-Automation GmbH
+60F3DA Logic Way GmbH
+A06D09 Intelcan Technosystems
+BC1401 Hitron Technologies.
+68D925 ProSys Development Services
+2C2D48 bct electronic GesmbH
+B41DEF Internet Laboratories
+284121 OptiSense Network
+5057A8 Cisco Systems
+38458C MyCloud Technology
+0C9D56 Consort Controls
+3CCE73 Cisco Systems
+A47C14 ChargeStorm AB
+F4600D Panoptic Technology
+ACCF23 Hi-flying electronics technology
+C08170 Effigis GeoSolutions
+78C4AB Shenzhen Runsil Technology
+709A0B Italian Institute of Technology
+240917 Devlin Electronics Limited
+DC37D2 Hunan HKT Electronic Technology
+048B42 Skspruce Technology Limited
+5076A6 Ecil Informatica Ind. Com. Ltda
+B431B8 Aviwest
+241125 Hutek
+0036FE SuperVision
+CC187B Manzanita Systems
+38B12D Sonotronic Nagel GmbH
+E006E6 Hon Hai Precision Ind.
+8020AF Trade Fides
+50D274 Steffes
+48D54C Jeda Networks
+3497FB Advanced RF Technologies
+C46413 Cisco Systems
+143AEA Dynapower Company
+9CA134 Nike
+B4D8A9 BetterBots
+7CC8D7 Damalisk
+0091FA Synapse Product Development
+A05AA4 Grand Products Nevada
+24C0B3 RSF
+E00B28 Inovonics
+500B32 Foxda Technology Industrial(ShenZhen)Co.
+E8039A Samsung Electronics
+302DE8 JDA, (JDA Systems)
+70CA9B Cisco Systems
+2C3F38 Cisco Systems
+803F5D Winstars Technology
+780738 Z.U.K. Elzab
+640E36 Taztag
+70EE50 Netatmo
+EC63E5 ePBoard Design
+60B606 Phorus
+F4E6D7 Solar Power Technologies
+78DDD6 c-scape
+984A47 CHG Hospital Beds
+3C6A7D Niigata Power Systems
+FC455F Jiangxi Shanshui Optoelectronic Technology
+3C7059 MakerBot Industries
+F8FE5C Reciprocal Labs
+6C9CED Cisco Systems
+94E0D0 HealthStream Taiwan
+DCF858 Lorent Networks
+589396 Ruckus Wireless
+A05E6B Melper
+30B3A2 Shenzhen Heguang Measurement & Control Technology
+F0007F Janz - Contadores de Energia
+CC944A Pfeiffer Vacuum GmbH
+0C8525 Cisco Systems
+BCE59F Waterworld Technology
+1C5C55 Prima Cinema
+082522 Advansee
+4C2F9D ICM Controls
+E467BA Danish Interpretation Systems A/S
+642737 Hon Hai Precision Ind.
+BCFE8C Altronic
+24BBC1 Absolute Analysis
+7CDD11 Chongqing MAS Sci&tech.co.
+C43C3C Cybelec SA
+00D632 GE Energy
+C40ACB Cisco Systems
+7463DF VTS GmbH
+3828EA Fujian Netcom Technology
+2CEE26 Petroleum Geo-Services
+DC3E51 Solberg & Andersen AS
+40F407 Nintendo
+D8B90E Triple Domain Vision
+7C4B78 Red Sun Synthesis Pte
+28D1AF Nokia
+3482DE Kayo Technology
+68BC0C Cisco Systems
+2C9EFC Canon
+98C845 PacketAccess
+988217 Disruptive
+80FFA8 Unidis
+489BE2 SCI Innovations
+B0E50E NRG Systems
+4C5FD2 Alcatel-Lucent
+E878A1 Beoview Intercom DOO
+3057AC Irlab
+9002A9 Zhejiang Dahua Technology
+28AF0A Sirius XM Radio
+2486F4 Ctek
+3CE5B4 Kidasen Industria E Comercio DE Antenas Ltda
+A85BF3 Audivo GmbH
+344F69 Ekinops SAS
+2C4401 Samsung Electronics
+C02973 Audyssey Laboratories
+30168D ProLon
+B451F9 NB Software
+30688C Reach Technology
+88F488 cellon communications technology(shenzhen)Co.
+0041B4 Wuxi Zhongxing Optoelectronics Technology
+0007AB Samsung Electronics
+48F7F1 Alcatel-Lucent
+D453AF Vigo System
+1CE192 Qisda
+20C8B3 Shenzhen Bul-tech
+60D819 Hon Hai Precision Ind.
+945103 Samsung Electronics
+58B0D4 ZuniData Systems
+64557F Nsfocus Information Technology
+406AAB RIM
+248707 SEnergy
+EC3F05 Institute 706, The Second Academy China Aerospace Science & Industry
+C4C19F National Oilwell Varco Instrumentation, Monitoring, and Optimization (NOV IMO)
+68CD0F U Tek Company Limited
+D4CEB8 Enatel
+ECF236 Neomontana Electronics
+E4A5EF Tron Link Electronics
+AC4AFE Hisense Broadband Multimedia Technology
+2C1EEA Aerodev
+FC6C31 LXinstruments GmbH
+3C6F45 Fiberpro
+B4FC75 Sema Electronics(hk)
+5C16C7 Big Switch Networks
+B0BF99 Wizitdongdo
+147DB3 JOA Telecom.co.
+3CD16E Telepower Communication
+00077D Cisco Systems
+D0176A Samsung Electronics
+1045BE Norphonic AS
+A0E295 DAT System
+40F14C ISE Europe Sprl
+98293F Fujian Start Computer Equipment
+70D4F2 RIM
+9067F3 Alcatel Lucent
+64D912 Solidica
+8C5CA1 d-broad
+C8F981 Seneca s.r.l.
+8C7712 Samsung Electronics
+703187 ACX GmbH
+14307A Avermetrics
+8C7EB3 Lytro
+587675 Beijing Echo Technologies
+78EF4C Unetconvergence
+E8DA96 Zhuhai Tianrui Electrical Power Tech.
+6CA780 Nokia
+04888C Eifelwerk Butler Systeme GmbH
+1013EE Justec International Technology
+704642 Chyng Hong Electronic
+78BEB6 Enhanced Vision
+ECEA03 Darfon Lighting
+C8903E Pakton Technologies
+7465D1 Atlinks
+301A28 Mako Networks
+D4945A Cosmo
+5CF207 Speco Technologies
+B01B7C Ontrol A.S.
+D47B75 Harting Electronics Gmbh
+70E843 Beijing C&W Optical Communication Technology
+08ACA5 Benu Video
+D89DB9 eMegatech International
+405A9B Anovo
+ACCA54 Telldus Technologies AB
+CC1EFF Metrological Group BV
+941673 Point Core Sarl
+6C5D63 ShenZhen Rapoo Technology
+E4D71D Oraya Therapeutics
+C8FE30 Bejing Dayo Mobile Communication Technology
+64B64A ViVOtech
+DCA7D9 Compressor Controls
+C455A6 Cadac Holdings
+BCBBC9 Kellendonk Elektronik GmbH
+781DFD Jabil
+103711 Simlink AS
+601199 Siama Systems
+300B9C Delta Mobile Systems
+90EA60 SPI Lasers 
+D46F42 Waxess USA
+B0A72A Ensemble Designs
+50795B Interexport Telecomunicaciones
+E8C229 H-Displays (MSC) Bhd
+3C6200 Samsung electronics
+B0BDA1 Zaklad Elektroniczny Sims
+8C4435 Shanghai BroadMobi Communication Technology
+24B8D2 Opzoon Technology
+24CBE7 MYK
+88BFD5 Simple Audio
+948B03 Eaget Innovation and Technology
+802DE1 Solarbridge Technologies
+F081AF IRZ Automation Technologies
+14EB33 BSMediasoft
+AC8674 Open Mesh
+14A9E3 MST
+589835 Technicolor
+50D6D7 Takahata Precision
+B4A5A9 Modi Gmbh
+D09B05 Emtronix
+98EC65 Cosesy ApS
+900917 Far-sighted mobile
+88F077 Cisco Systems
+AC4723 Genelec
+20B7C0 Omicron Electronics Gmbh
+D42C3D Sky Light Digital Limited
+806CBC NET New Electronic Technology GmbH
+1C184A ShenZhen RicherLink Technologies
+2013E0 Samsung Electronics
+04E662 Acroname
+F0BF97 Sony
+C44AD0 Fireflies Systems
+88E0A0 Shenzhen VisionSTOR Technologies
+6879ED Sharp
+9CC0D2 Conductix-Wampfler GmbH
+408BF6 Shenzhen TCL New Technology;
+447E95 Alpha and Omega
+50C971 GN Netcom A/S
+E8B748 Cisco Systems
+DC16A2 Medtronic Diabetes
+78CA04 Nokia
+2C8BF2 Hitachi Metals America
+58F98E Secudos Gmbh
+2826A6 PBR electronics GmbH
+CC7669 Seetech
+E437D7 Henri Depaepes.
+582F42 Universal Electric
+AC20AA Dmatek
+E0A1D7 SFR
+28852D Touch Networks
+F02A61 Waldo Networks
+B8415F ASP AG
+2CB69D RED Digital Cinema
+988E34 Zhejiang Boxsam Electronic
+D44C24 Vuppalamritha Magnetic Components
+4CB4EA HRD (S) PTE.
+34BDF9 Shanghai WDK Industrial
+74CE56 Packet Force Technology Limited Company
+A89B10 inMotion
+888C19 Brady Asia Pacific
+747DB6 Aliwei Communications
+B41489 Cisco Systems
+AC6F4F Enspert
+8886A0 Simton Technologies
+F0C88C LeddarTech
+68EBC5 Angstrem Telecom
+448C52 Ktis
+686359 Advanced Digital Broadcast SA
+B8E779 9Solutions Oy
+4018D7 Smartronix
+18922C Virtual Instruments
+F80F84 Natural Security SAS
+FCA13E Samsung Electronics
+BC4760 Samsung Electronics
+EC9ECD Artesyn Embedded Technologies
+303955 Shenzhen Jinhengjia Electronic
+FC5B24 Weibel Scientific A/S
+34B571 Plds
+A862A2 Jiwumedia
+984E97 Starlight Marketing (H. K.)
+E4E0C5 Samsung Electronics
+7C6ADB SafeTone Technology
+EC986C Lufft Mess- und Regeltechnik GmbH
+B0518E Holl technologyLtd.
+DCDECA Akyllor
+A071A9 Nokia
+8065E9 BenQ
+845DD7 Shenzhen Netcom Electronics
+447DA5 Vtion Information Technology (fujian)
+0CCDD3 Eastriver Technology
+B8E589 Payter BV
+C89C1D Cisco Systems
+503DE5 Cisco Systems
+801440 Sunlit System Technology
+948D50 Beamex Oy Ab
+94E226 D. ORtiz Consulting
+74A722 LG Electronics
+78D6F0 Samsung Electro Mechanics
+E8E732 Alcatel-Lucent
+386E21 Wasion Group
+D8C99D EA Display Limited
+CCFC6D RIZ Transmitters
+AC80D6 Hexatronic AB
+9CF938 Areva NP Gmbh
+500E6D TrafficCast International
+1CFEA7 IDentytech Solutins
+D0B53D Sepro Robotique
+A0DE05 JSC Irbis-T
+8895B9 Unified Packet Systems Crop
+78593E Rafi Gmbh &KG
+684352 Bhuu Limited
+3CC0C6 d&b audiotechnik GmbH
+F8DAF4 Taishan Online Technology
+D8E3AE Cirtec Medical Systems
+A83944 Actiontec Electronics
+FC1FC0 Eurecam
+4891F6 Shenzhen Reach software technology
+EC14F6 BioControl AS
+B8D06F Guangzhou Hkust FOK Ying Tung Research Institute
+B4C44E VXL eTech Pvt
+F0933A NxtConect
+6052D0 Facts Engineering
+8C278A Vocollect
+FCAF6A Qulsar
+ECE555 Hirschmann Automation
+DCD0F7 Bentek Systems
+D0574C Cisco Systems
+8818AE Tamron
+20D607 Nokia
+58DB8D Fast
+18EF63 Cisco Systems
+CCCE40 Janteq
+8C4DEA Cerio
+ECFAAA The IMS Company
+CC55AD RIM
+F0F7B3 Phorm
+E8757F Firs Technologies(shenzhen)
+C83EA7 Kunbus Gmbh
+A8D3C8 Wachendorff Elektronik  GmbH & KG
+E0CF2D Gemintek
+68BDAB Cisco Systems
+9CADEF Obihai Technology
+D08999 Apcon
+4454C0 Thompson Aerospace
+B4A4E3 Cisco Systems
+90903C Trison Technology
+94DD3F A+V Link Technologies
+C8EE08 Tangtop Technology
+7472F2 Chipsip Technology
+C0CB38 Hon Hai Precision Ind.
+5CD998 D-Link
+D46CDA CSM GmbH
+60EB69 Quanta computer
+C4F464 Spica international
+74911A Ruckus Wireless
+544A05 wenglor sensoric gmbh
+5CCA32 Theben AG
+84C7A9 C3po
+F8AC6D Deltenna
+641084 Hexium Technical Development
+C416FA Prysm
+E0C286 Aisai Communication Technology
+D84B2A Cognitas Technologies
+684B88 Galtronics Telemetry
+842914 Emporia Telecom Produktions- und Vertriebsgesmbh & KG
+4C8B55 Grupo Digicon
+04A3F3 Emicon
+F866F2 Cisco Systems
+7C55E7 YSI
+C02BFC iNES. applied informatics GmbH
+AC34CB Shanhai Gbcom Communication Technology
+D4A928 GreenWave Reality
+9CFFBE Otsl
+2CD1DA Sanjole
+100E2B NEC Casio Mobile Communications
+445EF3 Tonalite Holding
+100C24 pomdevices
+58F6BF Kyoto University
+B407F9 Samsung Electro-mechanics
+7CED8D Microsoft
+1880F5 Alcatel-Lucent Shanghai Bell
+54FDBF Scheidt & Bachmann GmbH
+B40EDC LG-Ericsson
+A4D1D1 ECOtality North America
+C8D5FE Shenzhen Zowee Technology
+C49313 100fio networks technology
+A4A80F Shenzhen Coship Electronics
+B8921D BG T&A
+48FCB8 Woodstream
+548922 Zelfy
+F8C091 Highgates Technology
+6C5CDE SunReports
+241F2C Calsys
+284846 GridCentric
+58B9E1 Crystalfontz America
+646707 Beijing Omnific Technology
+D4000D Phoenix Broadband Technologies
+E87AF3 S5 Tech S.r.l.
+40C7C9 Naviit
+A0A763 Polytron Vertrieb GmbH
+D496DF Sungjin C&T
+D07DE5 Forward Pay Systems
+7CEF18 Creative Product Design
+FCD4F6 Messana Air.Ray Conditioning s.r.l.
+0CD696 Amimon
+B43741 Consert
+F8FB2F Santur
+2CCD43 Summit Technology Group
+6C8D65 Wireless Glue Networks
+80501B Nokia
+CCFCB1 Wireless Technology
+CC5C75 Weightech Com. Imp. Exp. Equip. Pesagem Ltda
+A098ED Shandong Intelligent Optical Communication Development
+34C69A Enecsys
+502A8B Telekom Research and Development Sdn Bhd
+F88DEF Tenebraex
+EC43E6 Awcer
+F0EC39 Essec
+5849BA Chitai Electronic
+181714 Daewoois
+80B289 Forworld Electronics
+14A62C S.M. Dezac
+C80AA9 Quanta Computer
+A8F470 Fujian Newland Communication Science Technologies
+DC1D9F U & B tech
+081651 Shenzhen SEA Star Technology
+DC49C9 Casco Signal
+B09134 Taleo
+A863DF Displaire
+104369 Soundmax Electronic Limited 
+C06C0F Dobbs Stanford
+5475D0 Cisco Systems
+BC6A16 tdvine
+C8EF2E Beijing Gefei Tech.
+98DCD9 Unitec
+30525A NST
+6089B7 Kael Mhendslk Elektronk Tcaret Sanay Lmted rket
+2CA780 True Technologies
+545FA9 Teracom Limited
+ECC882 Cisco Systems
+A0B9ED Skytap
+502DF4 Phytec Messtechnik GmbH
+38E8DF b gmbh medien + datenbanken
+10189E Elmo Motion Control
+88FD15 Lineeye
+10445A Shaanxi Hitech Electronic
+60B3C4 Elber Srl
+04C880 Samtec
+884B39 Siemens AG, Healthcare Sector
+44C233 Guangzhou Comet Technology DevelopmentLtd
+B482FE Askey Computer
+307C30 RIM
+BC4E3C Core Staff
+80BAAC TeleAdapt
+FC4463 Universal Audio
+F06853 Integrated
+10E6AE Source Technologies
+A4ADB8 Vitec Group, Camera Dynamics
+90A2DA Gheo SA
+C41ECE HMI Sources
+BCD5B6 d2d technologies
+1C8F8A Phase Motion Control SpA
+A4B1EE H. Zander Gmbh & KG
+486FD2 StorSimple
+D4F143 Iproad.
+CC5459 OnTime Networks AS
+3CB17F Wattwatchers Ld
+00DB45 Thamway
+A0231B TeleComp R&D
+94C4E9 PowerLayer Microsystems HongKong Limited
+8843E1 Cisco Systems
+B4ED19 Pie Digital
+888717 Canon
+E0271A TTC Next-generation Home Network System WG
+84C727 Gnodal
+E4AB46 UAB Selteka
+D479C3 Cameronet GmbH & KG
+945B7E Trilobit LTDA.
+E85B5B LG Electronics
+20D906 Iota
+78A2A0 Nintendo
+404022 ZIV
+70F395 Universal Global Scientific Industrial
+74F726 Neuron Robotics
+18FC9F Changhe Electronics
+A438FC Plastic Logic
+601D0F Midnite Solar
+50A6E3 David Clark Company
+549A16 Uzushio Electric
+4001C6 3com Europe
+608D17 Sentrus Government Systems Division
+24BF74 Private
+80912A Lih Rong electronic Enterprise
+8038FD LeapFrog Enterprises
+7072CF EdgeCore Networks
+803B9A ghe-ces electronic ag
+9CCD82 Cheng UEI Precision Industry
+C8AACC Private
+008CFA Inventec
+003D41 Hatteland Computer AS
+087618 ViE Technologies Sdn. Bhd.
+A4AD00 Ragsdale Technology
+2C1984 IDN Telecom
+3863F6 3nod Multimedia(shenzhen)co.
+347E39 Nokia Danmark A/S
+A87E33 Nokia Danmark A/S
+DCE2AC Lumens Digital Optics
+98D88C Nortel Networks
+C8873B Net Optics
+6CBEE9 Alcatel-Lucent-IPD
+B0E97E Advanced Micro Peripherals
+D44CA7 Informtekhnika & Communication
+202CB7 Kong Yue Electronics & Information Industry (Xinhui)
+68CC9C Mine Site Technologies
+04B466 BSP
+E41F13 IBM
+00271B Alec Sicherheitssysteme GmbH
+002718 Suzhou NEW Seaunion Video Technology
+002713 Universal Global Scientific Industrial
+00270C Cisco Systems
+00270B Adura Technologies
+002705 Sectronic
+002706 Yoisys
+0026F9 S.E.M. srl
+0026F3 SMC Networks
+688540 IGI Mobile
+6465C0 Nuvon
+F0DE71 Shanghai EDO Technologies
+A00798 Samsung Electronics
+28FBD3 Ragentek Technology Group
+7C1EB3 2N Telekomunikace a.s.
+9C1874 Nokia Danmark A/S
+146E0A Private
+1045F8 LNT-Automation GmbH
+644F74 Lenus
+787F62 GiK mbH
+D4AAFF Micro World
+C4FCE4 DishTV NZ
+0CD7C2 Axium Technologies
+40F52E Leica Microsystems (Schweiz) AG
+C02250 Private
+64BC11 CombiQ AB
+4097D1 BK Electronics cc
+68AAD2 Datecs,
+0026EC Legrand Home Systems
+0026E6 Visionhitech
+0026E0 Asiteq
+0026DA Universal Media /Slovakia/ s.r.o.
+0026D3 Zeno Information System
+0026D4 Irca SpA
+0026CD PurpleComm
+10880F Daruma Telecomunicaes e Informtica
+4C4B68 Mobile Device
+94BA31 Visiontec da Amaznia Ltda.
+F45FF7 DQ Technology
+60F13D Jablocom S.r.o.
+0CEF7C AnaCom
+E08FEC Repotec
+D0D286 Beckman Coulter K.K.
+1C0FCF Sypro Optics GmbH
+0025AB AIO LCD PC BU / TPV
+0025A4 EuroDesign embedded technologies GmbH
+00259D Private
+002598 Zhong Shan City Litai Electronic Industrial
+002591 Nextek
+00258C Esus Elektronik SAN. VE DIS. TIC. STI.
+002587 Vitality
+002581 x-star networks
+002582 Maksat Technologies (P)
+002578 JSC Concern Sozvezdie
+00257D PointRed Telecom Private
+002577 D-BOX Technologies
+002571 Zhejiang Tianle Digital Electric
+00256A inIT - Institut Industrial IT
+002565 Vizimax
+00255E Shanghai Dare Technologies
+002558 Mpedia
+002635 Bluetechnix GmbH
+00262F Hamamatsu TOA Electronics
+002623 JRD Communication
+002628 companytec automao e controle ltda.
+00261C Neovia
+002615 Teracom Limited
+002616 Rosemount
+002610 Apacewave Technologies
+002609 Phyllis
+00268C StarLeaf
+002692 Mitsubishi Electric
+002686 Quantenna Communcations
+002680 SIL3Ltd
+00267F Zenterio AB
+00267A wuhan hongxin telecommunication technologies
+002679 Euphonic Technologies
+002673 Ricoh Company
+00266D MobileAccess Networks
+0025D6 The Kroger
+0025CA LS Research
+0025CF Nokia Danmark A/S
+0025D0 Nokia Danmark A/S
+0025C3 Nortel Networks
+0025BE Tektrap Systems
+0025BD Italdata Ingegneria dell'Idea
+0025B7 Costar  electronics
+0025B0 Schmartz
+002552 VXI
+002546 Cisco Systems
+002545 Cisco Systems
+002535 Minimax GmbH & KG
+002532 Digital Recorders
+00252B Stirling Energy Systems
+0025FD OBR Centrum Techniki Morskiej
+002603 Shenzhen Wistar Technology
+0025F3 Nordwestdeutsche Zhlerrevision
+0025EC Humanware
+0025E2 Everspring Industry
+0025DD Sunnytek Information
+002667 Carecom
+002660 Logiways
+002656 Sansonic Electronics USA
+002653 DaySequerra
+00264C Shanghai DigiVision Technology
+002647 WFE Technology
+00263B Onbnetech
+0026C1 Artray
+0026B5 Icomm Tele
+0026AF Duelco A/S
+0026AB Seiko Epson
+0026A5 Microrobot.co.
+00269F Private
+002699 Cisco Systems
+002489 Vodafone Omnitel N.V.
+00248E Infoware ZRt.
+002490 Samsung Electronics
+00247D Nokia Danmark A/S
+002482 Ruckus Wireless
+002476 TAP.tv
+00246F Onda Communication spa
+00246A Solid Year
+0023FA RG Nets
+0023FF Beijing Httc Technology
+0023F4 Masternaut
+0023EA Cisco Systems
+0023E4 IPnect
+0023DE Ansync
+0023D1 TRG
+0023CB Shenzhen Full-join Technology
+0023D2 Inhand Electronics
+0023D7 Samsung Electronics
+0024B4 Escatronic Gmbh
+0024AF EchoStar Technologies
+0024A8 ProCurve Networking by HP
+0024AD Adolf Thies Gmbh & KG
+00249C Bimeng Comunication System
+002526 Genuine Technologies
+002525 Ctera Networks
+002520 SMA Railway Technology GmbH
+00251B Philips CareServant
+002516 Integrated Design Tools
+00250F On-Ramp Wireless
+002503 IBM
+00250A Security Expert
+0024DD Centrak
+0024D8 IlSung Precision
+0024CC Fascinations Toys and Gifts
+0024D1 Thomson
+0024CA Tobii Technology AB
+0024C5 Meridian Audio Limited
+0024B9 Wuhan Higheasy Electronic Technology DevelopmentLtd
+002425 Shenzhenshi chuangzhicheng Technology
+002419 Private
+002412 Benign Technologies
+00240C Delec Gmbh
+002406 Pointmobile
+0023F9 Double-Take Software
+002463 Phybridge
+002459 ABB Automation products GmbH
+00245E Hivision
+002451 Cisco Systems
+00244C Solartron Metrology
+002445 CommScope Canada
+00243F Storwize
+002440 Halo Monitoring
+00243B Cssi (S) Pte
+0024FC QuoPin
+0024F7 Cisco Systems
+0024F0 Seanodes
+0024E9 Samsung Electronics,, Storage System Division
+0024EB ClearPath Networks
+0024E4 Withings
+002435 Wide
+00242F Micron
+00241F DCT-Delta GmbH
+00241E Nintendo
+0023C5 Radiation Safety and Control Services
+0023C4 Lux Lumen
+0023B8 Sichuan Jiuzhou Electronic Technology
+0023BF Mainpine
+0023B2 Intelligent Mechatronic Systems
+0023AC Cisco Systems
+0023A0 Hana CNS
+0023A5 SageTV
+0022B6 Superflow Technologies Group
+0022B1 Elbit Systems
+0022AA Nintendo
+0022A3 California Eastern Laboratories
+00229E Social Aid Research
+002291 Cisco Systems
+002292 Cinetal
+002297 Xmos Semiconductor
+00228B Kensington Computer Products Group
+002284 Desay A&V Science AND Technology
+00227F Ruckus Wireless
+002277 NEC Australia
+00226D Shenzhen Giec Electronics
+002263 Koos Technical Services
+002267 Nortel Networks
+002259 Guangzhou New Postcom Equipment
+0022E4 Apass Technology
+0022DD Protecta Electronics
+0022D7 Nintendo
+0022D8 Shenzhen GST Security and Safety Technology Limited
+0022D1 Albrecht Jung GmbH & KG
+0022C3 Zeeport Technology
+0022C7 Segger Microcontroller Gmbh & KG
+0022BD Cisco Systems
+002344 Objective Interface Systems
+002343 TEM AG
+00233E Alcatel-Lucent-IPD
+002337 Global Star Solutions ULC
+002331 Nintendo
+00232B IRD A/S
+00231C Fourier Systems
+00231B Danaher Motion - Kollmorgen
+00239F Institut fr Prftechnik
+002399 VD Division, Samsung Electronics
+002393 Ajinextek
+00238F Nidec Copal
+00238B Quanta Computer
+002385 Antipode
+00237E Elster Gmbh
+00237F Plantronics
+002379 Union Business Machines
+002253 Entorian Technologies
+002250 Point Six Wireless
+002249 Home Multienergy SL
+00224A Raylase AG
+002240 Universal Telecom S/A
+00222D SMC Networks
+00222E maintech GmbH
+002363 Zhuhai RaySharp Technology
+002364 Power Instruments Pte
+002369 Cisco-Linksys
+002370 Snell
+00235D Cisco Systems
+002356 Packet Forensics
+00234A Private
+002313 Qool Technologies
+00230D Nortel Networks
+002301 Witron Technology Limited
+0022F7 Conceptronic
+0022EA Rustelcom
+0022F0 3 Greens Aviation Limited
+0022E9 ProVision Communications
+00211C Cisco Systems
+002117 Tellord
+002110 Clearbox Systems
+002106 RIM Testing Services
+001FFF Respironics
+001FFE HPN Supply Chain
+001FF8 Siemens AG, Sector Industry, Drive Technologies, Motion Control Systems
+001FFD Indigo Mobile Technologies
+002221 Itoh Denki
+00221B Morega Systems
+002220 Mitac Technology
+002227 uv-electronic GmbH
+002214 Rinnai Korea
+00220E Indigo Security
+002208 Certicom
+002201 Aksys Networks
+0021FC Nokia Danmark A/S
+0021F7 HPN Supply Chain
+0021A0 Cisco Systems
+00219C Honeywld Technology
+002192 Baoding Galaxy Electronic Technology 
+00218C Topcontrol Gmbh
+002186 Universal Global Scientific Industrial
+00217F Intraco Technology Pte
+00217A Sejin Electron
+002179 Iogear
+002173 Ion Torrent Systems
+001FC3 SmartSynch
+001FC8 Up-Today Industrial
+001FC1 Hanlong Technology
+001FC2 Jow Tong Technology
+001FBC Evga
+001FB0 TimeIPS
+001FB5 I/O Interconnect
+001FA9 Atlanta DTH
+0021F1 Tutus Data AB
+0021F2 Easy3call Technology Limited
+0021EB ESP Systems
+0021E5 Display Solution AG
+0021E4 I-win
+0021DF Martin Christ GmbH
+0021D2 Samsung Electronics
+0021D8 Cisco Systems
+0021CC Flextronics International
+001FF1 Paradox Hellas
+001FEC Synapse lectronique
+001FE5 In-Circuit GmbH
+001FDE Nokia Danmark A/S
+001FD9 RSD Communications
+001FD4 4ipnet
+001FCF MSI Technology GmbH
+00213F A-Team Technology
+002139 Escherlogic
+002134 Brandywine Communications
+00212F Phoebe Micro
+002129 Cisco-Linksys
+00212A Audiovox
+002123 Aerosat Avionics
+00216D Soltech
+00216C Odva
+002167 HWA JIN T&I
+002160 Hidea Solutions
+002154 D-tacq Solutions
+00214D Guangzhou Skytone Transmission Technology Com.
+002147 Nintendo
+002148 Kaco Solar Korea
+0021C5 3DSP
+0021BF Hitachi High-Tech Control Systems
+0021C0 Mobile Appliance
+0021B9 Universal Devices
+0021B3 Ross Controls
+0021B2 Fiberblaze A/S
+0021AD Nordic ID Oy
+0021A6 Videotec Spa
+001F16 Wistron
+001F11 Openmoko
+001F0B Federal State Unitary Enterprise Industrial UnionElectropribor
+001EFF Mueller-Elektronik GmbH & KG
+001F06 Integrated Dispatch Solutions
+001F05 iTAS Technology
+001EF3 From2
+001EF8 Emfinity
+001F7A WiWide
+001F70 Botik Technologies
+001F75 GiBahn Media
+001F64 Beijing Autelan Technology
+001F6B LG Electronics
+001F5D Nokia Danmark A/S
+001F5E Dyna Technology
+001F58 EMH Energiemesstechnik GmbH
+001F4C Roseman Engineering
+001F51 HD Communications
+001F4B Lineage Power
+001F9F Thomson Telecom Belgium
+001F93 Xiotech
+001F98 Daiichi-dentsu
+001F8C CCS
+001F8A Ellion Digital
+001F83 Teleplan Technology Services Sdn Bhd
+001E37 Universal Global Scientific Industrial
+001E30 Shireen
+001E2B Radio Systems Design
+001E24 Zhejiang Bell Technology
+001E18 Radio Activity srl
+001E1D East Coast Datacom
+001E1E Honeywell Life Safety
+001E13 Cisco Systems
+001E0E Maxi View Holdings Limited
+001E60 Digital Lighting Systems
+001E59 Silicon Turnkey Express
+001E54 Toyo Electric
+001E4D Welkin Sciences
+001E48 Wi-Links
+001E43 Aisin AW
+001E3E KMW
+001EC3 Kozio
+001EBC Wintech Automation
+001EB7 TBTech,
+001EB0 ImesD Electronica S.L.
+001EA5 Robotous
+001EAB TeleWell Oy
+001E9E ddm hopt + schuler Gmbh + KG
+001E99 Vantanol Industrial
+001F45 Enterasys
+001F36 Bellwin Information,
+001F35 Air802
+001F30 Travelping
+001F23 Interacoustics
+001F24 Digitview Technology
+001F1D Atlas Material Testing Technology
+001E92 Jeulin
+001E89 Crfs Limited
+001E84 Pika Technologies
+001E7D Samsung Electronics
+001E83 Lan/man Standards Association (lmsc)
+001E6C Opaque Systems
+001EE6 Shenzhen Advanced Video Info-Tech
+001EE0 Urmet Domus SpA
+001EDB Giken Trastem
+001ED6 Alentec & Orion AB
+001ECF Philips Electronics UK
+001ECA Nortel
+001C96 Linkwise Technology Pte
+001C91 Gefen
+001C8A Cirrascale
+001C84 STL Solution
+001C80 New Business Division/Rhea-Information
+001C76 The Wandsworth Group
+001C6F Emfit
+001C71 Emergent Electronics
+001C70 Novacomm Ltda
+001C6A Weiss Engineering
+001D59 Mitra Energy & Infrastructure
+001D52 Defzone
+001D4C Alcatel-Lucent
+001D48 Sensor-Technik Wiedemann GmbH
+001D41 Hardy Instruments
+001D42 Nortel
+001D3C Muscle
+001D30 YX Wireless
+001D35 Viconics Electronics
+001D2F QuantumVision
+001CD3 ZP Engineering SEL
+001CCE By Techdesign
+001CC7 Rembrandt Technologies, D/b/a Remstream
+001CC2 Part II Research
+001CBB MusicianLink
+001CB1 Cisco Systems
+001CB7 USC DigiArk
+001CA3 Terra
+001CA5 Zygo
+001CAA Bellon
+001C9D Liecthi AG
+001DCA PAV Electronics Limited
+001DC4 Aioi Systems
+001DC3 Rikor TV
+001DB1 Crescendo Networks
+001DB2 Hokkaido Electric Engineering
+001DB7 Tendril Networks
+001DAD Sinotech Engineering Consultants,  Geotechnical Enginee
+001DA8 Takahata Electronics
+001DA7 Seamless Internet
+001DA1 Cisco Systems
+001D9A Godex International
+001D95 Flash
+001D8E Alereon
+001D87 VigTech Labs Sdn Bhd
+001D88 Clearwire
+001D7E Cisco-Linksys
+001D82 GN A/S (GN Netcom A/S)
+001D7D Giga-byte Technology
+001D6C ClariPhy Communications
+001D71 Cisco Systems
+001D78 Invengo Information Technology
+001D65 Microwave Radio Communications
+001D5E Coming Media
+001D29 Doro AB
+001D22 Foss Analytical A/S
+001D1D Inter-M
+001D16 SFR
+001D10 LightHaus Logic
+001D0A Davis Instruments
+001D03 Design Solutions
+001CFE Quartics
+001CFD Universal Electronics
+001CF7 AudioScience
+001CEB Nortel
+001CE6 Innes
+001CE1 Indra Sistemas
+001CDA Exegin Technologies Limited
+001CD4 Nokia Danmark A/S
+001E07 Winy Technology
+001E02 Sougou Keikaku Kougyou
+001E01 Renesas Technology Sales
+001DFB Netcleus Systems
+001DF4 Magellan Technology Limited
+001DEF Trimm
+001DE8 Nikko Denki Tsushin(ndtc)
+001DE3 Intuicom
+001DDD DAT H.K. Limited
+001AF8 Copley Controls
+001AF3 Samyoung Electronics
+001AEE Shenztech
+001AE2 Cisco Systems
+001AE7 Aztek Networks
+001AD4 iPOX Technology
+001AD6 Jiagnsu Aetna Electric
+001B97 Violin Technologies
+001B9C Satel sp. z o.o.
+001B90 Cisco Systems
+001B86 Bosch Access Systems GmbH
+001B8B NEC Platforms
+001B7F TMN Technologies Telecomunicacoes Ltda
+001B81 Dataq Instruments
+001B80 Lord
+001B7A Nintendo
+001B73 DTL Broadcast
+001B6E Anue Systems
+001B67 Cisco Systems
+001B60 Navigon AG
+001B54 Cisco Systems
+001B48 Shenzhen Lantech Electronics
+001B4D Areca Technology
+001B41 General Infinity
+001B3C Software Technologies Group
+001B35 Chongqing Jinou Science & Technology Development
+001B2E Sinkyo Electron
+001B30 Solitech
+001BC7 StarVedia Technology
+001BC6 Strato Rechenzentrum AG
+001BC5 Ieee Registration Authority  - Please see Oui36/ma-s Public Listing for More Information.
+001BBB RFTech
+001BB6 Bird Electronic
+001BAA XenICs nv
+001BAF Nokia Danmark A/S
+001BA3 Flexit Group GmbH
+001C63 Truen
+001C57 Cisco Systems
+001C5E Aston France
+001C46 Qtum
+001C4D Aplix IP Holdings
+001C3A Element Labs
+001C41 scemtec Transponder Technology GmbH
+001C34 Huey Chiao International
+001C33 Sutron
+001C35 Nokia Danmark A/S
+001BF7 Lund IP Products AB
+001BF9 Intellitect Water
+001BF8 Digitrax
+001BF2 Kworld Computer
+001BEB DMP Electronics
+001BE6 VR AG
+001BDF Iskra Sistemi d.d.
+001BD3 Panasonic AVC Company
+001BD8 DVTel
+001BCC Kingtek Cctv Alliance
+001AC8 ISL (Instrumentation Scientifique de Laboratoire)
+001ACF C.T. Elettronica
+001AC3 Scientific-Atlanta
+001AB9 PMC
+001ABE Computer Hi-tech
+001AAB eWings s.r.l.
+001AB2 Cyber Solutions
+001AB7 Ethos Networks
+001C2E HPN Supply Chain
+001C27 Sunell Electronics
+001C22 Aeris Elettronica s.r.l.
+001C1D Chenzhou Gospell Digital Technology
+001C18 Sicert S.r.L.
+001C0A Shenzhen AEE Technology
+001C05 Nonin Medical
+001BFE Zavio
+001B29 Avantis.Co.
+001B23 SimpleComTools
+001B1E Hart Communication Foundation
+001B12 Apprion
+001B17 Palo Alto Networks
+001B0B Phidgets
+001B10 ShenZhen Kang Hui Technology
+001B04 Affinity International S.p.a
+001AFF Wizyoung Tech.
+001AFD Evolis
+00191C Sensicast Systems
+00191E Beyondwiz
+001923 Phonex Korea
+00192A Antiope Associates
+001910 Knick Elektronische Messgeraete GmbH & KG
+001917 Posiflex
+001909 Devi - Danfoss A/S
+00190B Southern Vision Systems
+001904 WB Electronics Sp. z o.o.
+0018FF PowerQuattro
+0018FA Yushin Precision Equipment
+001955 Cisco Systems
+00194E Ultra Electronics - TCS (Tactical Communication Systems)
+001950 Harman Multimedia
+001949 Tentel  Comtech
+001942 ON Software International Limited
+00193D GMC Guardian Mobility
+001936 Sterlite Optical Technologies Limited
+00193B Wilibox Deliberant Group
+00192F Cisco Systems
+001A20 Cmotech
+001A22 eQ-3 Entwicklung GmbH
+001A14 Xin Hua Control Engineering
+001A0D HandHeld entertainment
+001A0F Sistemas Avanzados de Control
+001A08 Simoco
+001A01 Smiths Medical
+0019FC PT. Ufoakses Sukses Luarbiasa
+0019EF Shenzhen Linnking Electronics
+0019F1 Star Communication Network Technology
+0019F6 Acconet (PTE)
+001A76 SDT information Technology
+001A6F MI.TEL s.r.l.
+001A6A Tranzas
+001A63 Elster Solutions
+001A5E Thincom Technology
+001A57 Matrix Design Group
+001A5C Euchner GmbH+Co. KG
+001A50 PheeNet Technology
+001A9D Skipper Wireless
+001AA2 Cisco Systems
+001A91 FusionDynamic
+001A96 Ecler
+001A90 Trpico Sistemas e Telecomunicaes da Amaznia LTDA.
+001A8C Sophos
+001A85 NV Michel Van de Wiele
+001A87 Canhold International Limited
+001A86 AdvancedIO Systems
+0019B5 Famar Fueguina
+0019BA Paradox Security Systems
+0019A2 Ordyn Technologies
+0019AE Hopling Technologies
+0019A7 Itu-t
+001996 TurboChef Technologies
+00199B Diversified Technical Systems
+001991 avinfo
+00198A Northrop Grumman Systems
+00198C iXSea
+001985 IT Watchdogs
+001979 Nokia Danmark A/S
+001972 Plexus (Xiamen)
+00196B Danpex
+001966 Asiarock Technology Limited
+00195C Innotech
+001961 Blaupunkt  Embedded Systems GmbH
+0019DE Mobitek
+0019EA TeraMage Technologies
+0019CB ZyXEL Communications
+0019D0 Cathexis
+0019D7 Fortunetek
+0019B3 Stanford Research Systems
+001A44 JWTrading
+001A49 Micro Vision
+001A3D Ajin Vision
+001A31 Scan Coin Industries AB
+001A38 Sanmina-SCI
+001A2C Satec
+001A27 Ubistar
+0017AE GAI-Tronics
+0017A2 Camrivox
+0017A7 Mobile Computing Promotion Consortium
+00179D Kelman Limited
+001791 LinTech GmbH
+001796 Rittmeyer AG
+001798 Azonic Technology
+00178A Darts Technologies
+00177E Meshcom Technologies
+001785 Sparr Electronics
+001809 Cresyn
+00180E Avega Systems
+001810 IPTrade
+0017F6 Pyramid Meriden
+0017FB FA
+0017FD Amulet Hotkey
+0017EF IBM
+0017D7 ION Geophysical
+0017DC Daemyung Zero1
+0017DE Advantage Six
+0018C3 CS
+0018C5 Nokia Danmark A/S
+0018CA Viprinet GmbH
+0018BE Ansa
+0018B2 Adeunis RF
+0018B7 D3 LED
+0018AB Beijing Lhwt Microelectronics
+0018A6 Persistent Systems
+001895 Hansun Technologies
+00189A Hana Micron
+0018E7 Cameo Communications
+0018EE Videology Imaging Solutions
+0018E2 Topdata Sistemas de Automacao Ltda
+0018DB EPL Technology
+0018E0 Anaveo
+0018CF Baldor Electric Company
+0018D4 Unified Display Interface SIG
+00184A Catcher
+00184C Bogen Communications
+001845 Pulsar-Telecom
+00183E Digilent
+001828 e2v technologies (UK)
+00182D Artec Design
+001821 Sindoricoh
+001815 GZ Technologies
+00181C Exterity Limited
+001772 Astro Strobel Kommunikationssysteme Gmbh
+001777 Obsidian Research
+00176E Ducati Sistemi
+001762 Solar Technology
+001769 Cymphonix
+00175D Dongseo system.
+00175B ACS Solutions Switzerland
+001756 Vinci Labs Oy
+00174F iCatch
+0017CD CEC Wireless R&D
+0017D2 Thinlinx
+0017C6 Cross Match Technologies
+0017BA Sedo
+0017BF Coherent Research Limited
+0017C1 CM Precision Technology
+0017B3 Aftek Infosys Limited
+00186A Global Link Digital Technology
+00186F Setha Industria Eletronica Ltda
+001876 WowWee
+001869 Kingjim
+001864 Eaton
+00185D Taiguen Technology (shen-zhen)
+001851 SWsoft
+001858 TagMaster AB
+00189F Lenntek
+00188E Ekahau
+001887 Metasystem SpA
+001889 WinNet Solutions Limited
+00187B 4NSYS
+001661 Novatium Solutions (P)
+001663 KBT Mobile
+001668 Eishin Electronics
+001662 Liyuh Technology
+00165C Trackflow
+001655 Fuho Technology
+001650 Herley General Microwave Israel. 
+0015E4 Zimmer Elektromedizin
+0015DA Iritel A.D.
+0015DF Clivet
+0015D3 Pantech&Curitel Communications
+0015C7 Cisco Systems
+0015C0 Digital Telemedia
+0015BA iba AG
+00174A Socomec
+001743 Deck Srl
+00173D Neology
+00173E LeucotronEquipamentos Ltda.
+001738 International Business Machines
+00172C Taejin Infotech
+001720 Image Sensing Systems
+001725 Liquid Computing
+001701 KDE
+001703 Mosdan Internation
+0016FC Tohken
+0016F0 Dell
+0016F5 Dalian Golden Hualu Digital Technology
+0016E9 Tiba Medical
+0016E4 Vanguard Security Engineering
+0016DD Gigabeam
+0016E2 American Fibertek
+0016D3 Wistron
+0016D8 Senea AB
+00169C Cisco Systems
+00169E TV One
+0016A3 Ingeteam Transmission&Distribution
+001690 J-tek Incorporation
+001697 NEC
+001689 Pilkor Electronics
+00168B Paralan
+001684 Donjin
+00167D Sky-Line Information
+001678 Shenzhen Baoan Gaoke Electronics
+001649 SetOne GmbH
+00163F Crete Systems
+001638 Tecom
+001633 Oxford Diagnostics
+00162C Xanboo
+001625 Impinj
+001627 Embedded-logic Design AND More Gmbh
+001619 Lancelan Technologies S.L.
+001614 Picosecond Pulse Labs
+001719 Audiocodes USA
+00171E Theo Benning GmbH & KG
+001712 Isco International
+00170D Dust Networks
+00160F Badger Meter
+00160A Sweex Europe BV
+001603 Coolksky
+0015FC Littelfuse Startco
+0015F7 Wintecronics
+0015F0 EGO BV
+0015EA Tellumat (Pty)
+0016C5 Shenzhen Xing Feng Industry
+0016C7 Cisco Systems
+0016CC Xcute Mobile
+0016C0 Semtech
+0016B9 ProCurve Networking
+0016B4 Private
+0016A8 CWT
+0016AD BT-Links Company Limited
+001553 Cytyc
+001555 DFM GmbH
+00154E IEC
+001547 AiZen Solutions
+001542 Microhard S.r.l.
+00153B EMH metering GmbH & KG
+001534 A Beltrnica-Companhia de Comunicaes
+001440 Atomic
+001439 Blonder Tongue Laboratories
+001434 Keri Systems
+00142D Toradex AG
+001426 NL Technology
+001421 Total Wireless Technologies Pte.
+00141C Cisco Systems
+001583 IVT
+00157E Weidmller Interface GmbH & KG
+001579 Lunatone Industrielle Elektronik GmbH
+001574 Horizon Semiconductors
+00156D Ubiquiti Networks
+001566 A-First Technology
+001561 JJPlus
+00155A Dainippon Pharmaceutical
+001554 Atalum Wireless
+001528 Beacon Medical Products d.b.a. BeaconMedaes
+001521 Horoquartz
+001523 Meteor Communications
+001522 Dea Security
+00151C Leneco
+001512 Zurich University of Applied Sciences
+00150B Sage Infotech
+001506 Neo Photonics
+0014FF Precise Automation
+0014F8 Scientific Atlanta
+0014F3 ViXS Systems
+0014E7 Stolinx
+0014EC Acro Telecom
+0014E2 datacom systems
+0014D6 Jeongmin Electronics
+0014DB Elma Trenew Electronic GmbH
+0014DD Covergence
+0014DC Communication System Design & Manufacturing (csdm)
+0014CF Invisio Communications
+0014CA Key Radio Systems Limited
+0014C3 Seagate Technology
+0014BC Synectic Telecom Exports PVT.
+0014B7 AR Infotek
+0014AD Gassner Wiege- und Metechnik GmbH
+0014B2 mCubelogics
+0014A6 Teranetics
+00149F System and Chips
+0014A1 Synchronous Communication
+001470 Prokom Software SA
+001469 Cisco Systems
+001462 Digiwell Technology
+00145D WJ Communications
+001450 Heim Systems GmbH
+001456 Edge Products
+00144C General Meters
+001445 Telefon-Gradnja d.o.o.
+001447 Boaz
+001446 SuperVision Solutions
+0015B3 Caretech AB
+0015A9 Kwang WOO I&C
+00159D Tripp Lite 
+001591 RLW
+00158A Surecom Technology
+00158F NTT Advanced Technology
+001590 Hectronic GmbH
+0014A0 Accsense
+001493 Systimax Solutions
+00148E Tele Power
+001487 American Technology Integrators
+001482 Aurora Networks
+001481 Multilink
+00147C 3Com
+001475 Wiline Networks
+0012E7 Projectek Networking Electronics
+0012E8 Fraunhofer IMS
+0012DB Ziehl Industrie-elektronik Gmbh + KG
+0012E2 Alaxala Networks
+0012D6 Jiangsu Yitong High-Tech
+0012D5 Motion Reality
+0012C3 WIT
+0013E5 Tenosys
+0013EA Kamstrup A/S
+0013DE Adapt4
+0013D7 Spidcom Technologies SA
+0013D8 Princeton Instruments
+0013CF 4Access Communications
+0013D2 Page Iberica
+0013C9 Beyond Achieve Enterprises
+0013C2 Wacom
+0013BD Hymatom SA
+0013B8 RyCo Electronic Systems Limited
+00134E Valox Systems
+001353 Hydac Filtertechnik Gmbh
+00134D Inepro BV
+001347 Red Lion Controls
+00133B Speed Dragon Multimedia Limited
+001340 AD.EL s.r.l.
+00132E ITian Coporation
+001328 Westech Korea,
+00132D iWise Communications
+001334 Arkados
+0013B3 Ecom Communications Technology
+0013AC Sunmyung Electronics
+0013A6 Extricom
+0013A5 General Solutions
+0013A0 Algosystem
+001399 Stac
+001393 Panta Systems
+001394 Infohand
+00138D Kinghold
+0012C8 Perfect tech
+0012B9 Fusion Digital Technology
+0012BE Astek
+0012AC Ontimetek
+0012AB WiLife
+0012B2 Avolites
+0012A6 Dolby Australia
+001378 Qsan Technology
+00137D Dynalab
+001384 Advanced Motion Controls
+00137E CorEdge Networks
+00136C TomTom
+001365 Nortel
+00136B E-tec
+001359 ProTelevision Technologies A/S
+00135E Eab/rwi/k
+00129F RAE Systems
+001299 Ktech Telecommunications
+00129A IRT Electronics
+00128C Woodward Governor
+001293 GE Energy
+001287 Digital Everywhere Unterhaltungselektronik GmbH
+001280 Cisco Systems
+00131E Peiker acustic GmbH & KG
+001323 Cap
+001317 GN Netcom as
+00130B Mextal
+001312 Amedia Networks
+0012F8 WNI Resources
+0012FF Lely Industries N.V.
+001304 Flaircomm Technologies
+001410 Suzhou Keda Technology
+001417 RSE Informations Technologie GmbH
+001408 Eka Systems
+001402 kk-electronic a/s
+001401 Rivertree Networks
+0013FB RKC Instrument
+0013F4 Psitek (Pty)
+0013EF Kingjon Digital Technology
+0011F7 Shenzhen Forward Industry
+0011F2 Institute of Network Technologies
+0011EB Innovative Integration
+0011E6 Scientific Atlanta
+0011E5 KCodes
+0011DF Current Energy
+0011D3 NextGenTel Holding ASA
+00110E Tsurusaki Sealand Transportation
+001115 Epin Technologies
+001114 EverFocus Electronics
+001107 RGB Networks
+001108 Orbital Data
+001102 Aurora Multimedia
+000FFC Merit Li-Lin Ent.
+000FDA Yazaki
+000FF3 Jung Myoung Communications&Technology
+0011A2 Manufacturing Technology
+00119B Telesynergy Research
+00118C Missouri Department of Transportation
+001191 CTS-Clima Temperatur Systeme GmbH
+00118B Alcatel-Lucent, Enterprise Business Group
+001196 Actuality Systems
+00117E Progeny, A division of Midmark
+001179 Singular Technology
+001172 Cotron
+001166 Taelim Electronics
+00116B Digital Data Communications Asia
+00116C Nanwang Multimedia
+001162 Star Micronics
+001161 NetStreams
+001155 Sevis Systems
+00115C Cisco Systems
+001147 Secom-IndustryLTD.
+00114C caffeina applied research
+001274 NIT lab
+00127A Sanyu Industry
+00126D University of California, Berkeley
+001268 IPS d.o.o.
+001267 Panasonic
+001261 Adaptix
+001257 LeapComm Communication Technologies
+001222 Skardin (UK)
+001227 Franklin Electric
+00121B Sound Devices
+001221 B.Braun Melsungen AG
+001214 Koenig & Bauer AG
+00120F Ieee 802.3
+001208 Gantner Instruments GmbH
+001201 Cisco Systems
+001202 Decrane Aerospace - Audio International
+0011FC Harting Electric Gmbh &KG
+0011C7 Raymarine UK
+0011CC Guangzhou Jinpeng Group
+0011B5 Shenzhen Powercom
+0011BA Elexol
+0011C1 4P Mobile Data Processing
+0011A8 Quest Technologies
+0011A7 Infilco Degremont
+001250 Tokyo Aircaft Instrument
+00124B Texas Instruments
+001244 Cisco Systems
+001238 SetaBox Technology
+00123D GES
+00123E Erune Technology
+00122C Soenen Controls N.V.
+001231 Motion Control Systems
+001146 Telecard-Pribor
+001140 Nanometrics
+001139 Stoeber Antriebstechnik Gmbh + KG.
+00113A Shinboram
+001134 MediaCell
+001127 TASI
+00112A Niko NV
+001121 Cisco Systems
+000EBB Everbee Networks
+000EB4 Guangzhou Gaoke Communications Technologyltd.
+000EAE Gawell Technologies
+000EA8 United Technologists Europe Limited
+000EAD Metanoia Technologies
+000EA1 Formosa Teletek
+000E9C Benchmark Electronics 
+000E9B Ambit Microsystems
+000E8E SparkLAN Communications
+000E95 Fujiya Denki Seisakusho
+000FC1 Wave
+000FC8 Chantry Networks
+000FC7 Dionica R&D
+000FBA Tevebox AB
+000FA7 Raptor Networks Technology
+000FAE E2O Communications
+000FA8 Photometrics
+000F9A Synchrony
+000FA2 2xWireless
+000E89 Clematic
+000E82 Commtech Wireless
+000E7C Televes
+000E76 Gemsoc Innovision
+000E7B Toshiba
+000E6E MAT S.A. (Mircrelec Advanced Technology)
+000E72 CTS electronics
+000E68 E-TOP Network Technology
+000E67 Eltis Microelectronics
+000E62 Nortel Networks
+000FE7 Lutron Electronics
+000FEC Arkus
+000FE0 NComputing
+000FD4 Soundcraft
+000FD9 FlexDSL Telecommunications AG
+000FCD Nortel Networks
+000EEA Shadong Luneng Jicheng Electronics,Co.
+000EDD Shure Incorporated
+000EE4 BOE Technology Group
+000ED8 Positron Access Solutions
+000ECD Skov A/S
+000ECE S.I.T.T.I.
+000ED3 Epicenter
+000EC0 Nortel Networks
+000EC7 Motorola Korea
+000F93 Landis+Gyr
+000F94 Genexis BV
+000F8E Dongyang Telecom
+000F87 Maxcess International
+000F82 Mortara Instrument
+000F81 PAL Pacific
+000F74 Qamcom Technology AB
+000F7B Arce Sistemas
+000F68 Vavic Network Technology
+000F6F FTA Communication Technologies
+000F62 Alcatel Bell Space N.V.
+000F5C Day One Digital Media Limited
+000F55 Datawire Communication Networks
+000F49 Northover Solutions Limited
+000F50 StreamScale Limited
+000F42 Xalyo Systems
+000F1C DigitAll World
+000F0A Clear Edge Networks
+000F09 Private
+000F03 Com&c
+000EF7 Vulcan Portals
+000EFC Jtag Technologies
+000EE9 WayTech Development
+000EF0 Festo AG & KG
+000F4F Cadmus Technology
+000F35 Cisco Systems
+000F2E Megapower International
+000F29 Augmentix
+000F22 Helius
+000F0F Real ID Technology
+000F16 JAY HOW Technology,
+000F1B Ego Systems
+000D74 Sand Network Systems
+000D7B Consensys Computers
+000D6E K-Patents Oy
+000D68 Vinci Systems
+000D6D K-Tech Devices
+000D5B Smart Empire Investments Limited
+000D5C Robert Bosch GmbH, Vt-atmo
+000D61 Giga-Byte Technology
+000D55 Sanycom Technology
+000D49 Triton Systems of Delaware
+000D4E NDR
+000E5B ParkerVision - Direct2Data
+000E55 Auvitran
+000E56 4G Systems GmbH & KG
+000E4F Trajet GmbH
+000E48 Lipman TransAction Solutions
+000E43 G-Tek Electronics Sdn. Bhd.
+000E34 NexGen City
+000E3B Hawking Technologies
+000E2F Roche Diagnostics GmbH
+000DFB Komax AG
+000DE9 Napatech Aps
+000DEE Andrew RF Power Amplifier Group
+000DE2 CMZ Sistemi Elettronici
+000DDC VAC
+000DD6 ITI
+000DDB Airwave Technologies
+000DCA Tait Electronics
+000DCF Cidra
+000E28 Dynamic Ratings P/L
+000E22 Private
+000E21 MTU Friedrichshafen GmbH
+000E15 Tadlys
+000E1C Hach Company
+000E0D Hesch Schrder GmbH
+000E10 C-guys
+000DF5 Teletronics International
+000DFC Itfor
+000E01 Asip Technologies
+000CF0 M & N GmbH
+000CF5 InfoExpress
+000CE0 Trek Diagnostics
+000CE4 NeuroCom International
+000CE9 Bloomberg L.P.
+000CCE Cisco Systems
+000CD4 Positron Public Safety Systems
+000CCD IEC - Tc57
+000D15 Voipac s.r.o.
+000D16 UHS Systems
+000D1B Kyoto Electronics Manufacturing
+000D0F Finlux
+000D03 Matrics
+000D08 AboveCable
+000CFC S2io Technologies
+000CF6 Sitecom Europe BV
+000DA3 Emerging Technologies Limited
+000D9C Elan GmbH & KG
+000D96 Vtera Technology
+000D95 Opti-cell
+000D90 Factum Electronics AB
+000D89 Bils Technology
+000D80 Online Development
+000DC9 Thales Elektronik Systeme Gmbh
+000DC3 First Communication
+000DBC Cisco Systems
+000DB7 Sanko Electric
+000DB0 Olym-tech
+000DA8 Teletronics Technology
+000D41 Siemens AG ICM MP UC RD IT KLF1
+000D3A Microsoft
+000D35 PAC International
+000D2E Matsushita Avionics Systems
+000D28 Cisco Systems
+000D22 Unitronics
+000D27 Microplex Printware AG
+000C21 Faculty of Science and Technology, Keio University
+000C11 Nippon Dempa
+000C10 PNI
+000C12 Micro-Optronic-Messtechnik GmbH
+000C17 AJA Video Systems
+000C04 Tecnova
+000C0B Broadbus Technologies
+000BF8 Infinera
+000BFF Berkeley Camera Engineering
+000BEC Nippon Electric Instrument
+000BB8 Kihoku Electronic
+000BBD Connexionz Limited
+000BAD PC-PoS
+000BA0 T&L Information
+000BA7 Maranti Networks
+000BAC 3Com
+000B93 Ritter Elektronik
+000B98 NiceTechVision
+000B9B Sirius System
+000B8C Flextronics
+000BF1 LAP Laser Applikations
+000BDF Shenzhen RouterD Networks Limited
+000BDE Teldix Gmbh
+000BE0 SercoNet
+000BE5 Hims International
+000BD9 General Hydrogen
+000BAE Vitals System
+000BD0 XiMeta Technology Americas
+000BD5 Nvergence
+000BC4 Biotronik Gmbh
+000BC9 Electroline Equipment
+000BB1 Super Star Technology
+000BB6 Metalligence Technology
+000B79 X-COM
+000B80 Lycium Networks
+000B87 American Reliance
+000B6D Solectron Japan Nakaniida
+000B74 Kingwave Technology
+000B67 Topview Technology
+000B61 Friedrich Ltze GmbH & KG
+000B66 Teralink Communications
+000B68 Addvalue Communications Pte
+000B58 Astronautics C.A 
+000B50 Oxygnet
+000B44 Concord IDea
+000B49 RF-Link System
+000B4B Visiowave SA
+000B31 Yantai ZhiYang Scientific and technology industry
+000B3D Contal OK
+000B38 Knrr GmbH
+000B2A Howtel
+000B2C Eiki Industrial
+000C97 NV ADB TTV Technologies SA
+000C9C Chongho information & communications
+000C9E MemoryLink
+000C89 AC Electric Vehicles
+000C8B Connect Tech
+000C90 Octasic
+000C84 Eazix
+000C75 Oriental integrated electronics.
+000C77 Life Racing
+000C7C Internet Information Image
+000C43 Ralink Technology
+000C45 Animation Technologies
+000C29 VMware
+000C3C MediaChorus
+000C32 Avionic Design Development GmbH
+000C35 KaVo Dental GmbH & KG
+000C2B Elias Technology
+000C28 Rifatron
+000C1C MicroWeb
+000C64 X2 MSA Group
+000C69 National Radio Astronomy Observatory
+000C70 ACC GmbH
+000C51 Scientific Technologies
+000C56 Megatel Computer (1986)
+000C58 M&S Systems
+000C5D Chic Technology (china)
+000C4A Cygnus Microsystems (P) Limited
+000CC8 Xytronix Research & Design
+000CBB Iskraemeco
+000CB5 Premier Technolgies
+000CBC Iscutum
+000CC1 Cooper Industries
+000CA3 Rancho Technology
+000CAA Cubic Transportation Systems
+000A38 Apani Networks
+000A3F Data East
+000A44 Avery Dennison Deutschland GmbH
+000A46 ARO Welding Technologies SAS
+000A33 Emulex
+000A31 HCV Consulting
+000A2C Active Tchnology
+004252 RLX Technologies
+000A2A QSI Systems
+000A1E Red-M Products Limited
+000A23 Parama Networks
+000A17 Nestar Communications
+000A1C Bridge Information
+000B19 Vernier Networks
+000B1E Kappa Opto-electronics Gmbh
+000B25 Aeluros
+000B17 MKS Instruments
+000B12 Nuri Telecom
+000B0B Corrent
+000AFA Traverse Technologies Australia
+000AFF Kilchherr Elektronik AG
+000AF3 Cisco Systems
+000AF8 American Telecare
+000AEE GCD Hard- & Software GmbH
+000A06 Teledex
+000A09 TaraCom Integrated Products
+000A0B Sealevel Systems
+000A10 Fast Media Integrations AG
+0009F7 SED, a division of Calian
+000A01 Sohoware
+0009E9 Cisco Systems
+0009F0 Shimizu Technology
+0009EA YEM
+0009E4 K Tech Infosystem
+0009D8 Flt Communications AB
+0009DD Mavin Technology
+0009B1 Kanematsu Electronics
+0009A3 Leadfly Techologies
+0009AA Data Comm for Business
+0009A4 Hartec
+00099E Testech
+000992 InterEpoch Technology
+000997 Nortel Networks
+000991 GE Fanuc Automation Manufacturing
+00098B Entropic Communications
+000AAB Toyota Technical Development
+000AB0 Loytec Electronics Gmbh
+000AB7 Cisco Systems
+000AA4 Shanghai Surveillance Technology
+000AA9 Brooks Automation GmbH
+000A91 HemoCue AB
+000A9D King Young Technology
+000A8C Guardware Systems
+000A97 Sonicblue
+000A7D Valo
+000A84 Rainsun Enterprise
+000A89 Creval Systems
+0009D7 DC Security Products
+0009CA iMaxNetworks(Shenzhen)Limited.
+0009D1 Seranoa Networks
+0009C5 Kingene Technology
+0009BD Epygi Technologies
+0009B6 Cisco Systems
+00097F Vsecure 2000
+000984 MyCasa Network
+000971 Time Management
+000978 Aiji System
+000972 Securebase
+00096C Imedia Semiconductor
+000965 HyunJu Computer
+000960 Yozan
+000956 Network Systems Group, (NSG)
+000955 Young Generation International
+000AE9 AirVast Technology
+000ADB SkyPilot Network
+000ADD Allworx
+000AE2 Binatone Electronics International
+000ACA Yokoyama Shokai
+000ACF Provideo Multimedia
+000AD6 BeamReach Networks
+000ABC Seabridge
+000ABE Opnet Technologies
+000AC3 eM Technics
+000A78 Olitec
+000A71 Avrio Technologies
+000A76 Beida Jade Bird Huaguang Technology
+000A63 DHD GmbH
+000A65 GentechMedia.co.
+000A6A SVM Microwaves s.r.o.
+000A5E 3COM
+000A52 AsiaRF
+000A4B DataPower Technology
+00075A Air Products and Chemicals
+000754 Xyterra Computing
+00074E Ipfront
+00074D Zebra Technologies
+000742 Ormazabal
+000748 The Imaging Source Europe
+000736 Data Video Technologies
+00073D Nanjing Postel Telecommunications
+00073C Telecom Design
+00072A Innovance Networks
+00072F Intransa
+000730 Hutchison Optel Telecom Technology
+000725 Bematech International
+000818 Pixelworks
+000812 GM-2
+000811 Voix
+00080B Birka BPA Informationssystem AB
+000805 Techno-Holon
+00080C VDA Elettronica spa
+0007FB Giga Stream Umts Technologies Gmbh
+0007F5 Bridgeco AG
+0007E8 EdgeWave
+0007EF Lockheed Martin Tactical Systems
+0007E2 Bitworks
+0007D6 Commil
+0007DC Atek
+000923 Heaman System
+00091D Proteam Computer
+000924 Telebau GmbH
+000911 Cisco Systems
+000916 Listman Home Technologies
+00090A SnedFar Technology
+000904 Mondial Electronic
+000903 Panasas
+0008FE Unik C&C
+0008FA Karl E.Brinkmann GmbH
+0008EE Logic Product Development
+0008F0 Next Generation Systems
+000948 Vista Control Systems
+00094F elmegt GmbH & KG
+000943 Cisco Systems
+00093C Jacques Technologies P/L
+000936 Ipetronik GmbH & KG
+000935 Sandvine Incorporated
+000929 Sanyo Industries (UK) Limited
+000930 AeroConcierge
+0008E9 NextGig
+0008DC Wiznet
+0008E2 Cisco Systems
+0008DB Corrigent Systems
+0008D6 Hassnet
+0008CF Nippon Koei Power Systems
+0008C0 ASA Systems
+0008C5 Liontech
+0008C9 TechniSat Digital GmbH
+0008CA TwinHan Technology
+0008BF Aptus Elektronik AB
+0008B9 Kaon Media
+0008B3 Fastwel
+0008B2 Shenzhen Compass Technology Development
+0008A6 Multiware & Image
+0008AD Toyo-Linx
+00089A Alcatel Microelectronics
+0008A0 Stotz Feinmesstechnik GmbH
+000892 EM Solutions
+000896 Printronix
+00088C Quanta Network Systems
+000886 Hansung Teliann
+000873 DapTechnology
+00087A Wipotec GmbH
+00087F Spaun Electronic Gmbh & KG
+02608C 3com
+0007D0 Automat Engenharia de Automao Ltda.
+0007CD Kumoh Electronic
+0007C7 Synectics Systems Limited
+00047D Pelco
+0007BA UTStarcom
+00047E Siqura
+0007C1 Overture Networks
+0007C0 NetZerver
+0007AE Britestream Networks
+0007B4 Cisco Systems
+0007A6 Home Automation
+00079A Verint Systems
+0007A0 e-Watch
+000794 Simple Devices
+000793 Shin Satellite Public Company Limited
+00078D NetEngines
+00078E Garz & Friche GmbH
+000781 Itron
+000787 Idea System
+000777 Motah
+000771 Embedded System
+00075B Gibson Guitars
+000760 Tomis Information & Telecom
+000767 Yuxing Electronics Company Limited
+000879 CEM
+00086C Plasmon LMS
+00086D Missouri FreeNet
+000867 Uptime Devices
+000860 LodgeNet Entertainment
+000854 Netronix
+00085A IntiGate
+00081E Repeatit AB
+00082B Wooksung Electronics
+000824 Nuance Document Imaging
+0005BA Area Netwoeks
+0005B9 Airvana
+0005C0 Digital Network Alacarte
+000599 DRS Test and Energy Management or DRS-TEM
+0005A0 Mobiline Kft.
+0005A9 Princeton Networks
+0005AA Moore Industries International
+0005AF InnoScan Computing A/S
+0005B3 Asahi-Engineering
+00059F Yotta Networks
+0005A6 Extron Electronics
+0005B4 Aceex
+00058D Lynx Photonic Networks
+000587 Locus, Incorporated
+000593 Grammar Engine
+000586 Lucent Technologies
+00057A Overture Networks
+00063C Intrinsyc Software International
+00062F Pivotech Systems
+000636 Jedai Broadband Networks
+000635 PacketAir Networks
+000628 Cisco Systems
+00061F Vision Components GmbH
+000619 Connection Technology Systems
+00060D Wave7 Optics
+000613 Kawasaki Microelectronics Incorporated
+00060E Igys Systems
+0005EC Mosaic Systems
+0005D3 eProduction Solutions
+000608 At-Sky SAS
+000607 Omni Directional Control Technology
+0005E6 Egenera
+000580 FibroLAN
+000576 NSM Technology
+000570 Baydel
+00056A Heuft Systemtechnik GmbH
+000563 J-Works
+00055D D-link Systems
+000564 Tsinghua Bitway
+000557 Agile TV
+000551 F & S Elektronik Systeme GmbH
+00054B Eaton Automation AG
+00054A Ario Data Networks
+000544 Valley Technologies
+00053E KID Systeme GmbH
+000531 Cisco Systems
+000538 Merilus
+000532 Cisco Systems
+000525 Puretek Industrial
+00052B Horiba
+00051F Taijin Media
+000519 Siemens Building Technologies AG,
+000518 Jupiters Technology
+00050E 3ware
+00050F Tanaka S/S
+000508 Inetcam
+0004FE Pelago Networks
+000671 Softing AG
+000672 Netezza
+00067B Toplink C&C
+000665 Sunny Giken
+00066B Sysmex
+000652 Cisco Systems
+000659 EAL (Apeldoorn)
+000658 Helmut Fischer GmbH Institut fr Elektronik und Messtechnik
+00065F ECI Telecom - Ngts
+000646 ShenZhen XunBao Network Technology
+000640 White Rock Networks
+00064C Invicta Networks
+0006B5 Source Photonics
+0006A8 KC Technology
+00069E Uniqa
+000698 egnite GmbH
+000692 Intruvert Networks
+00068C 3com
+000685 NetNearU
+00068B AirRunner Technologies
+000686 Zardcom
+00067F Digeo
+0006DE Flash Technology
+0006E4 Citel Technologies
+0006D1 Tahoe Networks
+0006DA Itran Communications
+0006CB Jotron Electronics A/S
+0006CC JMI Electronics
+0006BB ATI Technologies
+0006C5 Innovi Technologies Limited
+0006AF Xalted Networks
+000719 Mobiis
+000720 Trutzschler GmbH & KG
+000713 IP One
+00070D Cisco Systems
+000714 Brightcom
+0006F1 Optillion
+0006F0 Digeo
+0006FB Hitachi Printing Solutions
+0006EB Global Data
+0005F2 Power
+0005FE Traficon N.V.
+0005E5 Renishaw PLC
+0005F8 Real Time Access
+0005FF SNS Solutions
+0005DD Cisco Systems
+0005D9 Techno Valley
+0005C6 Triz Communications
+0005CC Sumtel Communications
+00044C Jenoptik
+000448 Polaroid
+00043C Sonos
+000441 Half Dome Systems
+000435 Comptek International
+00042F International Communications Products
+000429 Pixord
+000422 Gordon Kapes
+00041C ipDialog
+00041D Corega of America
+000416 Parks S/A Comunicacoes Digitais
+000410 Spinnaker Networks
+00040F Asus Network Technologies
+00040A Sage Systems
+000403 Nexsi
+0004F8 Qualicable TV Industria E Com.
+0004F2 Polycom
+0004EB Paxonet Communications
+0004EC Memobox SA
+0004E6 Banyan Network Private Limited
+0004DC Nortel Networks
+0004E1 Infinior Microsystems
+0004DB Tellus Group
+0004E2 SMC Networks
+0004D5 Hitachi Information & Communication Engineering
+0004CF Seagate Technology
+0004C9 Micro Electron
+000487 Cogency Semiconductor
+000482 Medialogic
+000478 G. Star Technology
+000471 IPrad
+00046B Palm Wireless
+000465 i.s.t isdn-support technik GmbH
+000459 Veristar
+00045E PolyTrax Information Technology AG
+000458 Fusion
+000452 RocketLogix
+000442 Nact
+0003F9 Pleiades Communications
+0003E2 Comspace
+0003F4 NetBurner
+0003F3 Dazzle Multimedia
+0003ED Shinkawa Electric
+0003E7 Logostek
+0003DF Desana Systems
+0003DB Apogee Electronics
+0003D6 Radvision
+0003CF Muxcom
+0003C8 CML Emergency Services
+0003C3 Micronik Multimedia
+0003C0 Rftnc
+0003BC COT GmbH
+0003B1 Hospira
+0003A5 Medea
+0003AA Watlow
+0003A2 Catapult Communications
+000397 Watchfront Limited
+00039E Tera System
+000392 Hyundai Teletek
+00038F Weinschel
+00038B Plus-one I&T
+000386 Ho Net
+00037D Stellcom
+000382 A-One
+00037A Taiyo Yuden
+000376 Graphtec Technology
+000369 Nippon Antenna
+00036F Telsey SPA
+000363 Miraesys
+00035E Metropolitan Area Networks
+000357 Intervoice-Brite
+00034C Shanghai DigiVision Technology
+000351 Diebold
+000311 Micro Technology
+00030A Argus Technologies
+000302 Charles Industries
+000305 MSC Vertriebs GmbH
+0002FE Viditec
+0002F2 eDevice
+0002F7 ARM
+0002EC Maschoff Design Engineering
+0002E4 JC Hyun Systems
+0002E7 CAB GmbH & KG
+0002E0 Etas Gmbh
+0002D9 Reliable Controls
+0002D4 PDA Peripherals
+0002D1 Vivotek
+0002CD TeleDream
+000349 Vidicode Datacommunicatie
+000340 Floware Wireless Systems
+008037 Ericsson Group
+000332 Cisco Systems
+000339 Eurologic Systems
+00032A UniData Communication Systems
+00032D Ibase Technology
+000326 Iwasaki Information Systems
+00031D Taiwan Commate Computer
+000318 Cyras Systems
+0004C2 Magnipix
+0004B6 Stratex Networks
+0004BC Giantec
+0004B0 Elesign
+0004A9 SandStream Technologies
+0004A8 Broadmax Technologies
+0004A2 L.S.I. Japan
+00049B Cisco Systems
+00049C Surgient Networks
+000496 Extreme Networks
+00048F TD Systems
+000488 Eurotherm Controls
+000281 Madge
+009064 Thomson
+00027F ask-technologies.com
+00027A IOI Technology
+000273 Coriolis Networks
+00026E NeGeN Access
+000263 UPS Manufacturing SRL
+00025C SCI Systems (Kunshan)
+000253 Televideo
+00024C SiByte
+00024E Datacard Group
+00012F Twinhead International
+00023C Creative Technology
+000240 Seedek
+000247 Great Dragon Information Technology (Group)
+000243 Raysis
+000239 Visicom
+000236 Init Gmbh
+000231 Ingersoll-Rand
+00022A Asound Electronic
+00022D Agere Systems
+000219 Paralon Technologies
+000186 Uwe Disch
+00017B Heidelberger Druckmaschinen AG
+000182 Dica Technologies AG
+00018E Logitec
+00019B Kyoto Microcomputer
+000194 Capital Equipment
+000197 Cisco Systems
+0001A3 Genesys Logic
+00014E WIN Enterprises
+0030AC Systeme Lauer GmbH
+00013E Ascom Tateco AB
+000145 Winsystems
+000126 PAC Labs
+00011A Hoffmann und Burmeister GbR
+00011D Centillium Communications
+000129 DFI
+000107 Leiser GmbH
+00010E Bri-Link Technologies
+000116 Netspect Technologies
+000103 3com
+00062B Intraserver Technology
+0002C1 Innovative Electronic Designs
+0002C8 Technocom Communications Technology (pte)
+0002A9 Racom, S.r.o.
+0002B8 WHI Konsult AB
+0002AC 3PAR data
+0002B1 Anritsu
+00029A Storage Apps
+0002A0 Flatstack
+000295 IP.Access Limited
+000294 Tokyo Sokushin
+000290 Woorigisool
+000286 Occam Networks
+00028B Vdsl Systems OY
+000222 Chromisys
+00021D Data General Communication
+00020A Gefran Spa
+000216 Cisco Systems
+000206 Telital R&D Denmark A/S
+000203 Woonsang Telecom
+0001F7 Image Display Systems
+0001EE Comtrol Europe
+0001E2 Ando Electric
+0001F1 Innovative Concepts
+00B06D Jones Futurex
+0030FE DSA GmbH
+00305E Abelko Innovation
+00301E 3com Europe
+00304D ESI
+003046 Controlled Electronic Manageme
+00307B Cisco Systems
+0001D6 manroland AG
+0001DB Freecom Technologies GmbH
+0001DE Trango Systems
+0001CF Alpha Data Parallel Systems
+0001CB EVR
+0001C4 NeoWave
+0001C0 CompuLab
+0001B9 SKF Condition Monitoring
+0001B5 Turin Networks
+00017F Experience Music Project
+00016C Foxconn
+000173 Amcc
+00015C Cadant
+000163 Cisco Systems
+00010A CIS Technology
+00016F Inkel
+000155 Promise Technology
+000151 Ensemble Communications
+000142 Cisco Systems
+000132 Dranetz - BMI
+00D07D Cosine Communications
+00D0CA Intrinsyc Software International
+00D058 Cisco Systems
+00D067 Campio Communications
+00D023 Infortrend Technology
+00D02A Voxent Systems
+00D068 Iwill
+00D09D Veris Industries
+00D09A Filanet
+00D00A Lanaccess Telecom
+00D04A Presence Technology Gmbh
+00D0C3 Vivid Technology PTE
+00D0F8 Fujian Star Terminal
+00D096 3com Europe
+00D003 Comda Enterprises
+00D029 Wakefern Food
+00D0F5 Orange Micro
+00D0F7 Next Nets
+00D078 Eltex of Sweden AB
+00D0AF Cutler-hammer
+00D026 Hirschmann Austria Gmbh
+00D037 Pace France
+00D010 Convergent Networks
+00D074 Taqua Systems
+00D0D5 Grundig AG
+00D034 Ormec Systems
+00D08C Genoa Technology
+00D059 Ambit Microsystems
+005020 Mediastar
+00503E Cisco Systems
+00D02B Jetcell
+005017 RSR S.r.l.
+00D0CC Technologies Lyre
+00506D Videojet Systems
+005077 Prolific Technology
+0050D4 Joohong Information
+00505E Digitek Micrologic
+0050E7 Paradise Innovations (asia)
+0050B9 Xitron Technologies
+00D049 Impresstek
+00D04D DIV OF Research & Statistics
+00D035 Behavior TECH. Computer
+00D02D Ademco
+00D07C Koyo Electronics
+00D05B Acroloop Motion Control
+00D0C6 Thomas & Betts
+00D02E Communication Automation
+00D0DA Taicom Data Systems
+00D0E8 MAC System
+00D03C Vieo
+00D09F Novtek Test Systems
+00D07E Keycorp
+00D0EA Nextone Communications
+00D020 AIM System
+00D064 Multitel
+00D072 Broadlogic
+00309B Smartware
+0030AF Honeywell GmbH
+003074 Equiinet
+003090 Cyra Technologies
+003030 Harmonix
+00307C Adid SA
+003063 Santera Systems
+00309F Amber Networks
+0030A8 Ol'e Communications
+00304C Appian Communications
+0030EF Neon Technology
+00306F Seyeon TECH.
+003031 Lightwave Communications
+003035 Corning Incorporated
+00302B Inalp Networks
+00305F Hasselblad
+00302D Quantum Bridge Communications
+003025 Checkout Computer Systems
+00D01F Senetas Security
+003012 Digital Engineering
+003077 Onprem Networks
+0030D4 AAE Systems
+00D00F Speech Design Gmbh
+00D0CF Moreton BAY
+00D073 ACN Advanced Communications
+00D030 Safetran Systems
+00D057 Ultrak
+00D03B Vision Products
+00D0BF Pivotal Technologies
+00D050 Iskratel
+00D0CB Dasan
+00D0D3 Cisco Systems
+00D08E Grass Valley, A Belden Brand
+00D0A3 Vocal DATA
+00D0E0 Dooin Electronics
+003054 Castlenet Technology
+003039 Softbook Press
+003017 BlueArc UK
+003076 Akamba
+00305D Digitra Systems
+0030F7 Ramix
+003033 Orient Telecom
+003083 Ivron Systems
+003007 OPTI
+0030DD Indigita
+0030F2 Cisco Systems
+003020 TSI
+003089 Spectrapoint Wireless
+003022 Fong Kai Industrial
+0030F8 Dynapro Systems
+0030C2 Comone
+003056 Beck IPC GmbH
+0030D2 WIN Technologies,
+003050 Versa Technology
+0030B8 RiverDelta Networks
+00904D Spec
+009079 ClearOne
+00908F Audio Codes
+0090D5 Euphonix
+0090A7 Clientec
+00907F WatchGuard Technologies
+00907E Vetronix
+00902F Netcore Systems
+00900D Overland Storage
+009044 Assured Digital
+009078 MER Telemanagement Solutions
+009009 I Controls
+009015 Centigram Communications
+0090F3 Aspect Communications
+0090A8 NineTiles Networks
+00507A Xpeed
+005002 Omnisec AG
+00508D Abit Computer
+0050CD Digianswer A/S
+0050C5 ADS Technologies
+00502F TollBridge Technologies
+005028 Aval Communications
+00505B Kawasaki LSI U.s.a.
+0050F8 Entrega Technologies
+00506F G-connect
+0050CC Xyratex
+0050D5 AD Systems
+0050AA Konica Minolta Holdings
+00509C Beta Research
+005027 Genicom
+005010 NovaNET Learning
+00509E Les Technologies SoftAcoustik
+00505F Brand Innovators
+005095 Peracom Networks
+005026 Cosystems
+0050EF SPE Systemhaus GmbH
+005093 Boeing
+0050D8 Unicorn Computer
+90C682 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+0055DA Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+DC4427 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+A03E6B Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+009034 Imagic
+009073 Gaio Technology
+0090C9 Dpac Technologies
+0090E7 Horsch Elektronik AG
+009001 Nishimu Electronics Industries
+0090FB Portwell
+009070 NEO Networks
+0090EF Integrix
+0090B0 Vadem
+0090D1 Leichu Enterprise
+0050D7 Telstrat
+0050F1 Intel
+00501B ABL Canada
+005058 VegaStream Group Limted
+005036 Netcam
+0050C9 Maspro Denkoh
+005009 Philips Broadband Networks
+0050C4 IMD
+0050A3 TransMedia Communications
+005099 3com Europe
+0050A4 IO TECH
+0050B3 Voiceboard
+0050B7 Boser Technology
+005056 VMware
+00908D Vickers Electronics Systems
+009042 ECCS
+009051 Ultimate Technology
+0090F9 Leitch
+0090FF Tellus Technology
+009018 ITO Electric Industry
+009002 Allgon AB
+009016 ZAC
+009005 Protech Systems
+00901E Selesta Ingegneria
+009090 I-bus
+0090AA Indigo Active Vision Systems Limited
+00903A Nihon Media Tool
+009055 Parker Hannifin Compumotor Division
+00909F Digi-data
+0090E4 NEC America
+009013 Samsan
+0090CC Planex Communications
+0090FA Emulex
+009004 3com Europe
+0090E1 Telena
+00504A Elteco A.S.
+00504C Galil Motion Control
+005021 EIS International
+00506E Corder Engineering
+00507E Newer Technology
+0050E6 Hakusan
+0050AE FDK
+00109D Clarinet Systems
+0010D2 Nitto Tsushinki
+001045 Nortel Networks
+00106B Sonus Networks
+0010EC RPCG
+001092 Netcore
+0010E2 ArrayComm
+001071 Advanet
+001069 Helioss Communications
+0010FD Cocom A/S
+0010AC Imci Technologies
+0010EF Dbtel Incorporated
+001017 Bosch Access Systems GmbH
+001024 Nagoya Electric Works
+0010DD Enable Semiconductor
+0010C9 Mitsubishi Electronics Logistic Support
+001085 Polaris Communications
+001044 InnoLabs
+001056 Sodick
+001099 InnoMedia
+001061 Hostlink
+001093 CMS Computers
+0010CD Interface Concept
+0010F3 Nexcom International
+001005 UEC Commercial
+001066 Advanced Control Systems
+0010E4 NSI
+001062 NX Server
+0010B9 Maxtor
+00108B Laseranimation Sollinger Gmbh
+00105C Quantum Designs (h.k.)
+001042 Alacritech
+001060 Billionton Systems
+0010DE International Datacasting
+00105D Draeger Medical
+0010E1 S.I. TECH
+001091 NO Wires Needed BV
+0010F5 Amherst Systems
+001090 Cimetrics
+001070 Caradon Trend
+0010BA Martinho-davis Systems
+00107C P-com
+0010AE Shinko Electric Industries
+001040 Intermec
+0010B0 Meridian Technology
+001077 SAF Drive Systems
+0010F4 Vertical Communications
+001065 Radyne
+00104A The Parvus
+0010B3 Nokia Multimedia Terminals
+001037 CYQ've Technology
+0010CA Telco Systems
+001051 Cmicro
+0010DC Micro-star International
+0010EE CTI Products
+00101B Cornet Technology
+001032 Alta Technology
+001025 Grayhill
+001009 Horo Quartz
+0010F8 Texio Technology
+00104D Surtec Industries
+00E0E0 SI Electronics
+00E00F Shanghai Baud Data
+00E0D1 Telsis Limited
+00E005 Technical
+00E072 Lynk
+00E0C1 Memorex Telex Japan
+00E0AD EES Technology
+00E025 dit
+00E0B1 Alcatel-Lucent, Enterprise Business Group
+00E0E4 Fanuc Robotics North America
+00E031 Hagiwara Electric
+00E0A5 ComCore Semiconductor
+00E044 Lsics
+00E05D Unitec
+00E0B3 EtherWAN Systems
+00E053 Cellport LABS
+00E07D Netronix
+00E0ED Silicom
+00E0B4 Techno Scope
+00E0C6 Link2it,
+00E06D Compuware
+00E0E6 Incaa Datacom
+00E074 Tiernan Communications
+00E059 Controlled Environments
+00E006 Silicon Integrated SYS.
+00E0F8 Dicna Control AB
+00E004 Pmc-sierra
+00E0DE Datax NV
+00E078 Berkeley Networks
+00E041 Cspi
+00E0E2 Innova
+00E009 Marathon Technologies
+00E02F Mcns Holdings
+00E04C Realtek Semiconductor
+00E047 InFocus
+00E092 Admtek Incorporated
+00E0FF Security Dynamics Technologies
+08BBCC Ak-nord EDV Vertriebsges. mbH
+0060B2 Process Control
+006004 Computadores Modulares SA
+0060D6 NovAtel Wireless Technologies
+006000 Xycom
+00A019 Nebula Consultants
+00A0ED Brooks Automation
+00A0A9 Navtel Communications
+00A0E1 Westport Research Associates
+00A0D6 SBE
+00A05E Myriad Logic
+00A078 Marconi Communications
+00A00B Computex
+00A09A Nihon Kohden America
+00A095 Acacia Networks
+00A0F2 Infotek Communications
+00A0EF Lucidata
+00A03F Computer Society Microprocessor & Microprocessor Standards
+00A067 Network Services Group
+00A0A7 Vorax
+00A02D 1394 Trade Association
+00A0E6 Dialogic
+00A04A Nisshin Electric
+00A05B Marquip
+00A08D Jacomo
+00A06F THE Appcon Group
+00A08E Check Point Software Technologies
+00E0AA Electrosonic
+00E085 Global Maintech
+00E05A Galea Network Security
+00E022 Analog Devices
+00E0E7 Raytheon E-systems
+00E00C Motorola
+00E04A ZX Technologies
+00E00A DIBA
+00E0B9 Byas Systems
+00E054 Kodai Hitec
+00E0AF General Dynamics Information Systems
+00605B IntraServer Technology
+00604B Safe-com GmbH & KG
+00A0CD DR. Johannes Heidenhain Gmbh
+00A0DA Integrated Systems Technology
+00A03C Eg&g Nuclear Instruments
+00A038 Email Electronics
+00A0BE Integrated Circuit Systems, Communications Group
+00605D Scanivalve
+0060E4 Compuserve
+00600A Sord Computer
+0060C4 Soliton Systems K.K.
+0060C8 Kuka Welding Systems & Robots
+006030 Village Tronic Entwicklung
+0060E7 Randata
+00602A Symicron Computer Communications
+00601E Softlab
+0060F8 Loran International Technologies
+006088 White Mountain DSP
+00609A NJK Techno
+0060CC Emtrak, Incorporated
+006036 AIT Austrian Institute of Technology GmbH
+0060B9 NEC Platforms
+0060CE Acclaim Communications
+0060F5 Icon WEST
+0060A4 GEW Technologies (PTY)Ltd
+0060CA Harmonic Systems Incorporated
+006024 Gradient Technologies
+0060FB Packeteer
+0060BC KeunYoung Electronics & Communication
+0060B8 Corelis
+0060FE Lynx System Developers
+006001 InnoSys
+00607D Sentient Networks
+00606E Davicom Semiconductor
+00607E Gigalabs
+0060CF Alteon Networks
+006026 Viking Modular Solutions
+006003 Teraoka Weigh System PTE
+006059 Technical Communications
+006066 Lacroix Trafic
+0060DA Red Lion Controls
+006042 TKS (usa)
+00A023 Applied Creative Technology
+00A00F Broadband Technologies
+00A032 GES Singapore PTE.
+002034 Rotec Industrieautomation Gmbh
+0020B2 GKD Gesellschaft Fur Kommunikation Und Datentechnik
+002004 Yamatake-honeywell
+0020FE Topware / Grand Computer
+002073 Fusion Systems
+00207A WiSE Communications
+00205C InterNet Systems of Florida
+00207E Finecom
+00205A Computer Identics
+0020E4 Hsing Tech Enterprise
+00A000 Centillion Networks
+00A07B Dawn Computer Incorporation
+00A0DE Yamaha
+00A05C Inventory Conversion
+00206F Flowpoint
+0020DF Kyosan Electric MFG.
+002010 Jeol System Technology
+002020 Megatron Computer Industries
+002037 Seagate Technology
+0020A0 OA Laboratory
+00C0A3 Dual Enterprises
+00C095 Znyx
+0070B0 M/a-com Companies
+009D8E Cardiac Recorders
+006086 Logic Replacement TECH.
+001C7C Perq Systems
+00C059 Denso
+00C0A9 Barron Mccann
+00C069 Axxcelera Broadband Wireless
+00C019 Leap Technology
+00A062 AES Prodata
+00A0F4 GE
+00A008 Netcorp
+00A01B Premisys Communications
+00A04B TFL LAN
+00A015 Wyle
+00A011 Mutoh Industries
+00A0B6 Sanritz Automation
+00A0DD Azonix
+00A00A Airspan
+00A03B Toshin Electric
+00A0F3 Staubli
+00A097 JC Information Systems
+00A082 NKT Elektronik A/S
+00A072 Ovation Systems
+00A0B2 Shima Seiki
+00A0E5 NHC Communications
+00A0D3 Instem Computer Systems
+00A0BA Patton Electronics
+00A0B4 Texas Microsystems
+00A0AF WMS Industries
+00A0FE Boston Technology
+00202F Zeta Communications
+002060 Alcatel Italia
+00209A THE 3DO Company
+00205E Castle ROCK
+00207C Autec Gmbh
+002075 Motorola Communication Israel
+002015 Actis Computer SA
+0020E9 Dantel
+00204A Pronet Gmbh
+002029 Teleprocessing Products
+002051 Verilink
+0020A1 Dovatron
+002024 Pacific Communication Sciences
+00209D Lippert Automationstechnik
+002041 Data NET
+002076 Reudo
+00206E XACT
+0020CA Digital Ocean
+002085 Eaton
+0020CD Hybrid Networks
+0020E7 B&W Nuclear Service Company
+0020AC Interflex Datensysteme Gmbh
+0020F6 NET TEK  AND Karlnet
+0020D3 OST (ouest Standard Telematiqu
+0020D8 Nortel Networks
+002017 Orbotech
+002025 Control Technology
+00C08B Risq Modular Systems
+00C0CD Comelta
+00C04B Creative Microsystems
+00C0A1 Tokyo Denshi Sekei
+00C03E FA. GEBR. Heller Gmbh
+00C0E1 Sonic Solutions
+00C047 Unimicro Systems
+00C046 Blue Chip Technology
+00C00D Advanced Logic Research
+00C0FA Canary Communications
+00C0B7 American Power Conversion
+00C0BA Netvantage
+00C0B6 Overland Storage
+00C048 BAY Technical Associates
+00C03F Stores Automated Systems
+00C00E Psitech
+00C036 Raytech Electronic
+00C009 KT Technology (S) PTE
+00C0EA Array Technology
+00C03A Men-mikro Elektronik Gmbh
+00C040 Ecci
+00C04C Department OF Foreign Affairs
+00C01C Interlink Communications
+00C017 Fluke
+00C086 THE Lynk
+00C08D Tronix Product Development
+00C0AB Telco Systems
+00C0A2 Intermedium A/S
+00C070 Sectra Secure-transmission AB
+00C057 Myco Electronics
+00C0DF KYE Systems
+00C0F6 Celan Technology
+00C08F Panasonic Electric Works
+00C012 Netspan
+00C0C4 Computer Operational
+00C0C2 Infinite Networks
+00C0D3 Olympus Image Systems
+00C0B0 GCC Technologies
+00C0F4 Interlink System
+00C0E2 Calcomp
+00C0CA ALFA
+00C07B Ascend Communications
+00C052 Burr-brown
+00C0BE Alcatel - SEL
+00408F Wm-data Minfo AB
+0040B7 Stealth Computer Systems
+004057 Lockheed - Sanders
+004017 Silex Technology America
+004087 Ubitrex
+00400E Memotec
+00C09E Cache Computers
+00C093 Alta Research
+00C034 Transaction Network
+004034 Bustek
+004097 Datex Division OF
+00401E ICC
+00407C Qume
+004060 Comendec
+004056 MCM Japan
+004095 R.p.t. Intergroups Int'l
+0040C3 Fischer AND Porter
+0040F1 Chuo Electronics
+004061 Datatech Enterprises
+00408B Raylan
+004020 CommScope
+00406E Corollary
+004066 Hitachi Metals
+004016 ADC - Global Connectivity Solutions Division
+004086 Michels & Kleberhoff Computer
+0040DC Tritec Electronic Gmbh
+004074 Cable AND Wireless
+004084 Honeywell ACS
+0040B8 Idea Associates
+004058 Kronos
+0040A8 IMF International
+0080BB Hughes LAN Systems
+00C0A0 Advance Micro Research
+00C0D7 Taiwan Trading Center DBA
+00C037 Dynatem
+00C05F Fine-pal Company Limited
+0040CE Net-source
+004080 Athenix
+0040BB Goldstar Cable
+0040B1 Codonics
+00402E Precision Software
+00C0CE CEI Systems & Engineering PTE
+00409B HAL Computer Systems
+004073 Bass Associates
+10005A IBM
+004005 ANI Communications
+004099 Newgen Systems
+0040E1 Marner International
+0080DD GMX/gimix
+0080B7 Stellar Computer
+008002 Satelcom (uk)
+00805C Agilis
+0080C7 Xircom
+0080E7 Lynwood Scientific DEV.
+008070 Computadoras Micron
+00808F C. Itoh Electronics
+000091 Anritsu
+000094 Asante Technologies
+000090 Microcom
+000047 Nicolet Instruments
+0000FB Rechner ZUR Kommunikation
+0000A3 Network Application Technology
+00008F Raytheon
+00007E Clustrix
+00000A Omron Tateisi Electronics
+000063 Barco Control Rooms Gmbh
+00004E Ampex
+0000C2 Information Presentation TECH.
+000034 Network Resources
+000049 Apricot Computers
+0000E2 Acer Technologies
+000097 EMC
+0000D4 Pure Data
+0000E1 Grid Systems
+000031 Qpsx Communications
+000044 Castelle
+000027 Japan Radio Company
+004049 Roche Diagnostics International
+004029 Compex
+008038 Data Research & Applications
+008090 Microtek International
+0080C3 Bicc Information Systems & SVC
+00805A Tulip Computers Internat'l B.V
+0080F0 Panasonic Communications
+008043 Networld
+0080B0 Advanced Information
+008066 Arcom Control Systems
+004051 Gracilis
+004064 KLA Instruments
+004028 Netcomm Limited
+004013 NTT Data COMM. Systems
+0040A0 Goldstar
+0040B2 Systemforschung
+004071 ATM Computer Gmbh
+0080F7 Zenith Electronics
+0080BF Takaoka Electric MFG.
+0080F6 Synergy Microsystems
+00001F Telco Systems
+0000B4 Edimax Computer Company
+000058 Racore Computer Products
+000050 Radisys
+008082 PEP Modular Computers Gmbh
+008096 Human Designed Systems
+0080D5 Cadre Technologies
+00803E Synernetics
+00809A Novus Networks
+0080B3 Aval Data
+0080A3 Lantronix
+00803C TVS Electronics
+008061 Litton Systems
+0080AD Cnet Technology
+008081 Kendall Square Research
+008019 Dayna Communications
+00808B Dacoll Limited
+008097 Centralp Automatismes
+0080FC Avatar
+008076 Mcnc
+008080 Datamedia
+0000E6 Aptor Produits DE Comm Indust
+000084 Supernet
+0000FF Camtec Electronics
+00007B Research Machines
+000056 DR. B. Struck
+0000BB Tri-data
+080025 Control Data
+080020 Oracle
+027001 Racal-datacom
+080006 Siemens AG
+08007E Amalgamated Wireless(aus)
+080075 Dansk Data Electronik
+080073 Tecmar
+080069 Silicon Graphics
+080061 Jarogate
+08005D Gould
+080051 Experdata
+08004E 3com Europe
+08004A Banyan Systems
+08004C Hydra Computer Systems
+080043 Pixel Computer
+08003A Orcatech
+080035 Microfive
+080036 Intergraph
+08002D Lan-tec
+000025 Ramtek
+00003A Chyron
+000077 Interphase
+000096 Marconi Electronics
+000076 Abekas Video System
+0000EA Upnod AB
+000074 Ricoh Company
+00006A Computer Consoles
+0000C4 Waters DIV. OF Millipore
+000006 Xerox
+0001C8 Thomas Conrad
+02E6D3 Nixdorf Computer
+00DD0E Ungermann-bass
+08008D Xyvision
+080059 A/S Mycron
+021C7C Perq Systems
+100000 Private
+080004 Cromemco Incorporated
+00DD07 Ungermann-bass
+00003E Simpact
+04E0C4 Triumph-adler AG
+040AE0 Xmit AG Computer Networks
+080016 Barrister Info SYS
+080012 Bell Atlantic Integrated SYST.
+0001C8 Conrad
+0000F9 Quotron Systems
+0000BF Symmetric Computer Systems
+000085 Canon
+000028 Prodigy Systems
+000012 Information Technology Limited
+080085 Elxsi
+00005B Eltec Elektronik AG
+000054 Schneider Electric
+0000A9 Network Systems
+000059 Hellige Gmbh
+000099 MTX
+0000E9 Isicad
+08003F Fred Koschara Enterprises
+080002 Bridge Communications
+08008B Pyramid Technology
+000002 Xerox
+84F6FA Miovision Technologies Incorporated
+CC3B3E Lester Electrical
+C05627 Belkin International
+88074B LG Electronics (Mobile Communications)
+4065A3 Sagemcom Broadband SAS
+00789E Sagemcom Broadband SAS
+44E9DD Sagemcom Broadband SAS
+10F681 vivo Mobile Communication
+B888E3 Compal Information (kunshan)
+002622 Compal Information (kunshan)
+001EEC Compal Information (kunshan)
+DC0EA1 Compal Information (kunshan)
+FC4596 Compal Information (kunshan)
+208984 Compal Information (kunshan)
+247C4C Herman Miller
+100723 Ieee Registration Authority
+ACDE48 Private
+00A085 Private
+180373 Dell
+F8B156 Dell
+1C4024 Dell
+F8BC12 Dell
+001B5B 2Wire
+002456 2Wire
+002351 2Wire
+00253C 2Wire
+0022A4 2Wire
+C0830A 2Wire
+D0431E Dell
+246E96 Dell
+204747 Dell
+4C7625 Dell
+B8AC6F Dell
+001EC9 Dell
+E09861 Motorola Mobility, a Lenovo Company
+F4F1E1 Motorola Mobility, a Lenovo Company
+74C99A Ericsson AB
+3C197D Ericsson AB
+60BEB5 Motorola Mobility, a Lenovo Company
+7845C4 Dell
+B4E1C4 Microsoft Mobile Oy
+D86C02 Huaqin Telecom Technology
+0019D2 Intel Corporate
+7C5CF8 Intel Corporate
+001E67 Intel Corporate
+001F3C Intel Corporate
+0022FA Intel Corporate
+001517 Intel Corporate
+00166F Intel Corporate
+A44E31 Intel Corporate
+6C8814 Intel Corporate
+F81654 Intel Corporate
+3413E8 Intel Corporate
+34E6AD Intel Corporate
+FCF8AE Intel Corporate
+648099 Intel Corporate
+002314 Intel Corporate
+4025C2 Intel Corporate
+8CA982 Intel Corporate
+D07E35 Intel Corporate
+685D43 Intel Corporate
+90E2BA Intel Corporate
+0026C7 Intel Corporate
+8086F2 Intel Corporate
+78FF57 Intel Corporate
+20934D Fujian Star-net Communication
+00AA00 Intel
+6CF37F Aruba Networks
+605BB4 AzureWave Technology
+9C0E4A Shenzhen Vastking Electronic
+ACE5F0 Doppler Labs
+00F28B Cisco Systems
+5414FD Orbbec 3D Technology International
+1C4BD6 AzureWave Technology
+94DBC9 AzureWave Technology
+40E230 AzureWave Technology
+00006E Artisoft
+A0F459 Fn-link Technology Limited
+0C6AE6 Stanley Security Solutions
+E874E6 ADB Broadband Italia
+00247B Actiontec Electronics
+689C5E AcSiP Technology
+0012CF Accton Technology
+0030D3 Agilent Technologies
+38229D ADB Broadband Italia
+002233 ADB Broadband Italia
+D4D184 ADB Broadband Italia
+34C3D2 Fn-link Technology Limited
+38E3C5 Taicang T&W Electronics
+D0E44A Murata Manufacturing
+9433DD Taco
+948815 Infinique Worldwide
+3010B3 Liteon Technology
+00005F Sumitomo Electric Industries
+0008F6 Sumitomo Electric Industries
+001802 Alpha Networks
+ECCD6D Allied Telesis
+74C246 Amazon Technologies
+F0272D Amazon Technologies
+00225F Liteon Technology
+0018A4 Arris Group
+001311 Arris Group
+0015A2 Arris Group
+001596 Arris Group
+0000CA Arris Group
+983B16 Ampak Technology
+402BA1 Sony Mobile Communications AB
+0025E7 Sony Mobile Communications AB
+D05162 Sony Mobile Communications AB
+94CE2C Sony Mobile Communications AB
+001A80 Sony
+0024BE Sony
+001620 Sony Mobile Communications AB
+0012EE Sony Mobile Communications AB
+20689D Liteon Technology
+446D57 Liteon Technology
+000F9F Arris Group
+0011AE Arris Group
+002040 Arris Group
+0015CE Arris Group
+001626 Arris Group
+00111A Arris Group
+00152F Arris Group
+000B06 Arris Group
+44EE02 MTI
+001C11 Arris Group
+001CC1 Arris Group
+001D6B Arris Group
+001E5A Arris Group
+001DBE Arris Group
+001371 Arris Group
+C8AA21 Arris Group
+2C9E5F Arris Group
+002495 Arris Group
+002642 Arris Group
+A4ED4E Arris Group
+0024A1 Arris Group
+002375 Arris Group
+001ADB Arris Group
+00149A Arris Group
+001A1B Arris Group
+001F7E Arris Group
+0026B6 Askey Computer
+B4EEB4 Askey Computer
+FCB4E6 Askey Computer
+F05C19 Aruba Networks
+C43DC7 Netgear
+000FB5 Netgear
+00095B Netgear
+F87394 Netgear
+70AAB2 BlackBerry RTS
+0026FF BlackBerry RTS
+406F2A BlackBerry RTS
+002557 BlackBerry RTS
+0024FE AVM GmbH
+745AAA Huawei Technologies
+7C1CF1 Huawei Technologies
+C0FFD4 Netgear
+405D82 Netgear
+803773 Netgear
+00264D Arcadyan Technology
+74A528 Huawei Technologies
+3C8AB0 Juniper Networks
+4C9614 Juniper Networks
+88E0F3 Juniper Networks
+2C2172 Juniper Networks
+7819F7 Juniper Networks
+5C5EAB Juniper Networks
+009069 Juniper Networks
+B0C69A Juniper Networks
+88A25E Juniper Networks
+001BC0 Juniper Networks
+30A220 ARG Telecom
+F4B52F Juniper Networks
+783E53 BSkyB
+4CF2BF Cambridge Industries(Group)
+70D931 Cambridge Industries(Group)
+00E063 Cabletron Systems
+E01D3B Cambridge Industries(Group)
+D476EA zte
+0040FB Cascade Communications
+F05A09 Samsung Electronics
+503275 Samsung Electronics
+28CC01 Samsung Electronics
+B46293 Samsung Electronics
+04FE31 Samsung Electronics
+845181 Samsung Electronics
+D831CF Samsung Electronics
+F8D0BD Samsung Electronics
+FCC734 Samsung Electronics
+E4B021 Samsung Electronics
+B0EC71 Samsung Electronics
+3CBBFD Samsung Electronics
+24F5AA Samsung Electronics
+2CAE2B Samsung Electronics
+C488E5 Samsung Electronics
+7C9122 Samsung Electronics
+E8B4C8 Samsung Electronics
+18895B Samsung Electronics
+E0DB10 Samsung Electronics
+E09971 Samsung Electronics
+6077E2 Samsung Electronics
+680571 Samsung Electronics
+6C2F2C Samsung Electronics
+5056BF Samsung Electronics
+000136 CyberTAN Technology
+F88E85 Comtrend
+300D43 Microsoft Mobile Oy
+6C2779 Microsoft Mobile Oy
+607EDD Microsoft Mobile Oy
+F88096 Elsys Equipamentos Eletrnicos Ltda
+E0B9E5 Technicolor
+002100 Gemtek Technology
+0CBF15 Genetec
+000B5D Fujitsu Limited
+F4CAE5 Freebox SAS
+5846E1 Baxter International
+00D0BD Lattice Semiconductor (LPA)
+001F3A Hon Hai Precision Ind.
+647BD4 Texas Instruments
+102EAF Texas Instruments
+CC8CE3 Texas Instruments
+B4EED4 Texas Instruments
+D08CB5 Texas Instruments
+001831 Texas Instruments
+0023D4 Texas Instruments
+3C2DB7 Texas Instruments
+40984E Texas Instruments
+3C7DB1 Texas Instruments
+505663 Texas Instruments
+B0B448 Texas Instruments
+F08261 Sagemcom Broadband SAS
+D084B0 Sagemcom Broadband SAS
+00FEC8 Cisco Systems
+0030C5 Cadence Design Systems
+EC2280 D-Link International
+047863 Shanghai Mxchip Information Technology
+24BA13 Riso Kagaku
+24DA11 NO NDA
+70CA4D Shenzhen lnovance Technology
+DCC0EB Assa Abloy Cte Picarde
+001735 Intel Wireless Network Group
+9CDFB1 Shenzhen Crave Communication
+5CF938 Apple
+3871DE Apple
+BC5436 Apple
+0CC731 Currant
+00142F Savvius
+2CDDA3 Point Grey Research
+24FD5B SmartThings
+2876CD Funshion Online Technologies
+F4F5D8 Google
+F4F5E8 Google
+F88FCA Google
+BCD1D3 Shenzhen Tinno Mobile Technology
+BC4434 Shenzhen Tinno Mobile Technology
+0041D2 Cisco Systems
+4CFB45 Huawei Technologies
+A4BA76 Huawei Technologies
+003676 Pace plc
+78E3B5 Hewlett Packard
+984BE1 Hewlett Packard
+68B599 Hewlett Packard
+0C47C9 Amazon Technologies
+0017E6 Texas Instruments
+0017E8 Texas Instruments
+9059AF Texas Instruments
+E0C79D Texas Instruments
+14D64D D-Link International
+C8BE19 D-Link International
+BCF685 D-Link International
+CCB255 D-Link International
+84C9B2 D-Link International
+DCD321 Humax
+CC4EEC Humax
+88C255 Texas Instruments
+DC330D Qingdao Haier TelecomLtd
+0080E1 STMicroelectronics SRL
+58DC6D Exceptional Innovation
+00092D HTC
+F8DB7F HTC
+E899C4 HTC
+28565A Hon Hai Precision Ind.
+40490F Hon Hai Precision Ind.
+7CB15D Huawei Technologies
+002269 Hon Hai Precision Ind.
+18686A zte
+0C0535 Juniper Systems
+E0885D Technicolor CH USA
+8CF228 Shenzhen Mercury Communication Technologies
+08EA44 Aerohive Networks
+78F882 LG Electronics (Mobile Communications)
+8851FB Hewlett Packard
+AC162D Hewlett Packard
+A0B3CC Hewlett Packard
+E4115B Hewlett Packard
+C8CBB8 Hewlett Packard
+9457A5 Hewlett Packard
+0001E7 Hewlett Packard
+080009 Hewlett Packard
+0080A0 Hewlett Packard
+D48564 Hewlett Packard
+3C4A92 Hewlett Packard
+780AC7 Baofeng TV
+001D73 Buffalo.inc
+001601 Buffalo.inc
+106F3F Buffalo.inc
+8857EE Buffalo.inc
+009C02 Hewlett Packard
+78E7D1 Hewlett Packard
+001B78 Hewlett Packard
+001E0B Hewlett Packard
+2C6E85 Intel Corporate
+00D0B7 Intel
+0015D1 Arris Group
+C005C2 Arris Group
+6455B1 Arris Group
+0002B3 Intel
+001111 Intel
+001320 Intel Corporate
+0012F0 Intel Corporate
+9049FA Intel Corporate
+C8348E Intel Corporate
+00508B Hewlett Packard
+784859 Hewlett Packard
+1458D0 Hewlett Packard
+5065F3 Hewlett Packard
+A0481C Hewlett Packard
+A01D48 Hewlett Packard
+001DD3 Arris Group
+E8892C Arris Group
+E83EFC Arris Group
+083E0C Arris Group
+8C09F4 Arris Group
+3CDFA9 Arris Group
+94B2CC Pioneer
+887F03 Comper Technology Investment Limited
+E06066 Sercomm
+0019E0 Tp-link Technologies
+0023CD Tp-link Technologies
+002719 Tp-link Technologies
+40169F Tp-link Technologies
+940C6D Tp-link Technologies
+74EA3A Tp-link Technologies
+90F652 Tp-link Technologies
+10FEED Tp-link Technologies
+C46E1F Tp-link Technologies
+50FA84 Tp-link Technologies
+F483CD Tp-link Technologies
+882593 Tp-link Technologies
+808917 Tp-link Technologies
+5C899A Tp-link Technologies
+A81B5A Guangdong Oppo Mobile Telecommunications
+E422A5 Plantronics
+1C994C Murata Manufacturing
+F02765 Murata Manufacturing
+507224 Texas Instruments
+D4970B Xiaomi Communications
+F48B32 Xiaomi Communications
+20A783 miControl GmbH
+005053 Cisco Systems
+00500F Cisco Systems
+048A15 Avaya
+44322A Avaya
+FC8399 Avaya
+00040D Avaya
+D842AC Shanghai Feixun Communication
+34CDBE Huawei Technologies
+D46AA8 Huawei Technologies
+5439DF Huawei Technologies
+4846FB Huawei Technologies
+200BC7 Huawei Technologies
+104780 Huawei Technologies
+88308A Murata Manufacturing
+44A7CF Murata Manufacturing
+0013E0 Murata Manufacturing
+748EF8 Brocade Communications Systems
+00E052 Brocade Communications Systems
+000480 Brocade Communications Systems
+000088 Brocade Communications Systems
+344B50 zte
+FCC897 zte
+9CD24B zte
+C864C7 zte
+D0154A zte
+001FE2 Hon Hai Precision Ind.
+001DD9 Hon Hai Precision Ind.
+0016CE Hon Hai Precision Ind.
+0014A4 Hon Hai Precision Ind.
+D02788 Hon Hai Precision Ind.
+300ED5 Hon Hai Precision Ind.
+543530 Hon Hai Precision Ind.
+90489A Hon Hai Precision Ind.
+88E3AB Huawei Technologies
+00664B Huawei Technologies
+68A0F6 Huawei Technologies
+5CF96A Huawei Technologies
+B43052 Huawei Technologies
+88CEFA Huawei Technologies
+582AF7 Huawei Technologies
+F48E92 Huawei Technologies
+40CBA8 Huawei Technologies
+087A4C Huawei Technologies
+D46E5C Huawei Technologies
+2469A5 Huawei Technologies
+C8D15E Huawei Technologies
+F83DFF Huawei Technologies
+308730 Huawei Technologies
+002568 Huawei Technologies
+D47856 Avaya
+C057BC Avaya
+38BB3C Avaya
+E45D52 Avaya
+A4251B Avaya
+6CA849 Avaya
+30D17E Huawei Technologies
+9C28EF Huawei Technologies
+7C6097 Huawei Technologies
+60DE44 Huawei Technologies
+3400A3 Huawei Technologies
+643E8C Huawei Technologies
+0012D1 Texas Instruments
+70FF76 Texas Instruments
+B4994C Texas Instruments
+00C610 Apple
+70DEE2 Apple
+182032 Apple
+6CC26B Apple
+1040F3 Apple
+FC253F Apple
+183451 Apple
+C0847A Apple
+64200C Apple
+74E1B6 Apple
+0C771A Apple
+00F4B9 Apple
+C8334B Apple
+B8F6B1 Apple
+C09F42 Apple
+189EFC Apple
+6C3E6D Apple
+0016FE Alps Electric
+0498F3 Alps Electric
+38C096 Alps Electric
+E0750A Alps Electric
+B05947 Shenzhen Qihu Intelligent Technology Company Limited
+00E04F Cisco Systems
+001011 Cisco Systems
+0010F6 Cisco Systems
+80E01D Cisco Systems
+80E86F Cisco Systems
+E4AA5D Cisco Systems
+000389 Plantronics
+0CE0E4 Plantronics
+B0AA77 Cisco Systems
+78BAF9 Cisco Systems
+0016B6 Cisco-Linksys
+0018F8 Cisco-Linksys
+00252E Cisco Spvtg
+A4A24A Cisco Spvtg
+602AD0 Cisco Spvtg
+001BFB Alps Electric
+00E08F Cisco Systems
+203A07 Cisco Systems
+34A84E Cisco Systems
+E4D3F1 Cisco Systems
+1CE6C7 Cisco Systems
+E02F6D Cisco Systems
+8478AC Cisco Systems
+4403A7 Cisco Systems
+6886A7 Cisco Systems
+B4E9B0 Cisco Systems
+000832 Cisco Systems
+B0FAEB Cisco Systems
+500604 Cisco Systems
+70105C Cisco Systems
+7CFADF Apple
+101C0C Apple
+001124 Apple
+001D4F Apple
+001E52 Apple
+001F5B Apple
+001FF3 Apple
+0021E9 Apple
+00236C Apple
+002500 Apple
+60FB42 Apple
+14DAE9 Asustek Computer
+3C08F6 Cisco Systems
+D072DC Cisco Systems
+28C7CE Cisco Systems
+6CFA89 Cisco Systems
+58F39C Cisco Systems
+346288 Cisco Systems
+881DFC Cisco Systems
+F81EDF Apple
+90840D Apple
+D8A25E Apple
+C8BCC8 Apple
+28E7CF Apple
+D89E3F Apple
+040CCE Apple
+A4D1D2 Apple
+406C8F Apple
+C067AF Cisco Systems
+64E950 Cisco Systems
+189C5D Cisco Systems
+000EA6 Asustek Computer
+0013D4 Asustek Computer
+002618 Asustek Computer
+00248C Asustek Computer
+0050A2 Cisco Systems
+0050F0 Cisco Systems
+00905F Cisco Systems
+00902B Cisco Systems
+00100B Cisco Systems
+00100D Cisco Systems
+001014 Cisco Systems
+649ABE Apple
+94E96A Apple
+AC293A Apple
+10417F Apple
+7014A6 Apple
+A8667F Apple
+D02598 Apple
+CC29F5 Apple
+802994 Technicolor CH USA
+6C709F Apple
+0C3E9F Apple
+34E2FD Apple
+609217 Apple
+8863DF Apple
+80E650 Apple
+006171 Apple
+90FD61 Apple
+5C97F3 Apple
+6C4008 Apple
+24A074 Apple
+F02475 Apple
+20A2E4 Apple
+5CF5DA Apple
+D4B8FF Home Control Singapore Pte
+28E14C Apple
+54E43A Apple
+C8E0EB Apple
+A88808 Apple
+907240 Apple
+0C4DE9 Apple
+D89695 Apple
+0C3021 Apple
+F0F61C Apple
+B03495 Apple
+848E0C Apple
+8C2DAA Apple
+444C0C Apple
+84FCFE Apple
+E48B7F Apple
+5C969D Apple
+A8FAD8 Apple
+949426 Apple
+E0F5C6 Apple
+AC6462 zte
+C08488 Finis
+68E8EB Linktel Technologies
+20C3A4 RetailNext
+780541 Queclink Wireless Solutions
+C02DEE Cuff
+54A3FA BQT Solutions (Australia)Pty
+30F772 Hon Hai Precision Ind.
+9023EC Availink
+7467F7 Zebra Technologoes
+3891D5 Hangzhou H3C Technologies, Limited
+90DFFB Homerider Systems
+3C831E CKD
+381C23 Hilan Technology
+E03676 Huawei Technologies
+8C99E6 TCT Mobile Limited
+3CB72B Plumgrid
+243184 Sharp
+24DA9B Motorola Mobility, a Lenovo Company
+3052CB Liteon Technology
+DCFE07 Pegatron
+B8B2EB Googol Technology (HK) Limited
+C40049 Kamama
+50A9DE Smartcom - Bulgaria AD
+54AB3A Quanta Computer
+8809AF Masimo
+E8DED6 Intrising Networks
+B844D9 Apple
+DC2B2A Apple
+8C10D4 Sagemcom Broadband SAS
+203D66 Arris Group
+B83A9D Five Interactive
+089B4B iKuai Networks
+3C7873 Airsonics
+BC5FF6 Shenzhen Mercury Communication Technologies
+C8F9C8 NewSharp Technology(SuZhou)Co
+3C5CC3 Shenzhen First Blue Chip Technology
+A8741D Phoenix Contact Electronics Gmbh
+F4C613 Alcatel-Lucent Shanghai Bell
+A4C138 Telink Semiconductor (Taipei)
+683E34 Meizu Technology
+48E244 Hon Hai Precision Ind.
+D8EFCD Nokia
+D404CD Arris Group
+EC0133 Trinus Systems
+1C56FE Motorola Mobility, a Lenovo Company
+7CA23E Huawei Technologies
+501AA5 GN Netcom A/S
+F09A51 Shanghai Viroyal Electronic Technology Company Limited
+9870E8 Innatech SDN BHD
+50DF95 Lytx
+584925 E3 Enterprise
+94F278 Elma Electronic
+E8BDD1 Huawei Technologies
+3481F4 SST Taiwan
+F4B8A7 zte
+58F102 BLU Products
+B869C2 Sunitec Enterprise
+2CC548 IAdea
+84DBFC Alcatel-Lucent
+307CB2 Anov France
+90D8F3 zte
+D84710 Sichuan Changhong Electric
+444CA8 Arista Networks
+FCE33C Huawei Technologies
+BC6A2F Henge Docks
+E4907E Motorola Mobility, a Lenovo Company
+48066A Tempered Networks
+1CF03E Wearhaus
+DCDB70 Tonfunk Systementwicklung und Service GmbH
+C47D46 Fujitsu Limited
+68EDA4 Shenzhen Seavo Technology
+B899B0 Cohere Technologies
+2CC5D3 Ruckus Wireless
+80C5E6 Microsoft
+D85DEF Busch-Jaeger Elektro GmbH
+10DF8B Shenzhen CareDear Communication Technology
+00A784 ITX security
+800184 HTC
+38FACA Skyworth Digital Technology(Shenzhen)
+44C69B Wuhan Feng Tian Information Network
+C02567 Nexxt Solutions
+B46D35 Dalian Seasky Automation;Ltd
+B89ACD Elite Optoelectronic(asia)co.
+241C04 Shenzhen Jehe Technology Development
+F8CFC5 Motorola Mobility, a Lenovo Company
+BCF811 Xiamen Dnake Technology
+A8827F Cibn Oriental Network(beijing)
+609C9F Brocade Communications Systems
+900A39 Wiio
+C4693E Turbulence Design
+1C8341 Hefei Bitland Information TechnologyLtd
+4011DC Sonance
+249EAB Huawei Technologies
+DC56E6 Shenzhen Bococom Technology
+5CA178 TableTop Media (dba Ziosk)
+A0B437 General Dynamics C4 Sysems
+702A7D EpSpot AB
+B8B3DC Derek (shaoguan) Limited
+347A60 Pace plc
+6C1E70 Guangzhou Ybds IT
+C8E130 Milkyway Group
+8833BE Ivenix
+34CC28 Nexpring,
+144146 Honeywell (China)
+F41563 F5 Networks
+C4EA1D Technicolor
+20E407 Spark srl
+887384 Toshiba
+584704 Shenzhen Webridge Technology
+1C14B3 Pinyon Technologies
+A0E4CB ZyXEL Communications
+749CE3 Art2Wave Canada
+B856BD ITT
+107873 Shenzhen Jinkeyi Communication
+7CC709 Shenzhen Rf-link Elec&technology.
+3C8C40 Hangzhou H3C Technologies, Limited
+0071C2 Pegatron
+D45556 Fiber Mountain
+F01E34 Orico Technologies
+74A063 Huawei Technologies
+A89008 Beijing Yuecheng Technology
+183864 Cap-tech International
+08D34B Techman Electronics (Changshu)
+C808E9 LG Electronics
+78ACBF Igneous Systems
+206274 Microsoft
+5CCCFF Techroutes Network Pvt
+844BB7 Beijing Sankuai Online Technology
+148F21 Garmin International
+3C6A9D Dexatek Technology
+14893E Vixtel Technologies Limted
+60F189 Murata Manufacturing
+74A34A Zimi
+98F5A9 Ohsung Electronics
+D89341 General Electric Global Research
+F4645D Toshiba
+30D587 Samsung Electronics
+B04519 TCT mobile
+1436C6 Lenovo Mobile Communication Technology
+04C09C Tellabs
+2C337A Hon Hai Precision Ind.
+844464 ServerU
+589B0B Shineway Technologies
+A48CDB Lenovo
+4062B6 Tele system communication
+3C2C94 HangZhou Delan Technology
+78312B zte
+C035C5 Prosoft Systems
+F8B2F3 Guangzhou Bosma Technology
+1C7D22 Fuji Xerox
+ACD1B8 Hon Hai Precision Ind.
+7C11CD QianTang Technology
+0492EE iway AG
+48A9D2 Wistron Neweb
+F02A23 Creative Next Design
+8C9109 Toyoshima Electric Technoeogy(Suzhou)
+307350 Inpeco SA
+E8CC18 D-Link International
+B09137 ISis ImageStream Internet Solutions
+745C9F TCT mobile
+3C1E13 Hangzhou Sunrise Technology
+B4A828 Shenzhen Concox Information Technology
+A41242 NEC Platforms
+404EEB Higher Way Electronic
+50BD5F Tp-link Technologies
+147590 Tp-link Technologies
+ECB907 CloudGenix
+5CF9F0 Atomos Engineering P/L
+F409D8 Samsung Electro Mechanics
+FCDBB3 Murata Manufacturing
+B8186F Oriental Motor
+1C9C26 Zoovel Technologies
+9C3583 Nipro Diagnostics
+C456FE Lava International
+B89BE4 ABB Power Systems Power Generation
+C0EEFB OnePlus Tech (Shenzhen)
+E00DB9 Private
+108A1B Raonix
+8CF813 Orange Polska
+B479A7 Samsung Electro Mechanics
+B8F317 iSun Smasher Communications Private Limited
+2442BC Alinco,incorporated
+C401CE Presition (2000)
+D01242 Bios
+50F43C Leeo
+B43934 Pen Generations
+C03896 Hon Hai Precision Ind.
+DCC622 Buheung System
+5C2BF5 Vivint
+6C0B84 Universal Global Scientific Industrial
+D062A0 China Essence Technology (Zhumadian)
+CC10A3 Beijing Nan Bao Technology
+2CA30E Power Dragon Development Limited
+4CF5A0 Scalable Network Technologies
+84E058 Pace plc
+084656 Veo-labs
+4488CB Camco Technologies NV
+5014B5 Richfit Information Technology
+CC3080 Vaio
+F82441 Yeelink
+6CBFB5 Noon Technology
+489D18 Flashbay Limited
+8CB094 Airtech I&C
+70F196 Actiontec Electronics
+6C6EFE Core Logic
+E4C62B Airware
+80F8EB RayTight
+94B40F Aruba Networks
+4C2C83 Zhejiang KaNong Network Technology
+BCC342 Panasonic System Networks
+E89606 testo Instruments (Shenzhen)
+CC3F1D Intesis Software SL
+902181 Shanghai Huaqin Telecom Technology
+600417 Posbank
+A44AD3 ST Electronics(Shanghai)
+2497ED Techvision Intelligent Technology Limited
+104E07 Shanghai Genvision Industries
+4C11BF Zhejiang Dahua Technology
+FCD5D9 Shenzhen Sdmc Technology
+007532 Inid BV
+A002DC Amazon Technologies
+907EBA Utek Technology (shenzhen)
+488244 Life Fitness / Div. of Brunswick
+A8F7E0 Planet Technology
+2C5BE1 Centripetal Networks
+D87EB1 x.o.ware
+4045DA Spreadtrum Communications (Shanghai)
+98BE94 IBM
+D4B43E Messcomp Datentechnik GmbH
+A8E539 Moimstone
+98F170 Murata Manufacturing
+04C991 Phistek
+581F67 Open-m technology limited
+BC25F0 3D Display Technologies
+7CE524 Quirky
+D85DFB Private
+7CC4EF Devialet
+94AEE3 Belden Hirschmann Industries (Suzhou)
+44666E Ip-line
+705B2E M2Communication
+0C8C8F Kamo Technology Limited
+F4FD2B Zoyi Company
+FCAA14 Giga-byte Technology
+50FEF2 Sify Technologies
+3CD9CE Eclipse WiFi
+C80210 LG Innotek
+702DD1 Newings Communication
+44746C Sony Mobile Communications AB
+F4F646 Dediprog Technology
+ECD9D1 Shenzhen TG-NET Botone Technology
+748F4D MEN Mikro Elektronik GmbH
+A47E39 zte
+0C63FC Nanjing Signway Technology
+ACA9A0 Audioengine
+A8A668 zte
+60E327 Tp-link Technologies
+E4D332 Tp-link Technologies
+A0DA92 Nanjing Glarun Atten Technology
+6828BA Dejai
+48D18E Metis Communication
+A49F85 Lyve Minds
+7CD30A Inventec
+3481C4 AVM GmbH
+885BDD Aerohive Networks
+085700 Tp-link Technologies
+888914 All Components Incorporated
+D8150D Tp-link Technologies
+A06518 Vnpt Technology
+748F1B MasterImage 3D
+F03A4B Bloombase
+E4121D Samsung Electronics
+D82A15 Leitner SpA
+C4291D Klemsan Elektrik Elektronik San.ve Tic.as.
+704E01 Kwangwon Tech
+848433 Paradox Engineering SA
+D4319D Sinwatec
+DC052F National Products
+CC398C Shiningtek
+6C5F1C Lenovo Mobile Communication Technology
+B42C92 Zhejiang Weirong Electronic
+FC1349 Global Apps
+8C41F2 RDA Technologies
+FC07A0 LRE Medical GmbH
+AC02CA HI Solutions
+F490CA Tensorcom
+2C534A Shenzhen Winyao Electronic Limited
+CC856C Shenzhen MDK Digital Technology
+60FFDD C.E. Electronics
+FCBBA1 Shenzhen Minicreate Technology
+50B695 Micropoint Biotechnologies
+B48547 Amptown System Company GmbH
+3C25D7 Nokia
+1889DF CerebrEX
+30A8DB Sony Mobile Communications AB
+CC9F35 Transbit Sp. z o.o.
+407875 Imbel - Industria de Material Belico do Brasil
+0C4F5A ASA-RT s.r.l.
+B4B542 Hubbell Power Systems
+54CDEE ShenZhen Apexis Electronic
+F8F005 Newport Media
+98C0EB Global Regency
+D4224E Alcatel Lucent
+28DEF6 bioMerieux
+88E8F8 Yong TAI Electronic (dongguan)
+2C073C Devline Limited
+7CE4AA Private
+1820A6 Sage
+BCF61C Geomodeling Wuxi Technology
+083F3E WSH GmbH
+6C09D6 Digiquest Electronics
+684898 Samsung Electronics
+8C569D Imaging Solutions Group
+A43A69 Vers
+387B47 Akela
+7CCD11 MS-Magnet
+94FBB2 Shenzhen Gongjin Electronics
+4CE1BB Zhuhai HiFocus Technology
+8CDE99 Comlab
+1088CE Fiberhome Telecommunication Tech.Co.
+FCF647 Fiberhome Telecommunication Tech.Co.
+2C9AA4 NGI SpA
+B46698 Zealabs srl
+283B96 Cool Control
+80D433 LzLabs GmbH
+085AE0 Recovision Technology
+BCEE7B Asustek Computer
+8C3AE3 LG Electronics
+FC09D8 Acteon Group
+0C1262 zte
+687CC8 Measurement Systems S. de R.L.
+F015A0 KyungDong One
+ECF72B HD Digital Tech
+D8B6D6 Blu Tether Limited
+847207 I&C Technology
+94DF4E Wistron InfoComm(Kunshan)Co.
+E0AEB2 Bender GmbH &amp;KG
+BC9889 Fiberhome Telecommunication Tech.Co.
+2C553C Gainspeed
+B43E3B Viableware
+F854AF ECI Telecom
+7C0623 Ultra Electronics
+2464EF CYG Sunri
+50B888 wi2be Tecnologia S/A
+B8C1A2 Dragon Path Technologies, Limited
+50ED78 Changzhou Yongse Infotech
+8CB7F7 Shenzhen UniStrong Science & Technology
+085240 EbV Elektronikbau- und Vertriebs GmbH
+80F25E Kyynel
+844F03 Ablelink Electronics
+94B9B4 Aptos Technology
+D0B523 Bestcare Cloucal
+783D5B Telnet Redes Inteligentes
+D0C42F Tamagawa Seiki
+5CFFFF Shenzhen Kezhonglong Optoelectronic Technology
+F0D3A7 CobaltRay
+20D390 Samsung Electronics
+847616 Addat s.r.o.
+D46867 Neoventus Design Group
+68692E Zycoo
+A875E2 Aventura Technologies
+38BF2F Espec
+182012 Aztech Associates
+34BE00 Samsung Electronics
+343111 Samsung Electronics
+0CBD51 TCT Mobile Limited
+C0F991 GME Standard Communications P/L
+14EDA5 Wachter GmbH Sicherheitssysteme
+E056F4 AxesNetwork Solutions
+385AA8 Beijing Zhongdun Security Technology Development
+FC3FAB Henan Lanxin Technology
+F8FF5F Shenzhen Communication Technology
+DCC422 Systembase Limited
+F4BD7C Chengdu jinshi communication
+C8F36B Yamato Scale
+6C90B1 SanLogic
+845C93 Chabrier Services
+D44C9C Shenzhen Yoobao Technologyltd
+A88D7B SunDroid Global limited.
+A03B1B Inspire Tech
+3C6E63 Mitron OY
+502E5C HTC
+20D21F Wincal Technology
+FC1E16 Ipevo
+6C4B7F Vossloh-Schwabe Deutschland GmbH
+0CCB8D Asco Numatics Gmbh
+2847AA Nokia
+682DDC Wuhan Changjiang Electro-Communication Equipment
+FCB0C4 Shanghai DareGlobal Technologies
+1C63B7 OpenProducts 237 AB
+A0A23C Gpms
+708D09 Nokia
+FCE1D9 Stable Imaging Solutions
+38B74D Fijowave Limited
+A0E5E9 enimai
+9CBB98 Shen Zhen RND Electronic
+345C40 Cargt Holdings
+34885D Logitech Far East
+B462AD raytest GmbH
+6064A1 RADiflow
+8079AE ShanDong Tecsunrise 
+2C7155 HiveMotion
+909916 Elvees Neotek Ojsc
+FC1BFF V-zug AG
+AC5036 Pi-Coral
+FC019E Vievu
+34AA8B Samsung Electronics
+F45F69 Matsufu Electronics distribution Company
+F4A294 Eagle World Development, Limited
+2CCD69 Aqavi.com
+947C3E Polewall Norge AS
+E0D1E6 Aliph dba Jawbone
+28C671 Yota Devices OY
+DC1792 Captivate Network
+7C8306 Glen Dimplex Nordic as
+84253F Silex Technology
+907A0A Gebr. Bode GmbH & KG
+306112 PAV GmbH
+A0C6EC Shenzhen Anyk Technology
+ECF35B Nokia
+C80258 ITW GSE ApS
+1001CA Ashley Butterworth
+246AAB IT-IS International
+28F532 ADD-Engineering BV
+FC4BBC Sunplus Technology
+142D8B Incipio Technologies
+CCE8AC Soyea Technology
+78D38D Hongkong Yunlink Technology Limited
+1C48F9 GN Netcom A/S
+744BE9 Explorer Hypertech
+B836D8 Videoswitch
+F835DD Gemtek Technology
+0CF019 Malgn Technology
+D46A91 Snap AV
+E8519D Yeonhab Precision
+00B78D Nanjing Shining Electric Automation
+68E166 Private
+60FEF9 Thomas & Betts
+78FE41 Socus networks
+083571 CASwell
+DCF755 Sitronik
+E42D02 TCT Mobile Limited
+ACCA8E ODA Technologies
+6405BE NEW Light LED
+E03E4A Cavanagh Group International
+D890E8 Samsung Electronics
+24C696 Samsung Electronics
+30766F LG Electronics
+6CB350 Anhui comhigher tech
+A42305 Open Networking Laboratory
+1C86AD MCT
+28D93E Telecor
+882364 Watchnet DVR
+A05B21 Envinet Gmbh
+50B8A2 ImTech Technologies,
+A41566 Wei Fang Goertek Electronics
+B04C05 Fresenius Medical Care Deutschland GmbH
+A0EC80 zte
+9046B7 Vadaro Pte
+1C08C1 Lg Innotek
+201D03 Elatec GmbH
+C06C6D MagneMotion
+74CA25 Calxeda
+181EB0 Samsung Electronics
+CCBD35 Steinel GmbH
+788DF7 Hitron Technologies.
+6CECA1 Shenzhen Clou Electronics
+D862DB Eno
+68DB67 Nantong Coship Electronics
+BCC6DB Nokia
+BC261D Hong Kong Tecon Technology
+888964 GSI Electronics
+4C82CF Echostar Technologies
+9CA577 Osorno Enterprises
+C0C3B6 Automatic Systems
+A8294C Precision Optical Transceivers
+D0EB03 Zhehua technology limited
+A0861D Chengdu Fuhuaxin Technology
+9498A2 Shanghai Listen Tech.ltd
+2CB693 Radware
+88685C Shenzhen ChuangDao & Perpetual Eternal Technology
+B4FE8C Centro Sicurezza Italia SpA
+D82916 Ascent Communication Technology
+6472D8 GooWi Technology,Limited
+84ACA4 Beijing Novel Super Digital TV Technology
+3C6FF7 EnTek Systems
+B838CA Kyokko Tsushin System
+380FE4 Dedicated Network Partners Oy
+847A88 HTC
+0808C2 Samsung Electronics
+5461EA Zaplox AB
+78324F Millennium Group
+F05DC8 Duracell Powermat
+48F925 Maestronic
+C0885B SnD Tech
+64C667 Barnes&Noble
+C47DCC Zebra Technologies
+64535D Frauscher Sensortechnik
+105F06 Actiontec Electronics
+841715 GP Electronics (HK)
+087999 AIM GmbH
+84C2E4 Jiangsu Qinheng
+C0B8B1 BitBox
+0C722C Tp-link Technologies
+B01408 Lightspeed International
+9CE635 Nintendo
+F8FEA8 Technico Japan
+A8154D Tp-link Technologies
+D05099 ASRock Incorporation
+78A106 Tp-link Technologies
+A49EDB AutoCrib
+282CB2 Tp-link Technologies
+D43A65 Igrs Engineering Lab
+10B9FE Lika srl
+D42751 Infopia
+A895B0 Aker Subsea
+5C20D0 Asoni Communication
+E0C3F3 zte
+30CDA7 Samsung Electronics ITS, Printer division
+104D77 Innovative Computer Engineering
+3C081E Beijing Yupont Electric Power Technology
+7CA15D GN ReSound A/S
+B4DD15 ControlThings Oy Ab
+3C86A8 Sangshin elecom .co
+FCDD55 Shenzhen WeWins wireless
+CC0DEC Cisco Spvtg
+68B094 Inesa Electron
+40E730 DEY Storage Systems
+A8D236 Lightware Visual Engineering
+6C8686 Technonia
+4432C8 Technicolor USA
+78521A Samsung Electronics
+84E714 Liang Herng Enterprise,Co.Ltd.
+303D08 Glintt TES
+9C541C Shenzhen My-power Technology
+90187C Samsung Electro Mechanics
+FC1F19 Samsung Electro-mechanics
+E496AE Altographics
+F80BD0 Datang Telecom communication terminal (Tianjin)
+48B9C2 Teletics
+D046DC Southwest Research Institute
+F8F082 Orion Networks International
+046E49 TaiYear Electronic Technology (Suzhou)
+08606E Asustek Computer
+BC39A6 Csun System Technology
+ECB541 Shinano E and Eltd.
+D40057 MC Technologies GmbH
+48B8DE Homewins Technology
+20D5BF Samsung Eletronics
+6CD032 LG Electronics
+1065CF Iqsim
+B877C3 Decagon Devices
+849DC5 Centera Photonics
+580943 Private
+547FA8 Telco Systems, S.r.o.
+5474E6 Webtech Wireless
+AC5D10 Pace Americas
+88F490 Jetmobile Pte
+E8A364 Signal Path International / Peachtree Audio
+D0D6CC Wintop
+101D51 ON-Q dba ON-Q Mesh Networks
+34C99D Eidolon Communications Technology
+8C4AEE Giga TMS
+F46DE2 zte
+04F8C2 Flaircomm Microelectronics
+0C93FB BNS Solutions
+38B5BD E.G.O. Elektro-Ger
+B85AF7 Ouya
+E0D9A2 Hippih aps
+B0C4E7 Samsung Electronics
+F0F669 Motion Analysis
+F0219D Cal-Comp Electronics & Communications Company
+F8D7BF REV Ritter GmbH
+00B56D David Electronics
+B461FF Lumigon A/S
+9038DF Changzhou Tiannengbo System
+CC593E Toumaz
+AC8D14 Smartrove
+18673F Hanover Displays Limited
+8CCDE8 Nintendo
+A00ABF Wieson Technologies
+2091D9 I'M SPA
+744D79 Arrive Systems
+C83D97 Nokia
+38192F Nokia
+141BF0 Intellimedia Systems
+E45614 Suttle Apparatus
+842BBC Modelleisenbahn GmbH
+E856D6 NCTech
+4088E0 Beijing Ereneben Information Technology Limited Shenzhen Branch
+1CF4CA Private
+F490EA Deciso
+942197 Stalmart Technology Limited
+AC9403 Envision Peripherals
+A865B2 Dongguan Yishang Electronic Technology, Limited
+60B982 RO.VE.R. Laboratories
+B46238 Exablox
+40704A Power Idea Technology Limited
+A40BED Carry Technology
+0CD996 Cisco Systems
+D82DE1 Tricascade
+C438D3 Tagatec
+547398 Toyo Electronics
+4C72B9 Pegatron
+E0AAB0 General Vision Electronics
+68B43A WaterFurnace International
+543968 Edgewater Networks
+C041F6 LG Electronics
+985E1B ConversDigital
+B8B7D7 2GIG Technologies
+1048B1 Beijing Duokan Technology Limited
+005D03 Xilinx
+24EE3A Chengdu Yingji Electronic Hi-tech
+F82285 Cypress Technology
+8482F4 Beijing Huasun Unicreate Technology
+0CC47E Eucast
+CCE798 My Social Stuff
+50724D BEG Brueck Electronic GmbH
+B898B0 Atlona
+1C66AA Samsung Electronics
+2C625A Finest Security Systems
+2074CF Shenzhen Voxtech
+34AF2C Nintendo
+ACBD0B Imac
+D8D27C Jema Energy
+10F3DB Gridco Systems
+B01203 Dynamics Hong Kong Limited
+7093F8 Space Monkey
+305D38 Beissbarth 
+FCD6BD Robert Bosch GmbH
+044A50 Ramaxel Technology (Shenzhen) limited company
+E42F26 Fiberhome Telecommunication Tech.Co.
+A4466B EOC Technology
+3CF392 Virtualtek.
+889676 TTC Marconi S.r.o.
+149FE8 Lenovo Mobile Communication Technology
+70B599 Embedded Technologies s.r.o.
+EC4C4D ZAO NPK RoTeK
+E8D483 Ultimate Europe Transportation Equipment Gmbh
+089E01 Quanta Computer
+ACD9D6 tci GmbH
+7493A4 Zebra Technologies
+9C0DAC Tymphany HK Limited
+8CD3A2 VisSim AS
+647657 Innovative Security Designs
+60455E Liptel s.r.o.
+944A09 BitWise Controls
+E8102E Really Simple Software
+D48CB5 Cisco Systems
+24A43C Ubiquiti Networks
+D41E35 Toho Electronics
+700BC0 Dewav Technology Company
+58C38B Samsung Electronics
+2CD444 Fujitsu Limited
+EC1A59 Belkin International
+60CBFB AirScape
+4C5427 Linepro Sp. z o.o.
+3CEAFB NSE AG
+3476C5 I-O Data Device
+407074 Life Technology (China)
+58BFEA Cisco Systems
+7C386C Real Time Logic
+D8AF3B Hangzhou Bigbright Integrated communications system
+78D34F Pace-O-Matic
+D857EF Samsung Electronics
+784405 Fujitu(hong Kong) Electronic
+C03F2A Biscotti
+5001BB Samsung Electronics
+F0FDA0 Acurix Networks LP
+44B382 Kuang-chi Institute of Advanced Technology
+344B3D Fiberhome Telecommunication Tech.Co.
+D80DE3 FXI Technologies AS
+1CE165 Marshal
+0CC0C0 Magneti Marelli Sistemas Electronicos Mexico
+AC40EA C&T Solution 
+BC8B55 NPP Eliks America DBA T&M Atlantic
+D8EB97 Trendnet
+202598 Teleview
+844915 vArmour Networks
+A04CC1 Helixtech
+1CB243 TDC A/S
+1C51B5 Techaya
+80DB31 Power Quotient International
+AC0142 Uriel Technologies SIA
+A007B6 Advanced Technical Support
+542A9C LSY Defense
+D487D8 Samsung Electronics
+F89955 Fortress Technology
+B827EB Raspberry Pi Foundation
+E88DF5 Znyx Networks
+48EA63 Zhejiang Uniview Technologies
+0CE5D3 DH electronics GmbH
+C47130 Fon Technology S.L.
+90CF7D Qingdao Hisense Electric
+48D7FF Blankom Antennentechnik Gmbh
+F47F35 Cisco Systems
+A0F419 Nokia
+BCC168 DinBox Sverige AB
+6CAE8B IBM
+A4F7D0 LAN Accessories
+D4EC0C Harley-Davidson Motor Company
+5C0A5B Samsung Electro-mechanics
+6CA96F TransPacket AS
+48ED80 daesung eltec
+A086EC Saehan Hitec
+BC4B79 SensingTek
+2818FD Aditya Infotech
+9003B7 Parrot
+E42C56 Lilee Systems
+50008C Hong Kong Telecommunications (HKT) Limited
+DCA8CF New Spin Golf
+34BA9A Asiatelco Technologies
+642DB7 Seungil Electronics
+008DDA Link One
+08B4CF Abicom International
+445F7A Shihlin Electric & Engineering
+28BA18 NextNav
+2C36F8 Cisco Systems
+AC3D05 Instorescreen Aisa
+F48E09 Nokia
+882012 LMI Technologies
+D443A8 Changzhou Haojie Electric
+BCB852 Cybera
+70D6B6 Metrum Technologies
+28D576 Premier Wireless
+6CE907 Nokia
+94DF58 IJ Electron
+8C0CA3 Amper
+28940F Cisco Systems
+5CEB4E R. Stahl HMI Systems Gmbh
+B8DAF7 Advanced Photonics
+2C36A0 Capisco Limited
+800A06 Comtec
+20FABB Cambridge Executive Limited
+1C0B52 Epicom S.A
+747E2D Beijing Thomson Citic Digital Technology
+E80C75 Syncbak
+18D66A Inmarsat
+C85645 Intermas France
+8C604F Cisco Systems
+74FF7D Wren Sound Systems
+380A94 Samsung Electronics
+2CC260 Ravello Systems
+30B216 Hytec Geraetebau GmbH
+34FC6F Alcea
+C0B357 Yoshiki Electronics Industry
+D8BF4C Victory Concept Electronics Limited
+C0DF77 Conrad Electronic SE
+C86000 Asustek Computer
+645299 The Chamberlain Group
+BC125E Beijing  WisVideo 
+C80718 TDSi
+B4944E WeTelecom
+345B11 EVI Heat AB
+988BAD Corintech
+4050E0 Milton Security Group
+C87CBC Valink
+409FC7 Baekchun I&C
+D4E33F Alcatel-Lucent
+C87D77 Shenzhen Kingtech Communication Equipment
+A078BA Pantech
+D4507A Ceiva Logic
+184617 Samsung Electronics
+9CC7D1 Sharp
+AC9CE4 Alcatel-Lucent Shanghai Bell
+00B9F6 Shenzhen Super Rich Electronics
+9C5C8D Firemax Indstria E Comrcio DE Produtos Eletrnicos  Ltda
+E01E07 Anite Telecoms  US.
+B06CBF 3ality Digital Systems GmbH
+20AA4B Cisco-Linksys
+080D84 GECO
+88E712 Whirlpool
+644BF0 CalDigit
+2838CF Gen2wave
+50FC30 Treehouse Labs
+70704C Purple Communications
+F47ACC SolidFire
+24BC82 Dali Wireless
+F80CF3 LG Electronics
+64C5AA South African Broadcasting
+64ED62 Woori Systems
+C4237A WhizNets
+8430E5 SkyHawke Technologies
+2C002C Unowhy
+0481AE Clack
+C09132 Patriot Memory
+A898C6 Shinbo
+006BA0 Shenzhen Universal Intellisys PTE
+502690 Fujitsu Limited
+B4211D Beijing GuangXin Technology
+E039D7 Plexxi
+FC946C Ubivelox
+38DE60 Mohlenhoff GmbH
+2839E7 Preceno Technology Pte.Ltd.
+28D997 Yuduan Mobile
+886B76 China Hopeful Group Hopeful Electric
+A0CF5B Cisco Systems
+18C451 Tucson Embedded Systems
+582EFE Lighting Science Group
+D826B9 Guangdong Coagent Electronics S &T
+F8D3A9 Axan Networks
+5CD4AB Zektor
+F8462D Syntec Incorporation
+58677F Clare Controls
+CCA374 Guangdong Guanglian Electronic TechnologyLtd
+50F61A Kunshan Jade Technologies
+20BBC6 Jabil Circuit Hungary
+2C9717 I.c.y.
+64E84F Serialway Communication Technology
+941D1C TLab West Systems AB
+40667A mediola - connected living AG
+64808B VG Controls
+7C6B52 Tigaro Wireless
+48C1AC Plantronics
+046D42 Bryston
+50CCF8 Samsung Electro Mechanics
+D0CF5E Energy Micro AS
+644D70 dSPACE GmbH
+807693 Newag SA
+FC1794 InterCreative
+181420 TEB SAS
+D03110 Ingenic Semiconductor
+AC81F3 Nokia
+94C6EB Nova Electronics
+10F9EE Nokia
+80971B Altenergy Power System
+1071F9 Cloud Telecomputers
+C47B2F Beijing JoinHope Image Technology
+18F650 Multimedia Pacific Limited
+704AAE Xstream Flow (Pty)
+9C934E Xerox
+3C26D5 Sotera Wireless
+FC2E2D Lorom IndustrialLTD.
+E84E06 Edup International (hk)
+B4C799 Zebra Technologies
+70B921 Fiberhome Telecommunication Technologies
+948FEE Hughes Telematics
+E8C320 Austco Communication Systems
+D8973B Artesyn Embedded Technologies
+008D4E Cjsc NII STT
+10C586 BIO Sound LAB
+E8BA70 Cisco Systems
+6473E2 Arbiter Systems
+00A1DE ShenZhen ShiHua Technology
+04E1C8 IMS Solues em Energia Ltda.
+E4DD79 En-Vision America
+60190C Rramac
+34A709 Trevil srl
+F80332 Khomp
+C40F09 Hermes electronic GmbH
+908D1D GH Technologies
+CCB55A Fraunhofer Itwm
+587521 Cjsc Rtsoft
+64D989 Cisco Systems
+44D3CA Cisco Systems
+24DAB6 Sistemas de Gestin Energtica S.A. de C.V
+B8F5E7 WayTools
+148A70 ADS GmbH
+FC0012 Toshiba Samsung Storage Technolgoy Korea 
+F44450 BND
+644346 GuangDong Quick Network Computer
+FCE892 Hangzhou Lancable Technology
+B8B42E Gionee Communication Equipment,Ltd.ShenZhen
+A84041 Dragino Technology, Limited
+686E23 Wi3
+DCF05D Letta Teknoloji
+D05A0F I-bt Digital
+9439E5 Hon Hai Precision Ind.
+7CDD20 Ioxos Technologies
+A0E9DB Ningbo FreeWings Technologies
+9C7BD2 Neolab Convergence
+900D66 Digimore Electronics
+980C82 Samsung Electro Mechanics
+48C862 Simo Wireless
+0CF3EE EM Microelectronic
+F0C27C Mianyang Netop Telecom Equipment
+BC35E5 Hydro Systems Company
+283410 Enigma Diagnostics Limited
+28CCFF Corporacion Empresarial Altra SL
+14B73D Archean Technologies
+A433D1 Fibrlink Communications
+84DE3D Crystal Vision
+B4AA4D Ensequence
+040A83 Alcatel-Lucent
+B42A39 Orbit Merret, spol. s r. o.
+B80B9D Ropex Industrie-elektronik Gmbh
+18AEBB Siemens Convergence Creators GmbH&Co.KG
+3891FB Xenox Holding BV
+50FAAB L-tek d.o.o.
+547F54 Ingenico
+A8E018 Nokia
+44AAE8 Nanotec Electronic GmbH & KG
+D8DF0D beroNet GmbH
+D8C068 Netgenetech.co.
+3C9157 Hangzhou Yulong Conmunication
+50E549 Giga-byte Technology
+A8FCB7 Consolidated Resource Imaging
+F87B8C Amped Wireless
+44D2CA Anvia TV Oy
+4C1A3A Prima Research And Production Enterprise
+AC0613 Senselogix
+CCF67A Ayecka Communication Systems
+200A5E Xiangshan Giant Eagle Technology Developing
+747818 ServiceAssure
+00BB8E HME
+C0A26D Abbott Point of Care
+205B2A Private
+18B430 Nest Labs
+F8769B Neopis
+08E672 Jebsee Electronics
+C89CDC Elitegroup Computer System
+58E476 Centron Communications Technologies Fujian
+B435F7 Zhejiang Pearmain Electronicsltd.
+0C6E4F PrimeVOLT
+685B36 Powertech Industrial
+983000 Beijing Kemacom Technologies
+F81D93 Longdhua(Beijing) Controls Technology
+CC5D4E ZyXEL Communications
+D0EB9E Seowoo
+8C5FDF Beijing Railway Signal Factory
+586D8F Cisco-Linksys
+14C21D Sabtech Industries
+74B00C Network Video Technologies
+C88439 Sunrise Technologies
+44E4D9 Cisco Systems
+0054AF Continental Automotive Systems
+EC7D9D MEI
+9C95F8 SmartDoor Systems
+D075BE Reno A&E
+7C6C39 Pixsys SRL
+9C5D95 VTC Electronics
+DC05ED Nabtesco 
+FC8329 Trei technics
+94E848 Fylde Micro
+AC5E8C Utillink
+549B12 Samsung Electronics
+CC7EE7 Panasonic AVC Networks Company
+BC99BC FonSee Technology
+986022 EMW
+80B32A Alstom Grid
+803457 OT Systems Limited
+B83D4E Shenzhen Cultraview Digital Technology,Ltd Shanghai Branch
+CCF3A5 Chi Mei Communication Systems
+143E60 Alcatel-Lucent
+C4242E Galvanic Applied Sciences
+6400F1 Cisco Systems
+04C5A4 Cisco Systems
+3CA72B MRV Communications (Networks)
+EC55F9 Hon Hai Precision Ind.
+F4D9FB Samsung Electronics
+584C19 Chongqing Guohong Technology Development Company Limited
+D0A311 Neuberger Gebudeautomation GmbH
+3C5A37 Samsung Electronics
+10A13B Fujikura Rubber
+F4E142 Delta Elektronika BV
+F00248 SmarteBuilding
+2CDD0C Discovergy GmbH
+40B2C8 Nortel Networks
+486B91 Fleetwood Group
+F43814 Shanghai Howell Electronic
+20AA25 Ip-net
+ECBBAE Digivoice Tecnologia em Eletronica Ltda
+DC2008 ASD Electronics 
+088DC8 Ryowa Electronics
+D491AF Electroacustica General Iberica
+D86BF7 Nintendo
+1CDF0F Cisco Systems
+34DF2A Fujikon Industrial,Limited
+C88447 Beautiful Enterprise
+C88B47 Nolangroup S.P.A con Socio Unico
+24BA30 Technical Consumer Products
+74D675 Wyma Tecnologia
+D01CBB Beijing Ctimes Digital Technology
+9481A4 Azuray Technologies
+BCE09D Eoslink
+346F92 White Rodgers Division
+8CDB25 ESG Solutions
+641A22 Heliospectra AB
+30142D Piciorgros GmbH
+E441E6 Ottec Technology GmbH
+10E2D5 Qi Hardware
+7CDA84 Dongnian Networks
+A036FA Ettus Research
+EC836C RM Tech
+C0C520 Ruckus Wireless
+6083B2 GkWare e.K.
+80D019 Embed
+D41296 Anobit Technologies
+B8FF6F Shanghai Typrotech TechnologyLtd
+DC9C52 Sapphire Technology Limited.
+68122D Special Instrument Development
+649B24 V Technology
+0475F5 Csst
+BC20BA Inspur (Shandong) Electronic Information
+249442 Open Road Solutions 
+E0F379 Vaddio
+B09AE2 Stemmer Imaging Gmbh
+CCD811 Aiconn Technology
+78D004 Neousys Technology
+78A051 iiNet Labs 
+58A76F iD
+44599F Criticare Systems
+3C2F3A Sforzato
+EC9233 Eddyfi NDT
+ECE90B Sistema Solucoes Eletronicas Ltda - Easytech
+A08C9B Xtreme Technologies
+607688 Velodyne
+980EE4 Private
+A4C0E1 Nintendo
+E828D5 Cots Technology
+08D5C0 Seers Technology
+8CB64F Cisco Systems
+6C33A9 Magicjack LP
+08B7EC Wireless Seismic
+BC71C1 XTrillion
+0C469D MS Sedco
+E0E8E8 Olive Telecommunication Pvt.
+0C3C65 Dome Imaging
+942053 Nokia
+D49C8E University of Fukui
+3C8BFE Samsung Electronics
+2CB0DF Soliton Technologies Pvt
+5CF3FC IBM
+D43D67 Carma Industries
+00BD27 Exar
+C8A729 SYStronics
+6C9CE9 Nimble Storage
+700258 01db-metravib
+D4E8B2 Samsung Electronics
+20FDF1 3com Europe
+389592 Beijing Tendyron
+705EAA Action Target
+0C8D98 TOP Eight IND
+30493B Nanjing Z-Com Wireless
+68DB96 Opwill Technologies
+00F860 PT. Panggung Electric Citrabuana
+FCEDB9 Arrayent
+44ED57 Longicorn
+38521A Alcatel-Lucent 7705
+C8A1B6 Shenzhen Longway Technologies
+641E81 Dowslake Microsystems
+88ACC1 Generiton
+785712 Mobile Integration Workgroup
+380A0A Sky-City Communication and Electronics Limited Company
+141BBD Volex
+78C6BB Innovasic
+DC4EDE Shinyei Technology
+888B5D Storage Appliance 
+F0F842 Keebox
+78A714 Amphenol
+F0DEF1 Wistron InfoComm (Kunshan)Co
+F450EB Telechips
+988EDD TE Connectivity Limerick
+98FC11 Cisco-Linksys
+180C77 Westinghouse Electric Company
+ACA016 Cisco Systems
+78E400 Hon Hai Precision Ind.
+E4AD7D SCL Elements
+40D40E Biodata
+7C051E Rafael
+58570D Danfoss Solar Inverters
+E47CF9 Samsung Electronics
+0C826A Wuhan Huagong Genuine Optics Technology
+5C0E8B Zebra Technologies
+38C7BA CS Services
+70D57E Scalar
+7866AE Ztec Instruments
+24AF4A Alcatel-Lucent-IPD
+78818F Server Racks Australia
+E0589E Laerdal Medical
+44D63D Talari Networks
+58FD20 Bravida Sakerhet AB
+9835B8 Assembled Products
+240B2A Viettel Group
+68E41F Unglaube Identech GmbH
+84F64C Cross Point BV
+206A8A Wistron InfoComm Manufacturing(Kunshan)Co.
+F80F41 Wistron InfoComm(ZhongShan)
+90513F Elettronica Santerno SpA
+7CA29B D.SignT GmbH & KG
+34AAEE Mikrovisatos Servisas UAB
+A40CC3 Cisco Systems
+34E0D7 Dongguan Qisheng Electronics Industrial
+40520D Pico Technology
+8C7CB5 Hon Hai Precision Ind.
+543131 Raster Vision
+90E0F0 Ieee 1722a Working Group
+1C6F65 Giga-byte Technology
+F0AD4E Globalscale Technologies
+903D5A Shenzhen Wision Technology Holding Limited
+609AA4 GVI Security
+F0ED1E Bilkon Bilgisayar Kontrollu Cih. Im.Ltd.
+24A937 Pure Storage
+348302 iFORCOM
+949C55 Alta Data Technologies
+389F83 OTN Systems N.V.
+8C541D LGE
+601283 Soluciones Tecnologicas para la Salud y el Bienestar SA
+003A9D NEC Platforms
+905446 TES Electronic Solutions
+DC7B94 Cisco Systems
+68234B Nihon Dengyo Kousaku
+18422F Alcatel Lucent
+A4BE61 EutroVision System
+E06290 Jinan Jovision Science & Technology
+A01859 Shenzhen Yidashi Electronics
+042234 Wireless Standard Extensions
+7812B8 Orantek Limited
+F0B6EB Poslab Technology
+FCCCE4 Ascon
+34862A Heinz Lackmann GmbH & KG
+842141 Shenzhen Ginwave Technologies
+B4ED54 Wohler Technologies
+544249 Sony
+24DBAD ShopperTrak RCT
+CC69B0 Global Traffic Technologies
+EC9B5B Nokia
+2872C5 Smartmatic
+B8A3E0 BenRui Technology
+B8F732 Aryaka Networks
+0CD502 Westell
+70828E OleumTech
+502A7E Smart electronic GmbH
+F0264C Dr. Sigrist AG
+3C1CBE Jadak
+506313 Hon Hai Precision Ind.
+A8995C aizo ag
+F445ED Portable Innovation Technology
+6C32DE Indieon Technologies Pvt.
+FCCF62 IBM
+D8E72B NetScout Systems
+B09074 Fulan Electronics Limited
+2CA835 RIM
+3CE5A6 Hangzhou H3C Technologies
+94F692 Geminico
+8C736E Fujitsu Limited
+30EFD1 Alstom Strongwish (Shenzhen)
+C835B8 Ericsson, EAB/RWI/K
+243C20 Dynamode Group
+70D5E7 Wellcore
+3CF72A Nokia
+FCE192 Sichuan Jinwangtong Electronic Science&Technology
+F8912A GLP German Light Products GmbH
+E02630 Intrigue Technologies
+8C9236 Aus.Linx Technology
+4012E4 Compass-EOS
+F8DC7A Variscite
+003A9C Cisco Systems
+E8E776 Shenzhen Kootion Technology
+702F97 Aava Mobile Oy
+9018AE Shanghai Meridian Technologies,
+0494A1 Catch THE Wind
+2C3427 Erco & Gener
+B42CBE Direct Payment Solutions Limited
+F47626 Viltechmeda UAB 
+EC4476 Cisco Systems
+9CEBE8 BizLink (Kunshan)
+88ED1C Cudo Communication
+B05B1F Thermo Fisher Scientific
+404A03 ZyXEL Communications
+743256 NT-ware Systemprg GmbH
+003AAF BlueBit
+C0BAE6 Application Solutions (Electronics and Vision)
+20BFDB DVL
+C87E75 Samsung Electronics
+889821 Teraon
+CC5076 Ocom Communications
+705812 Panasonic AVC Networks Company
+7C2CF3 Secure Electrans
+304174 Altec Lansing
+7830E1 UltraClenz
+FCFBFB Cisco Systems
+1C129D Ieee PES Psrc/sub
+B40832 TC Communications
+002720 New-sol COM
+00271C Mercury
+002712 MaxVision
+00270F Envisionnovation
+0026D7 KM Electornic Technology
+0026D1 S Squared Innovations
+0026CB Cisco Systems
+0026C4 Cadmos microsystems S.r.l.
+0026BE Schoonderbeek Elektronica Systemen
+0026B2 Setrix GmbH
+0026AC Shanghai Luster Teraband Photonic
+0026B1 Navis Auto Motive Systems
+0026A8 Daehap Hyper-tech
+0026A7 Connect SRL
+0026A1 Megger
+0026A2 Instrumentation Technology Systems
+00269B Sokrat
+002695 ZT Group Int'l
+00268F MTA SpA
+6C8CDB Otus Technologies
+B4417A ShenZhen Gongjin Electronics
+401597 Protect America
+60391F ABB
+A07332 Cashmaster International Limited
+7C7BE4 Z'sedai Kenkyusho
+40EF4C Fihonest communication
+24CF21 Shenzhen State Micro Technology
+04B3B6 Seamap (UK)
+10BAA5 Gana I&C
+586ED6 Private
+E09153 XAVi Technologies
+CC0080 Bettini SRL
+644BC3 Shanghai Woasis Telecommunications
+0CE709 Fox Crypto
+002709 Nintendo
+002703 Testech Electronics Pte
+0026FD Interactive Intelligence
+0026F6 Military Communication Institute
+0026F0 cTrixs International GmbH.
+0026EA Cheerchip Electronic Technology (ShangHai)
+0026E3 DTI
+0026DD Fival Science & Technology
+0026DE FDI Matelec
+7825AD Samsung Electronics
+54B620 Suhdol E&Cltd.
+C4AAA1 Summit Development, Spol.s r.o.
+78C40E H&D Wireless
+9C5B96 NMR
+E84ECE Nintendo
+E4FFDD Electron India
+F852DF VNL Europe AB
+1CF061 Scaps Gmbh
+A893E6 Jiangxi Jinggangshan Cking Communication Technology
+00267C Metz-Werke GmbH & KG
+002676 Commidt AS
+00266F Coordiwise Technology
+002670 Cinch Connectors
+002669 Nokia Danmark A/S
+002663 Shenzhen Huitaiwei Tech.
+00265D Samsung Electronics
+0025CD Skylane Optics
+0025C8 S-Access GmbH
+0025C7 altek
+0025C1 Nawoo Korea
+0025BA Alcatel-Lucent IPD
+0025B5 Cisco Systems
+0025AE Microsoft
+0025A8 Kontron (BeiJing) Technology
+0025A7 Comverge
+00262B Wongs Electronics
+002625 MediaSputnik
+00261E Qingbang Elec(sz)
+002619 FRC
+002612 Space Exploration Technologies
+00260B Cisco Systems
+00260C Dataram
+0025FF CreNova Multimedia
+002606 Raumfeld Gmbh
+0025F9 GMK electronic design GmbH
+0025A2 Alta Definicion Linceo S.L.
+002596 Gigavision srl
+00259B Beijing Pkunity Microsystems Technology
+002595 Northwest Signal Supply
+00258F Trident Microsystems
+00258B Mellanox Technologies
+002585 Kokuyo S&T
+00257B STJ  Electronics  PVT 
+002574 Kunimi Media Device
+00264F Krger &Gothe GmbH
+002648 Emitech
+002644 Thomson Telecom Belgium
+00263E Trapeze Networks
+002638 Xia Men Joyatech
+00263D MIA
+002631 Commtact
+00256F Dantherm Power
+002562 interbro
+002561 ProCurve Networking by HP
+00255C NEC
+002550 Riverbed Technology
+002555 Visonic Technologies 1993
+00254F Elettrolab Srl
+002518 Power Plus Communications AG
+002511 Elitegroup Computer System
+002513 CXP Digital BV
+00250C Enertrac
+002505 eks Engel GmbH & KG
+0024F9 Cisco Systems
+0024F2 Uniphone Telecommunication
+0024F4 Kaminario Technologies
+0024ED YT Elec.
+0024E6 In Motion Technology
+0024E1 Convey Computer
+0024DF Digitalbox Europe GmbH
+0024DA Innovar Systems Limited
+002549 Jeorich Tech.
+002538 Samsung Electronics,, Memory Division
+002542 Pittasoft
+002530 Aetas Systems
+002529 Comelit Group S.P.A
+002522 ASRock Incorporation
+00251D DSA Encore
+0025F5 DVS Korea,
+0025F0 Suga Electronics Limited
+0025EA Iphion BV
+0025E4 Omni-wifi
+0025E0 CeedTec Sdn Bhd
+0025DA Secura Key
+0025D9 DataFab Systems
+0025D4 Fortress Technologies
+002410 Nueteq Technology
+002409 The Toro Company
+002403 Nokia Danmark A/S
+002404 Nokia Danmark A/S
+0023F7 Private
+0023FD AFT Atlas Fahrzeugtechnik GmbH
+0023F6 Softwell Technology
+0023EC Algorithmix GmbH
+0023E7 Hinke A/S
+002387 ThinkFlood
+002381 Lengda Technology(Xiamen)
+002382 Lih Rong Electronic Enterprise
+00237B Whdi
+002372 More Star Industrial Group Limited
+0024CE Exeltech
+0024D3 Qualica
+0024C7 Mobilarm
+0024C2 Asumo
+0024BC HuRob
+0024B7 GridPoint
+0024AB A7 Engineering
+0024A6 Telestar Digital Gmbh
+00249A Beijing Zhongchuang Telecommunication Test
+00249F RIM Testing Services
+002487 Blackboard
+002498 Cisco Systems
+002485 ConteXtream
+002480 Meteocontrol GmbH
+002454 Samsung Electronics
+002448 SpiderCloud Wireless
+00244A Voyant International
+002449 Shen Zhen Lite Star Electronics Technology
+002443 Nortel Networks
+002439 Digital Barriers Advanced Technologies
+002479 Optec Displays
+00246D Weinzierl Engineering GmbH
+002474 Autronica Fire And Securirty
+002468 Sumavision Technologies
+002466 Unitron nv
+002461 Shin Wang Tech.
+00245C Design-Com Technologies
+00244F Asantron Technologies
+0023BB Schmitt Industries
+0023BA Chroma
+0023B5 Ortana
+0023A8 Marshall Electronics
+00239B Elster Solutions
+002396 Andes Technology
+002391 Maxian
+00238C Private
+002432 Neostar Technology
+002429 MK Master
+00241C FuGang Electronic (DG)
+002428 EnergyICT
+002416 Any Use
+0023E0 INO Therapeutics
+0023DA Industrial Computer Source (Deutschland)GmbH
+0023C8 Team-r
+0023C7 AVSystem
+0023C1 Securitas Direct AB
+0021DC Tecnoalarm S.r.l.
+0021E2 Creative Electronic GmbH
+0021D6 LXI Consortium
+0021CF The Crypto Group
+0021C9 Wavecom Asia Pacific Limited
+0021CA ART System
+0021C3 Cornell Communications
+002334 Cisco Systems
+00232E Kedah Electronics Engineering
+002329 DDRdrive
+002322 Kiss Teknical Solutions
+002325 Iolan Holding
+002319 Sielox
+002270 ABK North America
+002317 Lasercraft
+002310 LNC Technology
+002273 Techway
+002274 FamilyPhone AB
+00226F 3onedata Technology
+00226A Honeywell
+002260 Afreey
+002265 Nokia Danmark A/S
+00225B Teradici
+002256 Cisco Systems
+002255 Cisco Systems
+00224D Mitac International
+002252 Zoll Lifecor
+002246 Evoc Intelligent Technology
+002366 Beijing Siasun Electronic System
+00236B Xembedded
+002359 Benchmark Electronics ( Thailand ) Public Company Limited
+00235F Silicon Micro Sensors GmbH
+002353 F E T Elettronica snc
+002347 ProCurve Networking by HP
+00234C KTC AB
+002340 MiX Telematics
+00233A Samsung Electronics
+002339 Samsung Electronics
+002304 Cisco Systems
+0022FD Nokia Danmark A/S
+0022F3 Sharp
+0022EE Algo Communication Products
+0022E7 WPS Parking Systems
+0022E1 Zort Labs
+0022E2 Wabtec Transit Division
+0022DB Translogic
+0022A1 Huawei Symantec Technologies
+00229B AverLogic Technologies
+00229C Verismo Networks
+002295 SGM Technology for lighting spa
+00228E Tv-numeric
+002289 Optosecurity
+002282 8086 Consultancy
+00227C Woori SMT
+002279 Nippon Conlux
+00223C Ratio Entwicklungen Gmbh
+002236 Vector SP. Z O.O.
+002230 FutureLogic
+002229 Compumedics
+00221D Freegene Technology
+002224 Good Will Instrument
+002223 TimeKeeping Systems
+002216 Shibaura Vending Machine
+002217 Neat Electronics
+002211 Rohati Systems
+00220A OnLive
+002204 Koratek
+0021FF Cyfrowy Polsat SA
+0021FB LG Electronics
+0021F5 Western Engravers Supply
+0021EF Kapsys
+0021EE Full Spectrum
+0022CF Planex Communications
+0022D4 ComWorth
+0022CA Anviz Biometric Tech.
+0022C5 Inforson
+0022C0 Shenzhen Forcelink Electronic
+0022BB beyerdynamic GmbH & KG
+0022AE Mattel
+0022AD Telesis Technologies
+0022A8 Ouman Oy
+002132 Masterclock
+00212C SemIndia System Private Limited
+002131 Blynke
+00211F Shinsung Deltatech
+002120 Sequel Technologies
+002125 KUK JE Tong Shin
+002119 Samsung Electro-Mechanics
+002112 Wiscom System
+002109 Nokia Danmark A/S
+002108 Nokia Danmark A/S
+001FB9 Paltronics
+001FB7 WiMate Technologies
+001FB8 Universal Remote Control
+001FB2 Sontheim Industrie Elektronik GmbH
+001FAB I.S High Tech.inc
+001FA6 Stilo srl
+001FA1 Gtran
+001F9C Ledco
+00215E IBM
+002151 Millinet
+002152 General Satellite Research & Development Limited
+002157 National Datacast
+00214B Shenzhen Hamp Science & Technology
+002145 Semptian Technologies
+002144 SS Telecoms
+00213C AliphCom
+00213B Berkshire Products
+002190 Goliath Solutions
+002189 AppTech
+002184 Powersoft SRL
+002183 Vatech Hydro
+00217D Pyxis S.r.l.
+002177 W. L. Gore & Associates
+002176 YMax Telecom
+002171 Wesung TNC
+002164 Special Design Bureau for Seismic Instrumentation
+002103 GHI Electronics
+001FFA Coretree,
+001FF5 Kongsberg Defence & Aerospace
+001FF4 Power Monitors
+001FEE ubisys technologies GmbH
+001FE7 Simet
+001FDB Network Supply,
+001FD1 Optex
+001FCA Cisco Systems
+001FC5 Nintendo
+001FBE Shenzhen Mopnet Industrial
+001F62 JSC Stilsoft
+001F67 Hitachi
+001F55 Honeywell Security (China)
+001F56 Digital Forecast
+001F4F Thinkware
+001F48 Mojix
+001F43 Entes Elektronik
+001F8E Metris USA
+001F88 FMS Force Measuring Systems AG
+001F81 Accel Semiconductor
+001B58 ACE CAD Enterprise
+001F78 Blue Fox Porini Textile
+001F6E Vtech Engineering
+001F68 Martinsson Elektronik AB
+0021BD Nintendo
+0021BC Zala Computer
+0021B7 Lexmark International
+0021B0 Tyco Telecommunications
+0021AA Nokia Danmark A/S
+0021A4 Dbii Networks
+00219A Cambridge Visual Networks
+002196 Telsey 
+001E4B City Theatrical
+001E47 PT. Hariff Daya Tunggal Engineering
+001E41 Microwave Communication & Component
+001E3A Nokia Danmark A/S
+001E35 Nintendo
+001E2E Sirti
+001E27 SBN Tech
+001E28 Lumexis
+001DF2 Netflix
+001DEB Dinec International
+001DEC Marusys
+001DE6 Cisco Systems
+001DDA Mikroelektronika spol. s r. o.
+001DDF Sunitec Enterprise
+001DCC Hetra Secure Solutions
+001DC7 L-3 Communications Geneva Aerospace
+001DC0 Enphase Energy
+001ED8 Digital United
+001ED2 Ray Shine Video Technology
+001ED1 Keyprocessor
+001ECC Cdvi
+001EC5 Middle Atlantic Products
+001EC0 Microchip Technology
+001EBF Haas Automation
+001EB9 Sing Fai Technology Limited
+001EB2 LG innotek
+001F2E Triangle Research Int'l Pte
+001F2D Electro-Optical Imaging
+001F27 Cisco Systems
+001F20 Logitech Europe SA
+001F14 NexG
+001F1B RoyalTek Company
+001F0D L3 Communications - Telemetry West
+001F0E Japan Kyastem
+001E22 Arvoo Imaging Products BV
+001E1B Digital Stream Technology
+001E16 Keytronix
+001E15 Beech Hill Electronics
+001E11 Elelux International
+001E05 Xseed Technologies & Computing
+001E0C Sherwood Information Partners
+001DFE Palm
+001DF9 Cybiotronics (Far East) Limited
+001EAD Wingtech Group Limited
+001EA2 Symx Systems
+001EA7 Actiontec Electronics
+001EA1 Brunata a/s
+001E9B San-Eisha
+001E94 Supercom Technology
+001E8F Canon
+001E87 Realease Limited
+001E80 Last Mile
+001EFC JSC Massa-k
+001F01 Nokia Danmark A/S
+001F08 Risco
+001EF5 Hitek Automated
+001EFB Trio Motion Technology
+001EE9 Stoneridge Electronics AB
+001EEE ETL Systems
+001EE2 Samsung Electronics
+001E7B R.I.CO. S.r.l.
+001E76 Thermo Fisher Scientific
+001E6A Beijing Bluexon Technology
+001E71 MIrcom Group of Companies
+001E63 Vibro-Meter SA
+001E5E COmputime
+001E57 Alcoma, spol. s r.o.
+001E51 Converter Industry Srl
+001DB9 Wellspring Wireless
+001DB4 Kumho ENG
+001DAF Nortel
+001D9E Axion Technologies
+001DA3 SabiOso
+001D9D Artjoy International Limited
+001D45 Cisco Systems
+001D3E Saka Techno Science
+001D37 Thales-Panda Transportation System
+001D38 Seagate Technology
+001D32 Longkay Communication & Technology (Shanghai)
+001D2B Wuhan Pont Technology 
+001D1F Siauliu Tauro Televizoriai
+001D26 Rockridgesound Technology
+001D25 Samsung Electronics
+001D1A OvisLink
+001D7A Wideband Semiconductor
+001D74 Tianjin China-Silicon Microelectronics
+001D62 InPhase Technologies
+001D61 BIJ
+001D5B Tecvan Informtica Ltda
+001D54 Sunnic Technology & Merchandise
+001D4A Carestream Health
+001CE8 Cummins
+001CE4 EleSy JSC
+001CDD Cowbell Engineering
+001CDE Interactive Multimedia eXchange
+001CD8 BlueAnt Wireless
+001CD1 Waves Audio
+001CCB Forth Public Company Limited
+001CBE Nintendo
+001CC5 3Com
+001D0D Sony Computer Entertainment
+001D14 Speradtone Information Technology Limited
+001D08 Jiangsu Yinhe Electronics
+001D07 Shenzhen Sang Fei Consumer Communications
+001D01 Neptune Digital
+001CFA Alarm.com
+001CEE Sharp
+001CF5 Wiseblue Technology Limited
+001CB9 Kwang Sung Electronics
+001CAF Plato Networks
+001CB4 Iridium Satellite
+001C9F Razorstream
+001C9A Nokia Danmark A/S
+001C99 Shunra Software
+001C8C Dial Technology
+001C93 ExaDigm
+001C87 Uriver
+001C82 Genew Technologies
+001C1A Thomas Instrumentation
+001C0E Cisco Systems
+001C13 Optsys Technology
+001C07 Cwlinux Limited
+001C00 Entry Point
+001BF4 Kenwin Industrial(hk)
+001BEF Blossoms Digital Technology
+001BE2 AhnLab
+001C7D Excelpoint Manufacturing Pte
+001C73 Arista Networks
+001C78 Wyplay SAS
+001C6C Jabil Circuit (Guangzhou) Limited
+001C65 JoeScan
+001C67 Pumpkin Networks
+001C66 Ucamp
+001C60 CSP Frontier Technologies
+001C54 Hillstone Networks
+001C59 Devon IT
+001C4F Macab AB
+001C43 Samsung Electronics
+001C37 Callpod
+001C3C Seon Design
+001C30 Mode Lighting (UK
+001C2B Alertme.com Limited
+001C2A Envisacor Technologies
+001C29 Core Digital Electronics
+001C24 Formosa Wireless Systems
+001C1F Quest Retail Technology
+001D97 Alertus Technologies
+001D90 Emco Flow Systems
+001D84 Gateway
+001D67 Amec
+001D6E Nokia Danmark A/S
+001A93 Erco Leuchten Gmbh
+001A98 Asotel Communication Limited Taiwan Branch
+001A8E 3Way Networks
+001A89 Nokia Danmark A/S
+001A7D cyber-blue(HK)Ltd
+001A82 Proba Building Automation
+001A7C Hirschmann Multimedia
+001A78 ubtos
+001A7B Teleco
+001A71 Diostech
+001A6C Cisco Systems
+001A65 Seluxit
+001B7D CXR Anderson Jacobson
+001B71 Telular
+001B6A Powerwave Technologies Sweden AB
+001B65 China Gridcom
+001B5E BPL Limited
+001B57 Semindia Systems Private Limited
+001B46 Blueone Technology
+001B4B Sanion
+001BAD iControl Incorporated
+001BA6 intotech
+001BA1 mic AB
+001B93 JC Decaux SA DNT
+001B95 Video Systems SRL
+001B9A Apollo Fire Detectors
+001B94 T.E.M.A.
+001B8E Hulu Sweden AB
+001B89 Emza Visual Sense
+001B8A 2M Electronic A/S
+001B84 Scan Engineering Telecom
+001BD1 Sogestmatic
+001BD6 Kelvin Hughes
+001BCF Dataupia
+001BD0 Identec Solutions
+001BCA Beijing Run Technology Company
+001BC3 Mobisolution
+001BBE Icop Digital
+001BB4 Airvod Limited
+001BB9 Elitegroup Computer System
+001B14 Carex Lighting Equipment Factory
+001B0D Cisco Systems
+001B06 Ateliers R. Laumonier
+001B08 Danfoss Drives A/S
+001B01 Applied Radio Technologies
+001AF5 Pentaone.
+001AFA Welch Allyn
+001AF0 Alcatel - IPD
+001AE4 Medicis Technologies
+001AE9 Nintendo
+001ADD PePWave
+001AD1 Fargo
+001AD8 AlsterAero GmbH
+001ACA Tilera
+001ACC Celestial Semiconductor
+001AC5 BreakingPoint Systems
+001ABB Fontal Technology Incorporation
+001AC0 Joybien Technologies
+001A60 Wave Electronics
+001A55 ACA-Digital
+001A5A Korea Electric Power Data Network  (KDN)
+001A4E NTI AG / LinMot
+001A53 Zylaya
+001A42 Techcity Technology
+001A47 Agami Systems
+001A3B Doah Elecom
+001B3F ProCurve Networking by HP
+001B3A Sims
+001B33 Nokia Danmark A/S
+001B2C Atron Electronic Gmbh
+001B27 Merlin CSI
+001B25 Nortel
+001B20 TPine Technology
+001B19 Ieee I&M Society TC9
+001AB4 Ffei
+001AAF Blusens Technology
+001AA8 Mamiya Digital Imaging
+001A9F A-Link
+001AA6 Telefunken Radio Communication Systems GmbH &CO.KG
+00193F RDI technology(Shenzhen)
+001933 Strix Systems
+001938 UMB Communications
+00192D Nokia
+001921 Elitegroup Computer System
+001926 BitsGen
+001928 Siemens AG, Transportation Systems
+00190E Atech Technology
+001913 Chuang-Yi Network EquipmentLtd.
+001915 Tecom
+00191A Irlink
+001993 Changshu Switchgear MFG.,Ltd. (Former Changshu Switchgea
+001998 Sato
+00199D Vizio
+00198E Oticon A/S
+001980 Gridpoint Systems
+001987 Panasonic Mobile Communications
+00197B Picotest
+001968 Digital Video Networks(Shanghai)
+00196D Raybit Systems Korea
+00196F SensoPart GmbH
+001952 Acogito
+001957 Saafnet Canada
+001946 Cianet Industria e Comercio S/A
+001944 Fossil Partners
+001A2F Cisco Systems
+001A34 Konka Group
+001A36 Aipermon GmbH & KG
+001A25 Delta Dore
+001A17 Teak Technologies
+001A19 Computer Engineering Limited
+001A12 Essilor
+001A0B Bona Technology
+001A06 OpVista
+0018CD Erae Electronics Industry
+0018D2 High-Gain Antennas
+0018D7 Javad Navigation Systems
+0018D9 Santosha Internatonal
+0018C1 Almitec Informtica e Comrcio
+0018C8 Isonas
+0018BC ZAO NVP Bolid
+0018B5 Magna Carta
+0018B0 Nortel
+0018AE TVT
+001902 Cambridge Consultants
+001907 Cisco Systems
+0018FD Optimal Technologies International
+0018F1 Chunichi Denshi
+0018EA Alltec GmbH
+0018EC Welding Technology
+0018E5 Adhoco AG
+0018A2 XIP Technology AB
+0018A9 Ethernet Direct
+00189D Navcast
+001893 Shenzhen Photon Broadband Technology
+001898 Kingstate Electronics
+001891 Zhongshan General K-mate Electronics
+001885 Avigilon
+00188C Mobile Action Technology
+0019C8 AnyDATA
+0019C3 Qualitrol
+0019BE Altai Technologies Limited
+0019BC Electro Chance SRL
+0019B7 Nokia Danmark A/S
+0019A4 Austar Technology (hang zhou)
+0019A9 Cisco Systems
+0019AB Raycom
+0019B0 HanYang System
+0019FA Cable Vision Electronics
+0019FF Finnzymes
+0019EC Sagamore Systems
+0019F3 Cetis
+0019F8 Embedded Systems Design
+0019E5 Lynx Studio Technology
+0019E7 Cisco Systems
+0019CD Chengdu ethercom information technology
+0019D4 ICX Technologies
+0019D9 Zeutschel GmbH
+001823 Delta Electronics
+001817 D. E. Shaw Research
+00181E GDX Technologies
+001812 Beijing Xinwei Telecom Technology
+001806 Hokkei Industries
+00180B Brilliant Telecommunications
+001805 Beijing InHand Networking Technology
+0017B8 Novatron
+0017BD Tibetsystem
+0017B1 Acist Medical Systems
+0017AA elab-experience
+0017AC O'Neil Product Development
+0017A5 Ralink Technology
+0017A0 RoboTech srl
+00179B Chant Sincere
+00170F Cisco Systems
+001705 Methode Electronics
+00170A Inew Digital Company
+0016F9 Cetrta POT, D.o.o.
+0016F2 Dmobile System
+0016F7 L-3 Communications, Aviation Recorders
+0016E6 Giga-byte Technology
+00178F Ningbo Yidong Electronic
+001794 Cisco Systems
+00178D Checkpoint Systems
+00177C Smartlink Network Systems Limited
+001781 Greystone Data System
+001788 Philips Lighting BV
+00176C Pivot3
+001770 Arti Industrial Electronics
+001775 TTE Germany GmbH
+001760 Naito Densei Machida MFG.CO.
+001765 Nortel
+001767 Earforce AS
+00185A uControl
+00185F TAC
+001861 Ooma
+001866 Leutron Vision
+001853 Atera Networks
+00184E Lianhe Technologies
+001847 AceNet Technology
+00183B Cenits
+001840 3 Phoenix
+001842 Nokia Danmark A/S
+001825 Private
+00182A Taiwan Video & Monitor
+001836 Reliance Electric Limited
+001759 Cisco Systems
+001754 Arkino HiTOP Limited
+001746 Freedom9
+001748 Neokoros Brasil Ltda
+00174D Dynamic Network Factory
+001741 Defidev
+001733 SFR
+00173A Reach Systems
+00172E FXC
+001727 Thermo Ramsey Italia s.r.l.
+001722 Hanazeder Electronic GmbH
+00171B Innovation Lab
+001714 BR Controls Nederland bv
+001716 Qno Technology
+0017F4 Zeron Alliance
+0017F9 Forcom Sp. z o.o.
+001800 Unigrand
+0017ED WooJooIT
+0017D5 Samsung Electronics
+0017DA Spans Logic
+0017E1 Dacos Technologies
+0017C9 Samsung Electronics
+0017D0 Opticom Communications
+0017C4 Quanta Microsystems
+001880 Maxim Integrated Products
+00186D Zhenjiang Sapphire Electronic Industry
+001872 Expertise Engineering
+001874 Cisco Systems
+001879 dSys
+001686 Karl Storz Imaging
+00167F Bluebird Soft
+001681 Vector Informatik GmbH
+00167A Skyworth Overseas Dvelopment
+001674 EuroCB (Phils.)
+00166B Samsung Electronics
+00166D Yulong Computer Telecommunication Scientific(shenzhen)Co.
+001672 Zenway enterprise
+00166C Samsung Electonics Digital Video System Division
+001666 Quantier Communication
+00165F Fairmount Automation
+0016AA Kei Communication Technology
+0016AF Shenzhen Union Networks Equipment
+0016A5 Tandberg Storage ASA
+001699 Tonic DVB Marketing
+0016A0 Auto-Maskin
+001692 Scientific-Atlanta
+001694 Sennheiser Communications A/S
+00168D Korwin
+00165A Harman Specialty Group
+001653 Lego System A/S IE Electronics Division
+00164C Planet INT
+001647 Cisco Systems
+001642 Pangolin
+00163D Tsinghua Tongfang Legend Silicon Tech.
+001636 Quanta Computer
+001631 Xteam
+00162F Geutebrck GmbH
+001630 Vativ Technologies
+0015F5 Sustainable Energy Systems
+0015F4 Eventide
+0015EE Omnex Control Systems
+0015F3 Peltor AB
+0015E7 Quantec Tontechnik
+0015E2 Dr.Ing. Herbert Knauer GmbH
+0015DD IP Control Systems
+0015D8 Interlink Electronics
+0015CA TeraRecon
+001598 Kolektor group
+001593 U4EA Technologies
+00158C Liab ApS
+001586 Xiamen Overseas Chinese Electronic
+001585 Aonvision Technolopy
+001587 Takenaka Seisakusho
+001580 U-way
+00157B Leuze electronic GmbH + KG
+001576 LABiTec - Labor Biomedical Technologies GmbH
+00156A DG2L Technologies Pvt.
+00156F Xiranet Communications GmbH
+0016DF Lundinova AB
+0016DA Futronic Technology
+0016D5 Synccom
+0016C9 NAT Seattle
+0016D0 ATech elektronika d.o.o.
+0016BD ATI Industrial Automation
+0016C2 Avtec Systems
+0016BB Law-Chain Computer Technology
+00162A Antik computers & communications s.r.o.
+001623 Interval Media
+001617 MSI
+00161E Woojinnet
+00160D Be Here
+001606 Ideal Industries
+0015FA Cisco Systems
+001563 Cisco Systems
+001557 Olivetti
+00155C Dresser Wayne
+00154B Wonde Proud Technology
+001550 Nits Technology
+001545 Seecode
+00153E Q-Matic Sweden AB
+0015BC Develco
+0015B5 CI Network
+0015B0 Autotelenet
+0015AB PRO Sound
+0015A6 Digital Electronics Products
+00159F Terascala
+001532 Consumer Technologies Group
+001539 Technodrive srl
+00152B Cisco Systems
+00152D TenX Networks
+00152C Cisco Systems
+00151F Multivision Intelligent Surveillance (Hong Kong)
+001526 Remote Technologies
+00151A Hunter Engineering Company
+001515 Leipold+Co.GmbH
+001510 Techsphere
+001453 Advantech Technologies
+00144E Srisa
+001442 Atto
+001449 Sichuan Changhong Electric
+00143D Aevoe
+00143C Rheinmetall Canada
+00143B Sensovation AG
+001436 Qwerty Elektronik AB
+00142A Elitegroup Computer System
+0014AB Senhai Electronic Technology
+0014B0 Naeil Community
+0014B4 General Dynamics United Kingdom
+0014A9 Cisco Systems
+0014AA Ashly Audio
+00149D Sound ID
+001498 Viking Design Technology
+00148A Elin Ebg Traction Gmbh
+001491 Daniels Electronics dbo Codan Rado Communications
+001485 Giga-Byte
+001479 NEC Magnus Communications
+00147E InnerWireless
+001478 Shenzhen Tp-link Technologies
+001477 Nertec 
+001472 China Broadband Wireless IP Standard Group
+001466 Kleinhenz Elektronik GmbH
+00146B Anagran
+00145F Aditec
+001458 HS Automatic ApS
+0014E6 AIM Infrarotmodule GmbH
+0014E0 LET'S
+0014D4 K Technology
+0014D9 IP Fabrics
+0014CD DigitalZone
+0014C1 U.S. Robotics
+0014C6 Quixant
+0014BA Carvers SA de CV
+0014B5 Physiometrix
+0013C7 Ionos
+0013C0 Trix Tecnologia Ltda.
+0013B6 Sling Media
+0013AF Numa Technology
+0013B0 Jablotron
+0013AA ALS  & TEC
+0013A3 Siemens Com CPE Devices
+00139E Ciara Technologies
+001502 Beta Tech
+001509 Plus Technology
+0014FD Thecus Technology
+0014EF TZero Technologies
+0014F1 Cisco Systems
+0014F0 Business Security OL AB
+0014EA S Digm (Safe Paradigm)
+0014E5 Alticast
+001423 J-S Neurocom
+001419 Sidsa
+001412 S-TEC electronics AG
+00140D Nortel
+001409 Magneti Marelli   S.E.
+00140A Wepio
+0013FD Nokia Danmark A/S
+0013F8 Dex Security Solutions
+0013F1 Amod Technology
+0013F7 SMC Networks
+0013E7 Halcro
+0013DB Shoei Electric
+0013CC Tall Maple Systems
+001283 Nortel Networks
+001284 Lab33 Srl
+00127E Digital Lifestyles Group
+001277 Korenix Technologies
+001272 Redux Communications
+001271 Measurement Computing
+00126B Ascalade Communications Limited
+001264 daum electronic gmbh
+00125A Microsoft
+00125F Awind
+001255 NetEffect Incorporated
+00124E XAC Automation
+001247 Samsung Electronics
+001248 EMC (Kashya)
+001242 Millennial Net
+001236 ConSentry Networks
+00123B KeRo Systems ApS
+001368 Saab Danmark A/S
+00135C OnSite Systems
+001355 Tomen Cyber-business Solutions
+001356 Flir Radiation
+001350 Silver Spring Networks
+001344 Fargo Electronics
+001349 ZyXEL Communications
+001343 Matsushita Electronic Components (Europe) GmbH
+00133D Micro Memory Curtiss Wright
+001397 Oracle 
+00139D Marvell Hispana S.L.
+00138B Phantom Technologies
+001390 Termtek Computer
+001376 Tabor Electronics
+00137B Movon
+001382 Cetacea Networks
+001387 27M Technologies AB
+00136F PacketMotion
+001375 American Security Products
+001363 Verascape
+0012FA THX
+001301 IronGate S.L.
+001307 Paravirtual
+0012F5 Imarda New Zealand Limited
+0012EB PDH Solutions
+0012DE Radio Components Sweden AB
+0012DD Shengqu Information Technology (Shanghai)
+0012E4 Ziehl Industrie-electronik Gmbh + KG
+0012AF Elpro Technologies
+0012A8 intec GmbH
+0012A2 Vita
+0012A1 BluePacket Communications
+00129C Yulinet
+001290 Kyowa Electric & Machinery
+001295 Aiware
+00132A Sitronics Telecom Solutions
+001331 CellPoint Connect
+001336 Tianjin 712 Communication Broadcasting
+001324 Schneider Electric Ultra Terminal
+001314 Asiamajor
+001319 Cisco Systems
+00131A Cisco Systems
+00130D Galileo Avionica
+001308 Nuvera Fuel Cells
+00122F Sanei Electric
+001235 Andrew
+00122B Virbiage
+001212 Plus 
+001219 Ahead Communication Systems
+0012D8 International Games System
+0012CB CSS
+0012C5 V-Show  Technology (China)
+0012CC Bitatek
+0012B4 Work Microwave GmbH
+0012BB Telecommunications Industry Association TR-41 Committee
+001206 iQuest (NZ)
+00120B Chinasys Technologies Limited
+00120C CE-Infosys Pte
+0011FF Digitro Tecnologia Ltda
+0011FA Rane
+0011F9 Nortel Networks
+0011F0 Wideful Limited
+0011EF Conitec Datensysteme GmbH
+0011E9 Starnex
+001187 Category Solutions
+001182 IMI Norgren
+001181 InterEnergyLtd,
+00117B Bchi  Labortechnik AG
+001174 Wibhu Technologies
+00116F Netforyou
+001168 HomeLogic
+00115E ProMinent Dosiertechnik GmbH
+001157 Oki Electric Industry
+001158 Nortel Networks
+000FB2 Broadband Pacenet (India) Pvt.
+000FA5 BWA Technology GmbH
+000FB1 Cognio
+000FAC Ieee 802.11
+000F9C Panduit
+000FA0 Canon Korea Business Solutions
+000F97 Avanex
+000F8A WideView
+000F89 Winnertec System
+000F90 Cisco Systems
+000FD7 Harman Music Group
+000FD1 Applied Wireless Identifications Group
+000FD2 EWA Technologies
+000FC4 NST
+000FCB 3Com
+000FBF DGT Sp. z o.o.
+000FB8 CallURL
+0011DD Fromus TEC.
+0011E2 Hua Jung Components
+0011CF Thrane & Thrane A/S
+0011D6 HandEra
+0011D0 Tandberg Data ASA
+0011CA Long Range Systems
+0011C3 Transceiving System Technology
+0011B7 Octalix
+0011BE AGP Telecom
+0011BD Bombardier Transportation
+001105 Sunplus Technology
+00110C Atmark Techno
+000FF9 Valcretec
+000FFA Optinel Systems
+000FFF Control4
+000FF1 nex-G Systems Pte.Ltd
+000FE4 Pantech
+000FEA Giga-Byte Technology
+000FE3 Damm Cellular Systems A/S
+0011AB Trustable Technology
+0011B0 Fortelink
+0011A4 JStream Technologies
+001198 Prism Media Products Limited
+00119D Diginfo Technology
+00119E Solectron Brazil
+00118E Halytech Mace
+001193 Cisco Systems
+001152 Eidsvoll Electronics AS
+00114F US Digital Television
+001149 Proliphix
+001142 E-smartcom 
+00113D KN Soltec
+00113C Micronas GmbH
+001136 Goodrich Sensor Systems
+00112C IZT GmbH
+001130 Allied Telesis (Hong Kong)
+00111E Epsg (ethernet Powerlink Standardization Group)
+00111F Doremi Labs
+001112 Honeywell Cmss
+001118 BLX IC Design
+000F58 Adder Technology Limited
+000F52 York Refrigeration, Marine & Controls
+000F57 Cablelogic
+000F45 Stretch
+000F46 Sinar AG
+000F4B Oracle
+000F37 Xambala Incorporated
+000F3F Big Bear Networks
+000F3B Fuji System Machines
+000F31 Allied Vision Technologies Canada
+000F32 Lootom Telcovideo Network Wuxi
+000F2B Greenbell Systems
+000E98 HME Clear-Com
+000E93 Milnio 3 Sistemas Electrnicos
+000E8C Siemens AG A&D ET
+000E86 Alcatel North America
+000E80 Thomson Technology
+000E85 Catalyst Enterprises
+000E74 Solar Telecom. Tech
+000E79 Ample Communications
+000F24 Cisco Systems
+000F12 Panasonic Europe
+000F18 Industrial Control Systems
+000F11 Prodrive
+000F0C Synchronic Engineering
+000EFF Megasolution
+000F00 Legra Systems
+000F05 3B System
+000F7D Xirrus
+000F84 Astute Networks
+000F77 Dentum
+000F71 Sanmei Electronics
+000F78 Datacap Systems
+000F6A Nortel Networks
+000F65 icube
+000F5E Veo
+000E71 Gemstar Technology Development
+000E6C Device Drivers Limited
+000E65 TransCore
+000E5F activ-net GmbH & KG
+000E60 360SUN Digital Broadband
+000E52 Optium
+000E46 Niigata Seimitsu
+000E4D Numesa
+000E40 Nortel Networks
+000E3F Soronti
+000EC5 Digital Multitools
+000EB8 Iiga
+000EB7 Knovative
+000EBE B&B Electronics Manufacturing
+000EB2 Micro-Research Finland Oy
+000EAB Cray
+000EA5 Blip Systems
+000E9F Temic SDS Gmbh
+000E0A Sakuma Design Office
+000E12 Adaptive Micro Systems
+000E04 CMA/Microdialysis AB
+000DF7 Space Dynamics Lab
+000DFE Hauppauge Computer Works
+000E03 Emulex
+000DF1 Ionix
+000DEB CompXs Limited
+000DF2 Private
+000DE4 Diginics
+000EF9 REA Elektronik GmbH
+000EF2 Infinico
+000EED Nokia Danmark A/S
+000EE0 Mcharge
+000EDF PLX Technology
+000EE6 Adimos Systems
+000ECA Wtss
+000ED1 Osaka Micro Computer.
+000EDA C-tech United
+000ED6 Cisco Systems
+000E37 Harms & Wende GmbH &KG
+000E38 Cisco Systems
+000E31 Olympus Soft Imaging Solutions GmbH
+000E2A Private
+000E1E QLogic
+000E25 Hannae Technology
+000E18 MyA Technology
+000E17 Private
+000E0E ESA elettronica
+000C7E Tellium Incorporated
+000C86 Cisco Systems
+000C81 Schneider Electric (Australia) 
+000C72 Tempearl Industrial
+000C79 Extel Communications P/L
+000C66 Pronto Networks
+000C6B Kurz Industrie-Elektronik GmbH
+000C6D Edwards
+000DDF Japan Image & Network
+000DD2 Simrad Optronics ASA
+000DD1 Stryker
+000DD8 BBN
+000DCC Neosmart
+000DBF TekTone Sound & Signal Mfg.
+000DC0 Spagat AS
+000DC5 EchoStar Global B.V. 
+000DB9 PC Engines GmbH
+000D8C Shanghai Wedone Digital
+000D8B T&D
+000D85 Tapwave
+000D86 Huber + Suhner AG
+000D7E Axiowave Networks
+000D78 Engineering & Security
+000D77 FalconStor Software
+000D6B Mita-Teknik A/S
+000D65 Cisco Systems
+000D5F Minds
+000D66 Cisco Systems
+000CB1 Salland Engineering (Europe) BV
+000CB7 Nanjing Huazhuo Electronics
+000CBE Innominate Security Technologies AG
+000CC3 BeWAN systems
+000CB2 Union
+000CA5 Naman NZ
+000CAC Citizen Watch
+000C94 United Electronic Industries, (EUI)
+000C99 Hitel Link
+000CA0 StorCase Technology
+000C8D Matrix Vision Gmbh
+000C92 WolfVision Gmbh
+000D32 DispenseSource
+000D31 Compellent Technologies
+000D2C Patapsco Designs
+000D25 Sanden
+000D1F AV Digital
+000D19 Robe Show Lighting
+000D20 Asahikasei Technosystem
+000D0D ITSupported
+000D12 Axell
+000DB2 Ammasso
+000DAD Dataprobe
+000D9E Tokuden Ohizumi Seisakusyo
+000DA5 Fabric7 Systems
+000D99 Orbital Sciences; Launch Systems Group
+000D58 Private
+000D4C Outline Electronics
+000D53 Beijing 5w Communication
+000D3F VTI Instruments
+000D44 Audio BU - Logitech
+000D38 Nissin
+000CD1 Sfom Technology
+000CD6 Partner Tech
+000CDD AOS technologies AG
+000CCA Hgst a Western Digital Company
+000CC4 Tiptel AG
+000D00 Seaway Networks
+000D06 Compulogic Limited
+000CFA Digital Systems
+000CFF Mro-tek Limited
+000CED Real Digital Media
+000CEE jp-embedded
+000CF3 Call Image SA
+000CE7 MediaTek
+000CE3 Option International N.V.
+000B01 Daiichi Electronics
+000AF0 Shin-oh Electronics, R&D
+000AF5 Airgo Networks
+000AEC Koatsu Gas Kogyo
+000AE5 ScottCare
+000AE7 Eliop
+000AE0 Fujitsu Softek
+000AC8 Zpsys,ltd. (planning&management)
+000ACD Sunrich Technology Limited
+000AD4 CoreBell Systems
+000B5E Audio Engineering Society
+000B63 Kaleidescape
+000B55 ADInstruments
+000B5A HyperEdge
+000B52 Joymax Electronics
+000B4D Emuzed
+000B41 Ing. Bro Dr. Beutlhauser
+000B46 Cisco Systems
+000B33 Vivato Technologies
+000B3A QuStream
+000B3F Anthology Solutions
+000B95 eBet Gaming Systems
+000B8F Akita Electronics Systems
+000B89 Top Global Technology
+000B8E Ascent
+000B90 Adva Optical Networking
+000B7D Solomon Extreme International
+000B82 Grandstream Networks
+000B6F Media Streaming Networks
+000B76 ET&T Technology
+000AC1 Futuretel
+000AC6 Overture Networks.
+000AAE Rosemount Process Analytical
+000AB3 Fa. Gira
+000AB5 Digital Electronic Network
+000ABA Arcon Technology Limited
+000AA2 Systek
+000AA7 FEI Electron Optics
+000A8F Aska International
+000A94 ShangHai cellink
+000C4E Winbest Technology
+000C53 Private
+000C5A IBSmm Embedded Electronics Consulting
+000C5F Avtec
+000C47 SK Teletech(R&D Planning Team)
+000C4C Arcor AG&Co.
+000C3E Crest Audio
+000C37 Geomation
+000C2D FullWave Technology
+000C1A Quest Technical Solutions
+000C1E Global Cache
+000C23 Beijing Lanchuan Tech.
+000C0E XtremeSpectrum
+000C15 CyberPower Systems
+000C09 Hitachi IE Systems
+000BD3 cd3o
+000BC7 Icet
+000BCE Free2move AB
+000BC2 Corinex Communication
+000BBB Etin Systems
+000BC0 China Iwncomm
+000BAF Wooju Communications
+000BB4 RDC Semiconductor,
+000BA5 Quasar Cipta Mandiri
+000BAA Aiphone
+000B9E Yasing Technology
+000B27 Scion
+000B2E Cal-Comp Electronics (Thailand) Public Company Limited Taipe
+000B1B Systronix
+000B20 Hirata
+000B22 Environmental Systems and Services
+000B14 ViewSonic
+000B0D Air2U
+000B0F Bosch Rexroth
+000B08 Pillar Data Systems
+000AFC Core Tec Communications
+000BF6 Nitgen
+000BFB D-NET International
+000C02 ABB Oy
+000BEA Zultys Technologies
+000BEF Code
+000BE3 Key Stream
+000BE8 Aoip
+000BE9 Actel
+000BD7 Dorma Time + Access Gmbh
+000BDC Akcp
+000994 Cronyx Engineering
+000999 CP Georges Renault
+000987 Nishi Nippon Electric Wire & Cable
+000988 Nudian Electron
+00098D Velocity Semiconductor
+000981 Newport Networks
+000975 fSONA Communications
+00097A Louis Design Labs.
+000968 Technoventure
+000962 Sonitor Technologies AS
+000A9B TB Group
+000A9A Aiptek International
+000A80 Telkonet
+000A82 Tatsuta System Electronics
+000A87 Integrated Micromachines
+000A7B Cornelius Consult
+000A6D EKS Elektronikservice GmbH
+000A6F ZyFLEX Technologies
+000A74 Manticom Networks
+000A61 Cellinx Systems
+000A68 SolarFlare Communications
+0009BF Nintendo
+0009C3 Netas
+0009B9 Action Imaging Solutions
+0009BA Maku Informationstechik Gmbh
+0009AC Lanvoice
+0009B3 MCM Systems
+0009A7 Bang & Olufsen A/S
+00099A Elmo Company, Limited
+0009A0 Microtechno
+0009ED CipherOptics
+0009F2 Cohu,, Electronics Division
+0009E6 Cyber Switching
+0009E0 Xemics
+0009DA Control Module
+0009DF Vestel Komunikasyon Sanayi ve Ticaret A.S.
+0009CD Hudson Soft
+0009C7 Movistec
+0009CE SpaceBridge Semiconductor
+0009D3 Western DataCom
+000901 Shenzhen Shixuntong Information & Technoligy
+0008FC Gigaphoton
+0008F9 Artesyn Embedded Technologies
+0008F4 Bluetake Technology
+0008EB Romwin
+0008E4 Envenergy
+0008DF Alistel
+0008D8 Dowkey Microwave
+0008D2 Zoom Networks
+0008CC Remotec
+0008D1 Karel
+000967 Tachyon
+00096E Giant Electronics
+00095E Masstech Group
+000959 Sitecsoft
+00094D Braintree Communications
+000952 Auerswald GmbH & KG
+000946 Cluster Labs GmbH
+000940 Agfeo Gmbh & KG
+00093F Double-Win Enterpirse
+00093A Molex Fiber Optics
+000933 OphitLtd.
+000A5C Carel
+000A50 Remotek
+000A55 Markem
+000A4E Unitek Electronics
+000A42 Cisco Systems
+000A49 F5 Networks
+000A36 Synelec Telecom Multimedia
+000A3B GCT Semiconductor
+000A3D Elo Sistemas Eletronicos
+000A2F Artnix
+000927 Toyokeiki
+00092E B&Tech System
+000920 Epox Computer
+00091B Digital Generation
+000914 Computrols
+00090E Helix Technology
+000908 VTech Technology
+00090D Leader Electronics
+000A20 SVA Networks
+000A25 Ceragon Networks
+000A14 Teco a.s.
+000A19 Valere Power
+000A0D FCI Deutschland GmbH
+000A12 Azylex Technology
+0009F9 ART Japan
+0009FC Ipflex
+000A03 Endesa Servicios
+0006F4 Prime Electronics & Satellitics
+000705 Endress & Hauser GmbH
+0006F8 The Boeing Company
+0006FF Sheba Systems
+0006FD Comjet Information Systems
+0006E7 Bit Blitz Communications
+0006ED Inara Networks
+0006DC Syabas Technology (Amquest)
+0006E1 Techno Trade s.a
+0006E6 DongYang Telecom
+0006CF Thales Avionics In-Flight Systems
+0006D6 Cisco Systems
+0006D5 Diamond Systems
+0006C9 Technical Marketing Research
+0007B1 Equator Technologies
+0007B8 Corvalent
+0007B2 Transaccess
+0007A4 GN Netcom
+0007AA Quantum Data
+00079D Musashi
+00079E Ilinx
+000774 GuangZhou Thinker Technology
+000791 International Data Communications
+000798 Selea SRL
+000797 Netpower
+00078B Wegener Communications
+000785 Cisco Systems
+00077B Millimetrix Broadband Networks
+000856 Gamatronic Electronic Industries
+00082D Indus Teqsite Private Limited
+000821 Cisco Systems
+000814 TIL Technologies
+00081A Sanrad Intelligence Storage Communications (2000)
+00080F Proximion Fiber Optics AB
+000809 Systemonic AG
+000803 Cos Tron
+0007FF Gluon Networks
+0007F9 Sensaphone
+000894 InnoVISION Multimedia
+00088F Advanced Digital Technology
+000888 Oullim Information Technology
+000882 Sigma
+00087C Cisco Systems
+000875 Acorp Electronics
+000870 Rasvia Systems
+00086F Resources Computer Network
+000869 Command-e Technology
+000863 Entrisphere
+00085D Aastra
+000862 NEC Eluminant Technologies
+000850 Arizona Instrument
+000738 Young Technology
+00073F Woojyun Systec
+00072C Fabricom
+000733 Dancontrol Engineering
+000732 Aaeon Technology
+000716 J & S Marine
+00071B Cdvi Americas
+000722 The Nielsen Company
+00071C AT&T Fixed Wireless Services
+00070A Unicom Automation
+00070F Fujant
+000709 Westerstrand Urfabrik AB
+000702 Varian Medical Systems
+0006F3 AcceLight Networks
+0006C3 Schindler Elevator
+0006C8 Sumitomo Metal Micro Devices
+0006BF Accella Technologies
+0006B9 A5TEK
+0006B2 Linxtek
+0006AC Intersoft
+0006A6 Artistic Licence Engineering
+0006A2 Microtune
+000695 Ensure Technologies
+00069C Transmode Systems AB
+000696 Advent Networks
+0007F3 Thinkengine Networks
+0007EC Cisco Systems
+0007F2 IOA
+0007E6 edgeflow Canada
+0007E0 Palm
+0007D9 Splicecom
+0007DA Neuro Telecom
+0007D3 Spgprints
+0007CA Creatix Polymedia Ges Fur Kommunikaitonssysteme
+0007C4 Jean
+0007BE DataLogic SpA
+00077E Elrest GmbH
+00076F Synoptics Limited
+00076E Sinetica Limited
+00076A Nexteye
+00075E Ametek Power Instruments
+000765 Jade Quantum Technologies
+000764 YoungWoo Telecom
+000757 Topcall International AG
+000758 Dragonwave
+000752 Rhythm Watch
+00074B Daihen
+000745 Radlan Computer Communications
+0008C2 Cisco Systems
+0008BB NetExcell
+0008B5 TAI Guen Enterprise
+0008B6 RouteFree
+0008AF Novatec
+0008A9 SangSang Technology
+0008A8 Systec
+0008A3 Cisco Systems
+00089C Elecs Industry
+000690 Euracom Communication GmbH
+00068F Telemonitor
+000689 yLez Technologies Pte
+000683 Bravara Communications
+00D0B9 Microtek International
+00067D Takasago
+000675 Banderacom
+000679 Konami
+000663 Human Technology
+00066F Korea Data Systems
+000662 MBM Technology
+000669 Datasound Laboratories
+00055A Power Dsine
+00065C Malachite Technologies
+000610 Abeona Networks
+000616 Tel Net
+00060A Blue2space
+000604 @Track Communications
+00CBBD Cambridge Broadband Networks
+000603 Baker Hughes
+A06A00 Verilink
+0005EE Siemens AB, Infrastructure & Cities, Building Technologies Division, IC BT SSP SP BA PR
+0005F5 Geospace Technologies
+000601 Otanikeiki
+0005E8 TurboWave
+0005F4 System Base
+0005FB ShareGate
+0005DB PSI Nentec GmbH
+0005DF Electronic Innovation
+0005CF Thunder River Technologies
+0005C9 LG Innotek
+0005D5 Speedcom Wireless
+0005BC Resource Data Management
+0005C2 Soronti
+0005B0 Korea Computer Technology
+00059C Kleinknecht GmbH, Ing. Bro
+0005B6 Insys Microelectronics Gmbh
+0005A2 Celox Networks
+0005AC Northern Digital
+0004E5 Glonet Systems
+0004D9 Titan Electronics
+0004D3 Toyokeiki
+0004CC Peek Traffic
+0004C0 Cisco Systems
+0004C6 Yamaha Motor
+0004B9 S.I. Soubou
+0004BA KDD Media Will
+0004AF Digital Fountain
+0004B4 Ciac
+0004B3 Videotek
+0004A6 SAF Tehnika
+0004A0 Verity Instruments
+00050C Network Photonics
+000512 Zebra Technologies
+000506 Reddo Networks AB
+0004FC Stratus Computer (DE)
+0004F6 Amphus
+0004F5 SnowShore Networks
+0004E9 Infiniswitch
+0004F0 International Computers
+0004EF Polestar
+0004DF Teracom Telematica Ltda.
+000553 DVC Company
+000548 Disco
+00054D Brans Technologies
+000542 Otari
+00053C Xircom
+00052F Leviton Network Solutions
+00053B Harbour Networks, Beijing
+000535 Chip PC
+000529 Shanghai Broadan Communication Technology
+000523 AVL List GmbH
+000522 LEA*D
+00051C Xnet Technology
+000516 Smart Modular Technologies
+000650 Tiburon Networks
+000656 Tactel AB
+00062D TouchStar Technologies,
+000649 3M Deutschland GmbH
+000643 Sono Computer
+00064A Honeywell, (korea)
+00063F Everex Communications
+000639 Newtec
+000633 Cross Match Technologies GmbH
+000626 MWE GmbH
+00061D MIP Telecom
+000623 MGE UPS Systems France
+000589 National Datacomputer
+000595 Alesis
+00058F CLCsoft
+000596 Genotech
+00057D Sun Communications
+00057C RCO Security AB
+000583 ImageCom Limited
+000573 Cisco Systems
+000572 Deonet
+00056C Hung Chang
+000566 Secui.com
+000560 Leader Comm.co.
+000559 Intracom
+0004A5 Barco Projection Systems NV
+000499 Chino
+00048D Teo Technologies
+000493 Tsinghua Unisplendour
+000484 Amann GmbH
+00048A Temia Vertriebs GmbH
+00047A Axxessit ASA
+000474 Legrand
+00046E Cisco Systems
+000473 Photonex
+000467 Wuhan Research Institute of MII
+000461 Epox Computer
+0003D9 Secheron SA
+0003D2 Crossbeam Systems
+0003CD Clovertech
+0003CA MTS Systems
+0003C6 Icue Systems
+0003BF Centerpoint Broadband Technologies
+0003BA Oracle
+0003AF Paragea Communications
+0003B4 Macrotek International
+0003AC Fronius Schweissmaschinen
+0003A8 Idot Computers
+0003A1 Hiper Information & Communication
+000399 Dongju Informations & Communications
+00039C OptiMight Communications
+000390 Digital Video Communications
+000395 California Amplifier
+000380 SSH Communications Security
+000374 Control Microsystems
+0002F0 AME Optimedia Technology
+000379 Proscend Communications
+000371 Acomz Networks
+00036D Runtop
+0002E3 Lite-on Communications
+0002DE Astrodesign
+0002DB Netsec
+0002D7 Empeg
+0002D2 Workstation AG
+000223 ClickTV
+0002CB TriState
+0002C4 Vector International Bvba
+0002BF dotRocket
+0002BB Continuous Computing
+0002BC LVL 7 Systems
+0002B6 Acrosser Technology
+0002AF TeleCruz Technology
+0002AA PLcom
+00045B Techsan Electronics
+00044E Cisco Systems
+00044F Schubert System Elektronik Gmbh
+000454 Quadriga UK
+000445 LMS Skalar Instruments GmbH
+00044A iPolicy Networks
+000444 Western Multiplex
+00043E Telencomm
+000438 Nortel Networks
+000432 Voyetra Turtle Beach
+000437 Powin Information Technology
+00042B IT Access
+000361 Widcomm
+00035A Photron Limited
+000355 TeraBeam Internet Systems
+000353 Mitac
+00034F Sur-Gard Security
+00034A Rias
+000346 Hitachi Kokusai Electric
+000344 Tietech.Co.
+000343 Martin Professional A/S
+000334 Newport Electronics
+000337 Vaone
+00033C Daiden
+000329 F3
+000330 Imagenics,
+000321 Reco Research
+000324 Sanyo Consumer Electronics
+00031B Cellvision Systems
+0001A8 Welltech Computer
+00030F Digital China (Shanghai) Networks
+000314 Teleware Network Systems
+00030C Telesoft Technologies
+000308 AM Communications
+0002FC Cisco Systems
+000301 Exfo
+0002F9 Mimos Berhad
+0002F5 Vive Synergies
+0002EE Nokia Danmark A/S
+0002EA Focus Enhancements
+000269 Nadatel
+000265 Virditech
+00025E High Technology
+000261 Tilgin AB
+000259 Tsann Kuen China (Shanghai)Enterprise, IT Group
+000255 IBM
+000249 Aviv Infocom
+000250 Geyser Networks
+000242 Videoframe Systems
+000244 Surecom Technology
+00022C ABB Bomem
+00023A ZSK Stickmaschinen GmbH
+000425 Atmel
+000419 Fibercycle Networks
+00041A Ines Test and Measurement GmbH & CoKG
+000414 Umezawa Musen Denki
+000407 Topcon Positioning Systems
+0003F7 Plast-Control GmbH
+0003FE Cisco Systems
+0003FD Cisco Systems
+000401 Osaki Electric
+0003F0 Redfern Broadband Networks
+0003EB Atrica
+0003E5 Hermstedt SG
+0002A3 ABB Switzerland, Power Systems
+000298 Broadframe
+000292 Logic Innovations
+00028D Movita Technologies
+000283 Spectrum Controls
+000277 Cash Systemes Industrie
+00027C Trilithic
+000275 Smart Technologies
+000270 Crewave
+000104 Dvico
+000110 Gotham Networks
+00010C System Talks
+000113 Olympus
+000100 Equip'trans
+00B0AC Siae-microelettronica
+00B017 InfoGear Technology
+0030F0 Uniform Industrial
+00B0CE Technology Rescue
+00B080 Mannesmann Ipulsys
+00B09A Morrow Technologies
+00B091 Transmeta
+0030BE City-Net Technology
+000233 Mantra Communications
+00022F P-Cube
+000227 ESD Electronic System Design GmbH
+00021F Aculab PLC
+00021B Kollmorgen-Servotronix
+00020C Metro-Optix
+000218 Advanced Scientific
+000213 S.d.e.l.
+00020F Aatr
+0001F4 Enterasys Networks
+0001F9 TeraGlobal Communications
+000200 Net & Sys
+0001FC Keyence
+0001F3 QPS
+0001E4 Sitera
+0001EB C-COM
+0001F0 Tridium
+0001D4 Leisure Time
+0001D8 Teltronics
+0001C6 Quarry Technologies
+0001CC Japan Total Design Communication
+0001D1 CoNet Communications
+0001B3 Precision Electronic Manufacturing
+000160 Elmex
+00015E Best Technology
+000162 Cygnet Technologies
+000169 Celestix Networks Pte
+000175 Radiant Communications
+000159 S1
+000165 AirSwitch
+000171 Allied Data Technologies
+000157 Syswave
+000153 Archtek Telecom
+000144 EMC
+003038 XCP
+0030DB Mindready Solutions
+00306A Penta Media
+003021 Hsing TECH. Enterprise
+0030EA TeraForce Technology
+0030F4 Stardot Technologies
+003087 Vega Grieshaber KG
+003000 Allwell Technology
+003034 SET Engineering
+00308D Pinnacle Systems
+00304B Orbacom Systems
+0030FA Telica
+0001B1 General Bandwidth
+0001BB Frequentis
+0001B7 Centos
+0001AF Artesyn Embedded Technologies
+0001AB Main Street Networks
+000191 Syred Data Systems
+00019D E-Control Systems
+0001A4 Microlink
+000199 HeiSei Electronics
+0001A0 Infinilink
+00017C AG-E GmbH
+000188 Lxco Technologies ag
+000178 Margi Systems
+00018B NetLinks
+0030F5 Wild Lab.
+000184 Sieb & Meyer AG
+00303E Radcom
+0030D7 Innovative Systems,
+0030FC Terawave Communications
+00300F IMT - Information Management
+003004 Leadtek Research
+003018 Jetway Information
+003088 Ericsson
+0030CA Discovery Com
+00304F Planet Technology
+00014B Ennovate Networks
+00012C Aravox Technologies
+000138 XAVi Technologies
+000134 Selectron Systems AG
+00013B BNA Systems
+000147 Zhone Technologies
+00012B Telenet
+00011C Universal Talkware
+000123 Digital Electronics
+00011F RC Networks
+003045 Village Networks, (VNI)
+0030BB CacheFlow
+003053 Basler AG
+003072 Intellibyte
+0030B1 TrunkNet
+0030A7 Schweitzer Engineering
+00D086 Foveon
+00D05A Symbionics
+00D01A Urmet  TLC
+00D0F3 Solari DI Udine SPA
+00D089 Dynacolor
+00D08D Phoenix Group
+00D09C Kapadia Communications
+00D0FE Astral Point
+00D0DC Modular Mining Systems
+00D062 Digigram
+00D0A7 Tokyo Sokki Kenkyujo
+00D032 Yano Electric
+00D054 SAS Institute
+00D0EB Lightera Networks
+00D01E Pingtel
+00D0A9 Shinano Kenshi
+0030E9 GMA Communication Manufact'g
+003027 Kerbango
+0030F6 Securelogix
+0030B6 Cisco Systems
+0030B2 L-3 Sonoma EO
+0030D6 MSC Vertriebs Gmbh
+003008 Avio Digital
+00306D Lucent Technologies
+0030E4 Chiyoda System Riken
+00301A Smartbridges PTE.
+0030CD Conexant Systems
+003001 SMP
+0030E1 Network Equipment Technologies
+0050A7 Cisco Systems
+00D0EE Dictaphone
+00D0B8 Iomega
+005045 Rioworks Solutions
+00507C Videocon AG
+005065 TDK-Lambda
+0050C7 Private
+0050F4 Sigmatek Gmbh & KG
+005076 IBM
+005075 Kestrel Solutions
+005090 Dctri
+0050ED Anda Networks
+005096 Salix Technologies
+00509B Switchcore AB
+0050A9 Moldat Wireless Technolgies
+00503C Tsinghua Novel Electronics
+005030 Future Plus Systems
+005037 Koga Electronics
+00501F MRG Systems
+005092 Rigaku Osaka Plant
+00501C Jatom Systems
+00505C Tundo
+005068 Electronic Industries Association
+00501A IQinVision
+005063 OY Comsel System AB
+0050DE Signum Systems
+00507B Merlot Communications
+005078 Megaton House
+00508F Asita Technologies Int'l
+005057 Broadband Access Systems
+005087 Terasaki Electric
+00D03E Rocketchips
+00D03F American Communication
+00D033 Dalian Daxian Network
+00D0CE Asyst Electronic
+00D090 Cisco Systems
+00D0B6 Crescent Networks
+00D0D2 Epilog
+0050B6 Good WAY IND.
+0050FF Hakko Electronics
+005032 Picazo Communications
+0050DA 3com
+0050F9 Sensormatic Electronics
+0050F6 Pan-international Industrial
+00506C Beijer Electronics Products AB
+0050A5 Capitol Business Systems
+0050FC Edimax Technology
+005000 Nexo Communications
+00D071 Echelon
+00D066 Wintriss Engineering
+00D06F KMC Controls
+00D04B LA CIE Group
+00D060 Panasonic Europe
+00D002 Ditech
+00D0A6 Lanbird Technology
+00D0DE Philips Multimedia Network
+00D083 Invertex
+00D038 Fivemere
+00D00C Snijder Micro Systems
+00D0F2 Monterey Networks
+00D07B Comcam International
+00D05D Intelliworxx
+00D00D Micromeritics Instrument
+00D04C Eurotel Telecom
+00D0FD Optima Tele.com
+0030D8 Sitek
+003062 IP Video Networks
+003081 Altos C&C
+00D0B0 Bitswitch
+00D044 Alidian Networks
+00D004 Pentacom
+00D045 Kvaser AB
+00D0D0 Zhongxing Telecom
+2CD141 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+80E4DA Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+2C6A6F Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+1CCAE3 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+549A11 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+B8D812 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+1C21D1 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+7419F8 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+B437D1 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+BC3400 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+00902C Data & Control Equipment
+009049 Entridia
+009043 Tattile SRL 
+009076 FMT Aircraft Gate Support Systems AB
+009017 Zypcom
+00907B E-tech
+00102A ZF Microsystems
+00107D Aurora Communications
+00101C OHM Technologies INTL
+00106C Ednt Gmbh
+0010D4 Storage Computer
+0010BF InterAir Wireless
+001036 Inter-tel Integrated Systems
+001026 Accelerated Networks
+00104B 3com
+000629 IBM
+001004 THE Brantley Coile Company
+00103A Diamond Network Tech
+0010D8 Calista
+001031 Objective Communications
+00107E Bachmann Electronic Gmbh
+0010C0 ARMA
+001016 T.sqware
+00103D Phasecom
+0010C2 Willnet
+00107A AmbiCom
+0010C4 Media Global Links
+0010EB Selsius Systems
+0010FE Digital Equipment
+00102E Network Systems & Technologies PVT.
+0010C1 OI Electric
+00103E Netschools
+001049 ShoreTel
+00105E Spirent plc, Service Assurance Broadband
+005088 Amano
+0050A8 OpenCon Systems
+005062 Kouwell Electronics  **
+0050B1 Giddings & Lewis
+00500C e-Tek Labs
+005091 Netaccess
+005097 Mmc-embedded Computertechnik Gmbh
+0050AF Intergon
+0050EB Alpha-top
+0050BC Hammer Storage Solutions
+0090C3 Topic Semiconductor
+0090EC Pyrescom
+00903B TriEMS Research Lab
+009074 Argon Networks
+0090C1 Peco II
+0010D3 Grips Electronic Gmbh
+001087 Xstreamis PLC
+0010ED Sundance Technology
+001023 Network Equipment Technologies
+00104E Ceologic
+0010FB Zida Technologies Limited
+0010AD Softronics USB
+0010D5 Imasde Canarias
+0010E5 Solectron Texas
+00909D NovaTech Process Solutions
+009038 Fountain Technologies
+0090C5 Internet Magic
+0090AD Aspect Electronics
+009097 Sycamore Networks
+009008 HanA Systems
+0090D4 BindView Development
+009089 Softcom Microsystems
+0090C4 Javelin Systems
+009014 Rotork Instruments
+0090B5 Nikon
+0090C6 Optim Systems
+00909B Markem-imaje
+00905B Raymond AND LAE Engineering
+0090E8 Moxa Technologies
+0090A1 Flying Pig Systems/High End Systems
+0090FD CopperCom
+0090AC Optivision
+00902A Communication Devices
+009098 SBC Designs
+0090CF Nortel
+00900F Kawasaki Heavy Industries
+009036 ens
+0090E9 Janz Computer AG
+009032 Pelcombe Group
+0090B8 Rohde & Schwarz Gmbh & KG
+009058 Ultra Electronics, Command and Control Systems
+0090BE Ibc/integrated Business Computers
+009062 ICP Vortex Computersysteme Gmbh
+00108F Raptor Systems
+001089 WebSonic
+001086 Atto Technology
+001027 L-3 Communications East
+0010B8 Ishigaki Computer System
+00104C Teledyne LeCroy
+001001 Citel
+0010CF Fiberlane Communications
+001068 Comos Telecom
+001067 Ericsson
+0010F1 I-O
+001073 Technobox
+00E0C0 Seiwa Electric MFG.
+00E046 Bently Nevada
+00E015 Heiwa
+00E065 Optical Access International
+00E069 Jaycor
+00E05C Panasonic Healthcare
+00E087 LeCroy - Networking Productions Division
+00E049 Microwi Electronic Gmbh
+00E050 Executone Information Systems
+00E064 Samsung Electronics
+00E012 Pluto Technologies International
+00E0D8 Lanbit Computer
+00E02D InnoMediaLogic
+00E0A9 Funai Electric
+00E035 Artesyn Embedded Technologies
+00E060 Sherwood
+00E0A2 Microslate
+00E06C Ultra Electronics Limited (AEP Networks)
+00E0CE ARN
+00E091 LG Electronics
+00E05F e-Net
+00E02B Extreme Networks
+00E0C7 Eurotech SRL
+00E0C4 Horner Electric
+00E04D Internet Initiative Japan
+00607F Aurora Technologies
+00E039 Paradyne
+006091 First Pacific Networks
+006002 Screen Subtitling Systems
+006061 Whistle Communications
+0060BD Hubbell-pulsecom
+00E0A1 Hima Paul Hildebrandt Gmbh KG
+00E028 Aptix
+00E0F2 Arlotto Comnet
+00E020 Tecnomen OY
+00E0C5 Bcom Electronics
+00E0EE Marel HF
+00E0AC Midsco
+00E002 Crossroads Systems
+00E057 HAN Microtelecom.
+00E0F0 Abler Technology
+00E0B7 PI Group
+0010B1 For-a
+001041 Bristol Babcock
+0010F7 Iriichi Technologies
+0010E6 Applied Intelligent Systems
+00101E Matsushita Electronic Instruments
+0010F2 Antec
+0010BE March Networks
+006074 QSC Audio Products
+006058 Copper Mountain Communications
+00601B Mesa Electronics
+0060FF QuVis
+006056 Network Tools
+0060D8 Elmic Systems
+00607A DVS Gmbh
+006097 3com
+0060E3 Arbin Instruments
+00E0FD A-trend Technology
+00E0FB Leightronix
+00E0D3 Datentechnik Gmbh
+00E05E Japan Aviation Electronics Industry
+00E0E5 Cinco Networks
+00E0CF Integrated Device Technology
+00A0FD Scitex Digital Printing
+00A0F5 Radguard
+00A022 Centre FOR Development OF Advanced Computing
+00A087 Microsemi
+00A007 Apexx Technology
+00A066 ISA
+00A0AB Netcs Informationstechnik Gmbh
+00A0D8 Spectra - TEK
+00A01A Binar Elektronik AB
+00A0E8 Reuters Holdings PLC
+00A076 Cardware LAB
+00A0A3 Reliable Power Meters
+00A055 Data Device
+00A065 Symantec
+00A044 NTT IT
+006008 3com
+0060EF Flytech Technology
+006098 HT Communications
+0060F7 Datafusion Systems
+0060DE Kayser-Threde GmbH
+0060D0 Snmp Research Incorporated
+006079 Mainstream Data
+006020 Pivotal Networking
+0005A8 Wyle Electronics
+0060B7 Channelmatic
+0060A3 Continuum Technology
+006050 Internix
+0060E0 Axiom Technology
+0060A8 Tidomat AB
+00A056 Micropross
+00A051 Angia Communications.
+00A0A6 M.I. Systems
+00A0B0 I-O Data Device
+00A05F BTG Electronics Design BV
+00A094 Comsat
+00A010 Syslogic Datentechnik AG
+00A012 Telco Systems
+00A063 JRL Systems
+00A08F Desknet Systems
+00A0CC Lite-on Communications
+00A090 TimeStep
+00A0F7 V.I Computer
+00A09C Xyplex
+00A092 H. Bollmann Manufacturers
+00A04D EDA Instruments
+00A0DB Fisher & Paykel Production
+00A0A5 Teknor Microsysteme
+00A018 Creative Controllers
+00A09F Commvision
+00A06B DMS Dorsch Mikrosystem Gmbh
+006051 Quality Semiconductor
+00605E Liberty Technology Networking
+0060C6 DCS AG
+00609E ASC X3 - Information Technology Standards Secretariats
+006084 Digital Video
+00602D Alerton Technologies
+006093 Varian
+0060E2 Quest Engineering & Development
+00A039 Ross Technology
+00A06D Mannesmann Tally
+00608E HE Electronics, Technologie & Systemtechnik Gmbh
+0060F0 Johnson & Johnson Medical
+0060D2 Lucent Technologies Taiwan Telecommunications
+006077 Prisa Networks
+0060AB Larscom Incorporated
+0060E9 Atop Technologies
+00608B ConferTech International
+0060C3 Netvision
+00A0A0 Compact DATA
+00A0A4 Micros Systems
+00A024 3com
+00A08B Aston Electronic Designs
+00A0AA Spacelabs Medical
+00A04F Ameritec
+00A073 Com21
+00A084 Dataplex
+00A034 Axel
+00C0BC Telecom Australia/cssc
+00C0EF Abit
+00C03C Tower Tech S.r.l.
+00C061 Solectek
+00C074 Toyoda Automatic Loom
+00C07F Nupon Computing
+00C027 Cipher Systems
+00C025 Dataproducts
+00C022 Lasermaster Technologies
+00C0E6 Verilink
+00C05C Elonex PLC
+00C0C1 Quad/graphics
+00C091 Jabil Circuit
+00C002 Sercomm
+00C0F5 Metacomp
+00C042 Datalux
+00C089 Telindus Distribution
+00C09D Distributed Systems Int'l
+00C0A5 Dickens Data Systems
+00C0E3 Ositech Communications
+00C071 Areanex Communications
+00C0AF Teklogix
+00209F Mercury Computer Systems
+0020B7 Namaqua Computerware
+00201B Northern Telecom/network
+0020C0 Pulse Electronics
+00208D CMD Technology
+0020DD Cybertec
+0020BD Niobrara R &
+0020E6 Lidkoping Machine Tools AB
+002047 Steinbrecher
+0020B5 Yaskawa Electric
+002072 Worklink Innovations
+0020B8 Prime Option
+002092 Chess Engineering
+0020B9 Metricom
+00206B Konica Minolta Holdings
+0020FC Matrox
+00C003 Globalnet Communications
+00C0C3 Acuson Computed Sonography
+00C04D Mitec
+00C055 Modular Computing Technologies
+00C067 United Barcode Industries
+00C0B4 Myson Technology
+00C080 Netstar
+00C015 NEW Media
+00C09F Quanta Computer
+0070B3 Data Recall
+00E6D3 Nixdorf Computer
+00C083 Trace Mountain Products
+00C005 Livingston Enterprises
+00C064 General Datacomm IND.
+00C0C8 Micro Byte
+00C090 Praim S.r.l.
+00C011 Interactive Computing Devices
+00C0FD Prosum
+00C041 Digital Transmission Systems
+00C00F Quantum Software Systems
+00C076 I-data International A-S
+00C0C6 Personal Media
+00C03B Multiaccess Computing
+0020F4 Spectrix
+00204E Network Security Systems
+002027 Ming Fortune Industry
+0020ED Giga-byte Technology
+00200E Satellite Technology MGMT
+002096 Invensys
+0020BB ZAX
+00204D Inovis Gmbh
+002089 T3plus Networking
+00205F Gammadata Computer Gmbh
+002035 IBM
+0020E2 Information Resource Engineering
+002058 Allied Signal
+002081 Titan Electronics
+00201D Katana Products
+0020CF Test & Measurement Systems
+002043 Neuron Company Limited
+002018 CIS Technology
+002031 Tattile SRL 
+0020DE Japan Digital Laborat'yltd
+0020F7 Cyberdata
+0020EE Gtech
+00208C Galaxy Networks
+002063 Wipro Infotech
+0020DC Densitron Taiwan
+002078 Runtop
+002042 Datametrics
+0020F8 Carrera Computers
+00200C Adastra Systems
+0020C4 Inet
+00C099 Yoshiki Industrial
+00C0FC Elastic Reality
+00C0D0 Ratoc System
+00C07A Priva
+000701 Racal-datacom
+00C09C Hioki E.E.
+00C004 Japan Business Computerltd
+00C062 Impulse Technology
+000267 Node Runner
+002064 Protec Microsystems
+002032 Alcatel Taisel
+00207F Kyoei Sangyo
+002077 Kardios Systems
+002068 Isdyne
+00202A N.V. Dzine
+008006 Compuadd
+0080EF Rational
+0080C4 Document Technologies
+008095 Basic Merton Handelsges.m.b.h.
+008053 Intellicom
+008026 Network Products
+0080FE Azure Technologies
+008028 Tradpost (hk)
+0080B6 Themis Computer
+008058 Printer Systems
+0080C0 Penril Datacomm
+0080F5 Quantel
+00401D Invisible Software
+0040BD Starlight Networks
+00406D Lanco
+00404D Telecommunications Techniques
+0040A5 Clinicomp INTL.
+004059 Yoshida Kogyo K. K.
+004021 Raster Graphics
+004081 Mannesmann Scangraphic Gmbh
+00806C Cegelec Projects
+00404A West Australian Department
+00400A Pivotal Technologies
+004032 Digital Communications
+004042 N.a.t. Gmbh
+0040C2 Applied Computing Devices
+00403C Forks
+0040C4 Kinkei System
+0040D1 Fukuda Denshi
+004024 Compac
+0040B6 Computerm 
+00403F Ssangyong Computer Systems
+004003 Emerson Process Management Power & Water Solutions
+004090 Ansel Communications
+00409A Network Express
+0040DE Elsag Datamat spa
+004063 VIA Technologies
+00406C Copernique
+0040DF Digalog Systems
+004015 Ascom Infrasys AG
+008056 Sphinx Electronics Gmbh & KG
+008060 Network Interface
+00805E LSI Logic
+008093 Xyron
+00C05D L&N Technologies
+00C0E4 Siemens Building
+00C01B Socket Communications
+00C06E Haft Technology
+00406F Sync Research
+00401F Colorgraph
+0040CF Strawberry TREE
+0040F7 Polaroid
+004037 Sea-ilan
+0040CC Silcom Manuf'g Technology
+004052 Star Technologies
+00407A Societe D'exploitation DU Cnit
+004089 Meidensha
+00405A Goldstar Information & COMM.
+00404C Hypertec
+00C0EE Kyocera
+00C0CB Control Technology
+00C09A Photonics
+00C01A Corometrics Medical Systems
+00404B Maple Computer Systems
+004055 Metronix Gmbh
+004045 Twinhead
+00409D Digiboard
+00401A Fuji Electric
+0040B9 Macq Electronique SA
+0040C7 Ruby Tech
+004004 ICM
+004070 Interware
+008057 Adsoft
+00807A Aitech Systems
+0080AA Maxpeed
+00C0E7 Fiberdata AB
+00800A Japan Computer
+00806E Nippon Steel
+008010 Commodore International
+0080DA Bruel & Kjaer Sound & Vibration Measurement A/S
+0080E5 NetApp
+0080BC Hitachi Engineering
+008000 Multitech Systems
+0080A1 Microtest
+0080D0 Computer Peripherals
+00807D Equinox Systems
+008063 Hirschmann Automation and Control GmbH
+00608C 3com
+00804E Apex Computer Company
+00800E Atlantix
+00806F Onelan
+008098 TDK
+00809C Luxcom
+008065 Cybergraphic Systems
+008016 Wandel AND Goltermann
+0080E6 Peer Networks
+0080A2 Creative Electronic Systems
+0080E0 XTP Systems
+008050 Ziatech
+0000E0 Quadram
+000057 Scitex
+0000D6 Punch Line Holding
+0000C8 Altos Computer Systems
+000098 Crosscomm
+00007D Oracle
+0000A2 Bay Networks
+000038 CSS Labs
+000061 Gateway Communications
+000043 Micro Technology
+0000E7 Star Gate Technologies
+0000F3 Gandalf Data Limited
+000064 Yokogawa Electric
+00002C Autotote Limited
+00002A TRW - Sedd/inp
+0000F1 Magna Computer
+000083 Tadpole Technology PLC
+000020 Dataindustrier Diab AB
+00007A Dana Computer
+00007C Ampere Incorporated
+00008A Datahouse Information Systems
+000068 Rosemount Controls
+0000A8 Stratus Computer
+0000DF Bell & Howell PUB SYS DIV
+000062 Bull HN Information Systems
+0000AD Bruker Instruments
+0000D0 Develcon Electronics
+000093 Proteon
+008008 Dynatech Computer Systems
+0080FF SOC. DE Teleinformatique RTC
+000070 HCL Limited
+00008E Solbourne Computer
+0000DC Hayes Microcomputer Products
+000024 Connect AS
+000048 Seiko Epson
+008030 Nexus Electronics
+008022 Scan-optics
+000041 ICE
+00001E Telsist Industria Electronica
+00807B Artel Communications
+00802E Castle Rock Computing
+0080F9 Heurikon
+008005 Cactus Computer
+00801D Integrated Inference Machines
+008015 Seiko Systems
+008034 SMT Goupil
+0080C9 Alberta Microelectronic Centre
+00800B CSK
+000016 DU Pont Pixel Systems
+00005C Telematics International
+0000AC Conware Computer Consulting
+0000F2 Spider Communications
+000030 VG Laboratory Systems
+000035 Spectragraphics
+020701 Racal-datacom
+080011 Tektronix
+080040 Ferranti Computer SYS. Limited
+08003B Torus Systems Limited
+08003D Cadnetix Corporations
+080039 Spider Systems Limited
+080030 Network Research
+00009B Information International
+00DD0F Ungermann-bass
+000001 Xerox
+080021 3M Company
+AA0004 Digital Equipment
+08000C Miklyn Development
+00DD08 Ungermann-bass
+0000D8 Novell
+0000A0 Sanyo Electric
+08007F Carnegie-mellon University
+080082 Veritas Software
+08007B Sanyo Electric
+00DD0C Ungermann-bass
+000005 Xerox
+0000AA Xerox
+00406B Sysgen
+AA0001 Digital Equipment
+080001 Computervision
+000053 Compucorp
+08004B Planning Research
+080003 Advanced Computer COMM.
+080074 Casio Computer
+08005E Counterpoint Computer
+08005A IBM
+080056 Stanford Linear Accel. Center
+080053 Middle East TECH. University
+08004F Cygnet Systems
+F8E71E Ruckus Wireless
+00194B Sagemcom Broadband SAS
+001F95 Sagemcom Broadband SAS
+000E59 Sagemcom Broadband SAS
+A01B29 Sagemcom Broadband SAS
+90013B Sagemcom Broadband SAS
+ECDF3A vivo Mobile Communication
+E45AA2 vivo Mobile Communication
+00235A Compal Information (kunshan)
+001B38 Compal Information (kunshan)
+E46F13 D-Link International
+DC6DCD Guangdong Oppo Mobile Telecommunications
+CC1BE0 Ieee Registration Authority
+A43BFA Ieee Registration Authority
+F40E11 Ieee Registration Authority
+807B85 Ieee Registration Authority
+94C150 2Wire
+60FE20 2Wire
+989096 Dell
+B82A72 Dell
+00D09E 2Wire
+000D72 2Wire
+000F1F Dell
+14FEB5 Dell
+0015C5 Dell
+D4AE52 Dell
+B0E754 2Wire
+B8E625 2Wire
+549F35 Dell
+64006A Dell
+B4E10F Dell
+0023AE Dell
+9CD917 Motorola Mobility, a Lenovo Company
+9068C3 Motorola Mobility, a Lenovo Company
+408805 Motorola Mobility, a Lenovo Company
+A4A1C2 Ericsson AB
+348446 Ericsson AB
+AC2B6E Intel Corporate
+F8F1B6 Motorola Mobility, a Lenovo Company
+00216A Intel Corporate
+001E64 Intel Corporate
+0016EB Intel Corporate
+0018DE Intel Corporate
+681729 Intel Corporate
+5C514F Intel Corporate
+B808CF Intel Corporate
+C8F733 Intel Corporate
+4851B7 Intel Corporate
+5CC5D4 Intel Corporate
+7CCCB8 Intel Corporate
+F40669 Intel Corporate
+3CA9F4 Intel Corporate
+28B2BD Intel Corporate
+08D40C Intel Corporate
+843A4B Intel Corporate
+0CD292 Intel Corporate
+78929C Intel Corporate
+6805CA Intel Corporate
+ACA31E Aruba Networks
+9C1C12 Aruba Networks
+001A1E Aruba Networks
+28C2DD AzureWave Technology
+84D47E Aruba Networks
+A85840 Cambridge Industries(Group)
+002243 AzureWave Technology
+74F06D AzureWave Technology
+44D832 AzureWave Technology
+781881 AzureWave Technology
+B0EE45 AzureWave Technology
+240A64 AzureWave Technology
+D0E782 AzureWave Technology
+0C4C39 MitraStar Technology
+002423 AzureWave Technologies (Shanghai)
+A81D16 AzureWave Technology
+38A53C Comecer Netherlands
+001D8B ADB Broadband Italia
+A4526F ADB Broadband Italia
+581243 AcSiP Technology
+0026B8 Actiontec Electronics
+0030F1 Accton Technology
+001974 16063
+ECF00E AboCom
+3039F2 ADB Broadband Italia
+000827 ADB Broadband Italia
+001CA8 AirTies Wireless Netowrks
+9097D5 Espressif
+18FE34 Espressif
+54F6C5 Fujian Star-net Communication
+28EF01 Private
+5C338E Alpha Networks
+001AEB Allied Telesis R&D Center K.K.
+747548 Amazon Technologies
+A43111 ZIV
+5C93A2 Liteon Technology
+E8C74F Liteon Technology
+E8F724 Hewlett Packard Enterprise
+1C1448 Arris Group
+707E43 Arris Group
+001AAD Arris Group
+A47AA4 Arris Group
+701A04 Liteon Technology
+00D9D1 Sony
+48D224 Liteon Technology
+2CD05A Liteon Technology
+74E543 Liteon Technology
+A4DB30 Liteon Technology
+B8EE65 Liteon Technology
+001DBA Sony
+000AD9 Sony Mobile Communications AB
+000FDE Sony Mobile Communications AB
+001EDC Sony Mobile Communications AB
+001963 Sony Mobile Communications AB
+001B59 Sony Mobile Communications AB
+78843C Sony
+0023F1 Sony Mobile Communications AB
+3017C8 Sony Mobile Communications AB
+18002D Sony Mobile Communications AB
+3C0771 Sony
+D8D43C Sony
+0CFE45 Sony
+F8D0AC Sony
+04E676 Ampak Technology
+0022F4 Ampak Technology
+00041F Sony Computer Entertainment
+080046 Sony
+0003E0 Arris Group
+00128A Arris Group
+001225 Arris Group
+3C754A Arris Group
+0024C1 Arris Group
+002136 Arris Group
+0022B4 Arris Group
+002395 Arris Group
+0023ED Arris Group
+001B52 Arris Group
+00230B Arris Group
+001E8D Arris Group
+0023A2 Arris Group
+001BDD Arris Group
+001404 Arris Group
+745612 Arris Group
+E46449 Arris Group
+002493 Arris Group
+40FC89 Arris Group
+00195E Arris Group
+000D92 Arima Communications
+009096 Askey Computer
+0011F5 Askey Computer
+DCD87C Beijing Jingdong Century Trading
+001C4A AVM GmbH
+000B6A Asiarock Technology Limited
+40BA61 Arima Communications
+841B5E Netgear
+204E7F Netgear
+A021B7 Netgear
+0024B2 Netgear
+C03F0E Netgear
+001F33 Netgear
+1883BF Arcadyan Technology
+9C80DF Arcadyan Technology
+001CCC BlackBerry RTS
+94EBCD BlackBerry RTS
+644FB0 Hyunjin.com
+001A2A Arcadyan Technology
+001D19 Arcadyan Technology
+88252C Arcadyan Technology
+A4E4B8 BlackBerry RTS
+58671A Barnes&Noble
+BC0543 AVM GmbH
+002675 Aztech Electronics Pte
+001F3F AVM GmbH
+506A03 Netgear
+6CB0CE Netgear
+100D7F Netgear
+0020D6 Breezecom
+001018 Broadcom
+001BE9 Broadcom
+307C5E Juniper Networks
+0010DB Juniper Networks
+00121E Juniper Networks
+0014F6 Juniper Networks
+EC3EF7 Juniper Networks
+0C8610 Juniper Networks
+40A677 Juniper Networks
+841888 Juniper Networks
+002688 Juniper Networks
+0017CB Juniper Networks
+DC38E1 Juniper Networks
+40B4F0 Juniper Networks
+008077 Brother industries
+029D8E Cardiac Recorders
+FC2F40 Calxeda
+0026E4 Canal
+389496 Samsung Electronics
+0CB319 Samsung Electronics
+08EE8B Samsung Electronics
+84A466 Samsung Electronics
+981DFA Samsung Electronics
+FCF136 Samsung Electronics
+0C8910 Samsung Electronics
+54FA3E Samsung Electronics
+A89FBA Samsung Electronics
+FC1910 Samsung Electronics
+083D88 Samsung Electronics
+5C2E59 Samsung Electronics
+646CB2 Samsung Electronics
+F884F2 Samsung Electronics
+14B484 Samsung Electronics
+608F5C Samsung Electronics
+4CBCA5 Samsung Electronics
+78595E Samsung Electronics
+B0D09C Samsung Electronics
+4CA56D Samsung Electronics
+A48431 Samsung Electronics
+E4F8EF Samsung Electronics
+1432D1 Samsung Electronics
+E458E7 Samsung Electronics
+8CBFA6 Samsung Electronics
+7840E4 Samsung Electronics
+9000DB Samsung Electronics
+183A2D Samsung Electronics
+08373D Samsung Electronics
+50F520 Samsung Electronics
+A4EBD3 Samsung Electronics
+28987B Samsung Electronics
+1867B0 Samsung Electronics
+F40E22 Samsung Electronics
+9C3AAF Samsung Electronics
+BCF2AF devolo AG
+0270B3 Data Recall
+000FF6 Darfon Lighting
+702559 CyberTAN Technology
+0090D6 Crystal Group
+001DAA DrayTek
+02CF1C Communication Machinery
+0C75BD Cisco Systems
+38F0C8 Livestream
+74EAE8 Arris Group
+A811FC Arris Group
+0C1167 Cisco Systems
+001982 SmarDTV
+002682 Gemtek Technology
+001A73 Gemtek Technology
+00904B Gemtek Technology
+10C6FC Garmin International
+00E000 Fujitsu Limited
+00000E Fujitsu Limited
+002326 Fujitsu Limited
+0007CB Freebox SAS
+D86CE9 Sagemcom Broadband SAS
+3C81D8 Sagemcom Broadband SAS
+2CE412 Sagemcom Broadband SAS
+181E78 Sagemcom Broadband SAS
+0037B7 Sagemcom Broadband SAS
+0014BF Cisco-Linksys
+6C8DC1 Apple
+38CADA Apple
+8C579B Wistron Neweb
+B436A9 Fibocom Wireless 
+6416F0 Huawei Technologies
+48DB50 Huawei Technologies
+2400BA Huawei Technologies
+68DBCA Apple
+044BED Apple
+3CBB73 Shenzhen Xinguodu Technology
+3CCF5B Icomm HK Limited
+F40304 Google
+78ACC0 Hewlett Packard
+3C9066 SmartRG
+00195B D-Link
+000D88 D-Link
+001346 D-Link
+0021BA Texas Instruments
+0022A5 Texas Instruments
+0024BA Texas Instruments
+D03761 Texas Instruments
+0017E4 Texas Instruments
+5C6B32 Texas Instruments
+1C4593 Texas Instruments
+84DD20 Texas Instruments
+883314 Texas Instruments
+0017EB Texas Instruments
+C4EDBA Texas Instruments
+34B1F7 Texas Instruments
+C8A030 Texas Instruments
+205532 Gotech International Technology Limited
+002401 D-Link
+1CAFF7 D-Link International
+B8A386 D-Link International
+C8D3A3 D-Link International
+F4FC32 Texas Instruments
+649C8E Texas Instruments
+D8952F Texas Instruments
+001833 Texas Instruments
+4419B6 Hangzhou Hikvision Digital Technology
+C056E3 Hangzhou Hikvision Digital Technology
+C8E7D8 Shenzhen Mercury Communication Technologies
+E01C41 Aerohive Networks
+D854A2 Aerohive Networks
+9CEFD5 Panda Wireless
+C02C7A Shenzhen Horn Audio
+88B8D0 Dongguan Koppo Electronic
+38E7D8 HTC
+D8B377 HTC
+B4CEF6 HTC
+D40B1A HTC
+A08D16 Huawei Technologies
+2C8158 Hon Hai Precision Ind.
+601888 zte
+8002DF ORA
+D8FC38 Giantec Semiconductor
+2C6798 InTalTech
+D0BF9C Hewlett Packard
+B05ADA Hewlett Packard
+001083 Hewlett Packard
+0001E6 Hewlett Packard
+C44044 RackTop Systems
+3898D8 Meritech
+C8675E Aerohive Networks
+000CF1 Intel
+000E0C Intel
+BC0F64 Intel Corporate
+6CA100 Intel Corporate
+94659C Intel Corporate
+1002B5 Intel Corporate
+A468BC Private
+001DCF Arris Group
+001DD5 Arris Group
+001DD0 Arris Group
+5C571A Arris Group
+441EA1 Hewlett Packard
+D8D385 Hewlett Packard
+18A905 Hewlett Packard
+00237D Hewlett Packard
+002655 Hewlett Packard
+001438 Hewlett Packard
+001560 Hewlett Packard
+288023 Hewlett Packard
+645106 Hewlett Packard
+5CB901 Hewlett Packard
+DC4A3E Hewlett Packard
+2C59E5 Hewlett Packard
+9CB654 Hewlett Packard
+38EAA7 Hewlett Packard
+E83935 Hewlett Packard
+901ACA Arris Group
+E8ED05 Arris Group
+90C792 Arris Group
+789684 Arris Group
+CC65AD Arris Group
+986B3D Arris Group
+08EB74 Humax
+6CB56B Humax
+940937 Humax
+403DEC Humax
+E84DD0 Huawei Technologies
+D81FCC Brocade Communications Systems
+140467 SNK Technologies
+EC5F23 Qinghai Kimascend Electronics Technology
+047D50 Shenzhen Kang Ying TechnologyLtd.
+54EFFE Fullpower Technologies
+EC52DC World Media AND Technology
+A4D18C Apple
+CC25EF Apple
+240995 Huawei Technologies
+247F3C Huawei Technologies
+1C8E5C Huawei Technologies
+94772B Huawei Technologies
+F4E3FB Huawei Technologies
+04021F Huawei Technologies
+0034FE Huawei Technologies
+D02DB3 Huawei Technologies
+086361 Huawei Technologies
+F80113 Huawei Technologies
+70723C Huawei Technologies
+5C7D5E Huawei Technologies
+4C8BEF Huawei Technologies
+20F3A3 Huawei Technologies
+ACE87B Huawei Technologies
+688F84 Huawei Technologies
+001AB6 Texas Instruments
+D03972 Texas Instruments
+7C669D Texas Instruments
+78A504 Texas Instruments
+C4BE84 Texas Instruments
+D05FB8 Texas Instruments
+74D6EA Texas Instruments
+7CEC79 Texas Instruments
+E0E5CF Texas Instruments
+ACF7F3 Xiaomi Communications
+889471 Brocade Communications Systems
+CC4E24 Brocade Communications Systems
+50EB1A Brocade Communications Systems
+0027F8 Brocade Communications Systems
+000533 Brocade Communications Systems
+0060DF Brocade Communications Systems
+4CAC0A zte
+0026ED zte
+002293 zte
+FCD733 Tp-link Technologies
+10A5D0 Murata Manufacturing
+D4C9B2 Quanergy Systems
+E4CE02 WyreStorm Technologies
+2002AF Murata Manufacturing
+0026E8 Murata Manufacturing
+001C26 Hon Hai Precision Ind.
+00197D Hon Hai Precision Ind.
+90FBA6 Hon Hai Precision Ind.
+142D27 Hon Hai Precision Ind.
+ECCB30 Huawei Technologies
+786A89 Huawei Technologies
+2008ED Huawei Technologies
+509F27 Huawei Technologies
+CC96A0 Huawei Technologies
+54A51B Huawei Technologies
+F4C714 Huawei Technologies
+286ED4 Huawei Technologies
+A01290 Avaya
+F81547 Avaya
+506184 Avaya
+BCADAB Avaya
+B4A95A Avaya
+3C3A73 Avaya
+04F938 Huawei Technologies
+FC48EF Huawei Technologies
+80FB06 Huawei Technologies
+D4B110 Huawei Technologies
+CC53B5 Huawei Technologies
+002127 Tp-link Technologies
+54E6FC Tp-link Technologies
+D85D4C Tp-link Technologies
+F81A67 Tp-link Technologies
+F0F336 Tp-link Technologies
+44B32D Tp-link Technologies
+F07816 Cisco Systems
+001310 Cisco-Linksys
+0023BE Cisco Spvtg
+54D46F Cisco Spvtg
+24374C Cisco Spvtg
+BCC810 Cisco Spvtg
+484487 Cisco Spvtg
+445829 Cisco Spvtg
+481D70 Cisco Spvtg
+00214F Alps Electric
+00E036 Pioneer
+C83DFC Pioneer
+E0AE5E Alps Electric
+34C731 Alps Electric
+60380E Alps Electric
+64D4BD Alps Electric
+00000C Cisco Systems
+004096 Cisco Systems
+30F70D Cisco Systems
+B07D47 Cisco Systems
+D8B190 Cisco Systems
+F0B2E5 Cisco Systems
+188B9D Cisco Systems
+38ED18 Cisco Systems
+ECBD1D Cisco Systems
+DCCEC1 Cisco Systems
+84B261 Cisco Systems
+009EC8 Xiaomi Communications
+7C1DD9 Xiaomi Communications
+A086C6 Xiaomi Communications
+584498 Xiaomi Communications
+70E422 Cisco Systems
+0050BD Cisco Systems
+009086 Cisco Systems
+005054 Cisco Systems
+3C0E23 Cisco Systems
+001CC3 Pace plc
+14D4FE Pace plc
+70B14E Pace plc
+707630 Pace plc
+90E6BA Asustek Computer
+BCAEC5 Asustek Computer
+10BF48 Asustek Computer
+A80C0D Cisco Systems
+B83861 Cisco Systems
+6C9989 Cisco Systems
+580A20 Cisco Systems
+0050D1 Cisco Systems
+00500B Cisco Systems
+005073 Cisco Systems
+00603E Cisco Systems
+00E034 Cisco Systems
+001868 Cisco Spvtg
+887556 Cisco Systems
+60735C Cisco Systems
+FC9947 Cisco Systems
+7CC537 Apple
+70CD60 Apple
+24AB81 Apple
+581FAA Apple
+A46706 Apple
+3C0754 Apple
+E4CE8F Apple
+E8040B Apple
+B8C75D Apple
+403CFC Apple
+286AB8 Apple
+7CC3A1 Apple
+00E16D Cisco Systems
+F8C288 Cisco Systems
+E0ACF1 Cisco Systems
+FC5B39 Cisco Systems
+346F90 Cisco Systems
+E0D173 Cisco Systems
+74A02F Cisco Systems
+547C69 Cisco Systems
+689CE2 Cisco Systems
+40A6E8 Cisco Systems
+B8782E Apple
+000502 Apple
+0010FA Apple
+000393 Apple
+0016CB Apple
+0017F2 Apple
+001B63 Apple
+001EC2 Apple
+002608 Apple
+7C6D62 Apple
+40D32D Apple
+D83062 Apple
+C42C03 Apple
+6C2056 Cisco Systems
+BC1665 Cisco Systems
+44ADD9 Cisco Systems
+0C2724 Cisco Systems
+6C416A Cisco Systems
+F872EA Cisco Systems
+0C6803 Cisco Systems
+789F70 Apple
+DC3714 Apple
+40331A Apple
+94F6A3 Apple
+D81D72 Apple
+70ECE4 Apple
+38C986 Apple
+FCFC48 Apple
+2857BE Hangzhou Hikvision Digital Technology
+50D59C Thai Habel Industrial
+FCA386 Shenzhen Chuangwei-rgb Electronics
+F0F249 Hitron Technologies.
+A4C361 Apple
+AC7F3E Apple
+280B5C Apple
+90B931 Apple
+24A2E1 Apple
+80EA96 Apple
+600308 Apple
+04F13E Apple
+54724F Apple
+48746E Apple
+3CAB8E Apple
+7C6DF8 Apple
+48D705 Apple
+3CD0F8 Apple
+98D6BB Apple
+4CB199 Apple
+64E682 Apple
+804971 Apple
+98FE94 Apple
+D8004D Apple
+98B8E3 Apple
+80929F Apple
+885395 Apple
+9C04EB Apple
+78FD94 Apple
+C88550 Apple
+D4F46F Apple
+787E61 Apple
+60F81D Apple
+4C7C5F Apple
+48E9F1 Apple
+FCE998 Apple
+F099BF Apple
+68644B Apple
+A8968A Apple
+4C8D79 Apple
+207D74 Apple
+F4F15A Apple
+042665 Apple
+2CB43A Apple
+689C70 Apple
+087045 Apple
+CCE0C3 Mangstor
+84A423 Sagemcom Broadband SAS
+346987 zte
+58685D Tempo Australia
+789C85 August Home
+FCCF43 Huizhou City Huiyang District Meisiqi Industry Development
+5882A8 Microsoft
+B4EF04 Daihan Scientific
+049645 Wuxi SKY Chip Interconnection Technology
+5CE3B6 Fiberhome Telecommunication Technologies
+9C88AD Fiberhome Telecommunication Technologies
+C8C2C6 Shanghai Airm2m Communication Technology
+EC64E7 Mocacare
+D07C2D Leie IOT technology
+40862E JDM Mobile Internet Solution
+EC388F Huawei Technologies
+BC9C31 Huawei Technologies
+90C99B Recore Systems
+5CB559 Cnex Labs
+5CCF7F Espressif
+380546 Foctek Photonics
+6858C5 ZF TRW Automotive
+044169 GoPro
+ACC51B Zhuhai Pantum Electronics
+4473D6 Logitech
+E80734 Champion Optical Network Engineering
+D02544 Samsung Electro Mechanics
+6CEBB2 Dongguan Sen DongLv Electronics
+A03299 Lenovo (Beijing)
+A845CD Siselectron Technology
+D0C193 Skybell
+209BCD Apple
+F0B0E7 Apple
+A09169 LG Electronics
+CC20E8 Apple
+E435C8 Huawei Technologies
+38FF36 Ruckus Wireless
+D47208 Bragi GmbH
+489A42 Technomate
+B49D0B BQ
+98CB27 Galore Networks Pvt.
+30D32D devolo AG
+CC794A BLU Products
+60FD56 Woorisystems
+7CFE90 Mellanox Technologies
+483974 Proware Technologies
+E855B4 SAI Technology
+9CA69D Whaley TechnologyLtd
+342606 CarePredict
+B4AE2B Microsoft
+80EB77 Wistron
+B88981 Chengdu InnoThings Technology
+B4293D Shenzhen Urovo Technology
+906FA9 Nanjing Putian Telecommunications Technology
+14B370 Gigaset Digital Technology (Shenzhen)
+FC2FEF UTT Technologies
+EC21E5 Toshiba
+44FDA3 Everysight
+84D4C8 Widex A/S
+247260 Iottech
+44975A Shenzhen Fast Technologies
+584822 Sony Mobile Communications AB
+F8BF09 Huawei Technologies
+B4B265 Daeho I&T
+081FEB BinCube
+785F4C Argox Information
+E866C4 Datawise Systems
+5870C6 Shanghai Xiaoyi Technology
+803B2A ABB Xiamen Low Voltage Equipment
+A0A65C Supercomputing Systems AG
+5CB395 Huawei Technologies
+C412F5 D-Link International
+44F436 zte
+349B5B Maquet GmbH
+E861BE Melec
+54B80A D-Link International
+D8ADDD Sonavation
+C09A71 Xiamen Meitu Mobile Technologyltd
+340B40 Mios Elettronica SRL
+944A0C Sercomm
+D02516 Shenzhen Mercury Communication Technologies
+D05C7A Sartura d.o.o.
+583F54 LG Electronics (Mobile Communications)
+9C37F4 Huawei Technologies
+5CEB68 Cheerstar Technology
+F46A92 Shenzhen Fast Technologies
+14AEDB VTech Telecommunications
+EC4F82 Calix
+B8C3BF Henan Chengshi NetWork TechnologyLtd
+C0EE40 Laird Technologies
+F0182B LG Chem
+CC5FBF Topwise 3G Communication
+14DDA9 Asustek Computer
+485D36 Verizon
+EC60E0 Avi-on Labs
+145A83 Logi-D
+4CEEB0 SHC Netzwerktechnik GmbH
+188EF9 G2C
+809FAB Fiberhome Telecommunication Technologies
+D00492 Fiberhome Telecommunication Technologies
+F4E9D4 QLogic
+1422DB eero
+0C413E Microsoft
+007E56 China Dragon Technology Limited
+086266 Asustek Computer
+346C0F Pramod Telecom Pvt.
+3C912B Vexata
+F8C96C Fiberhome Telecommunication Tech.Co.
+48555F Fiberhome Telecommunication Tech.Co.
+54369B 1Verge Internet Technology (Beijing)
+E4FED9 Edmi Europe
+2852E0 Layon international Electronic & Telecom
+E48501 Geberit International AG
+1C3947 Compal Information (kunshan)
+2CAD13 Shenzhen Zhilu Technology
+68B983 b-plus GmbH
+BC74D7 HangZhou JuRu Technology
+E88E60 NSD
+545146 AMG Systems
+84DDB7 Cilag GmbH International
+78EB14 Shenzhen Fast Technologies
+D05BA8 zte
+8CE78C DK Networks
+E4BAD9 360 Fly
+7C3CB6 Shenzhen Homecare Technology
+BCE767 Quanzhou  TDX Electronics
+6CA7FA Youngbo Engineering
+D0929E Microsoft
+F4032F Reduxio Systems
+84CFBF Fairphone
+AC9E17 Asustek Computer
+ACC73F Vitsmo
+505527 LG Electronics
+18BDAD L-tech
+44D244 Seiko Epson
+10C07C Blu-ray Disc Association
+B87879 Roche Diagnostics GmbH
+4480EB Motorola Mobility, a Lenovo Company
+D06F4A Topwell International Holdings Limited
+BC54F9 Drogoo Technology
+349E34 Evervictory ElectronicLtd
+A0C2DE Costar Video Systems
+3809A4 Firefly Integrations
+00A509 WigWag
+A86405 nimbus
+7076FF Kerlink
+68F0BC Shenzhen LiWiFi Technology
+BCD165 Cisco Spvtg
+4CA928 Insensi
+2884FA Sharp
+3C1E04 D-Link International
+E0FFF7 Softiron
+DC60A1 Teledyne Dalsa Professional Imaging
+78E980 RainUs
+7C8274 Shenzhen Hikeen Technology
+B40566 SP Best
+70AD54 Malvern Instruments
+DCE026 Patrol Tag
+EC3C88 Mcnex
+F07959 Asustek Computer
+E08E3C Aztech Electronics Pte
+78A351 Shenzhen Zhibotong Electronics
+34FCEF LG Electronics
+94E2FD Boge Kompressoren Otto Boge Gmbh & KG
+E4695A Dictum Health
+D46132 Pro Concept Manufacturer
+54A050 Asustek Computer
+841826 Osram GmbH
+14F893 Wuhan FiberHome Digital Technology
+9816EC IC Intracom
+DCDA4F Getck Technology
+30FAB7 Tunai Creative
+0809B6 Masimo
+14EDE4 Kaiam
+3438AF Inlab Software GmbH
+D897BA Pegatron
+049B9C Eadingcore  Intelligent Technology
+842690 Beijing Thought Science
+B84FD5 Microsoft
+587BE9 AirPro Technology India Pvt.
+FC1D84 Autobase
+4CE933 RailComm
+6050C1 Kinetek Sports
+003560 Rosen Aviation
+EC59E7 Microsoft
+08EFAB Sayme Wireless Sensor Network
+BC52B4 Alcatel-Lucent
+C81B6B Innova Security
+5C966A Rtnet
+2C5089 Shenzhen Kaixuan Visual Technology,Limited
+A89DD2 Shanghai DareGlobal Technologies
+EC13B2 Netonix
+74BADB Longconn Electornics(shenzhen)Co.
+4C7403 BQ
+5876C5 Digi I'S
+00A2F5 Guangzhou Yuanyun Network Technology
+70FC8C OneAccess SA
+2C600C Quanta Computer
+902CC7 C-MAX Asia Limited
+B8AEED Elitegroup Computer Systems
+1C965A Weifang goertek Electronics
+188219 Alibaba Cloud Computing
+B41780 DTI Group
+D437D7 zte
+AC3870 Lenovo Mobile Communication Technology
+80EACA Dialog Semiconductor Hellas SA
+60512C TCT mobile limited
+4CBC42 Shenzhen Hangsheng Electronics
+D82522 Pace plc
+987E46 Emizon Networks Limited
+8432EA Anhui Wanzten P&T
+ACA213 Shenzhen Bilian electronic
+90B686 Murata Manufacturing
+4C6E6E Comnect Technology
+F4DD9E GoPro
+40B3CD Chiyoda Electronics
+3451AA JID Global
+04572F Sertel Electronics UK
+08B2A3 Cynny Italia S.r.L.
+D8977C Grey Innovation
+80AD67 Kasda Networks
+9CAD97 Hon Hai Precision Ind.
+30595B streamnow AG
+B8AD3E Bluecom
+10C37B Asustek Computer
+48D855 Telvent
+284ED7 OutSmart Power Systems
+5C5BC2 YIK
+184A6F Alcatel-Lucent Shanghai Bell
+EC8A4C zte
+340AFF Qingdao Hisense Communications
+8014A8 Guangzhou V-solution Electronic Technology
+908C63 GZ Weedong Networks Technology 
+B49EAC Imagik Int'l
+C8E42F Technical Research Design and Development
+FC2325 EosTek (Shenzhen)
+485929 LG Electronics
+A81374 Panasonic AVC Networks Company
+4C83DE Cisco Spvtg
+5CB6CC NovaComm Technologies
+B4AE6F Circle Reliance, DBA Cranberry Networks
+B89919 7signal Solutions
+90DA6A Focus H&S
+A45DA1 ADB Broadband Italia
+A43D78 Guangdong Oppo Mobile Telecommunications
+E8EF89 Opmex Tech.
+F4C447 Coagent International Enterprise Limited
+08DF1F Bose
+542AA2 Alpha Networks
+58238C Technicolor CH USA
+84948C Hitron Technologies.
+CCA0E5 DZG Metering GmbH
+3059B7 Microsoft
+80414E BBK Electronics
+0874F6 Winterhalter Gastronom GmbH
+FCC2DE Murata Manufacturing
+1C1CFD Dalian Hi-Think Computer Technology
+7062B8 D-Link International
+B875C0 PayPal
+E47FB2 Fujitsu Limited
+38262B UTran Technology
+20ED74 Ability enterprise
+982F3C Sichuan Changhong Electric
+7824AF Asustek Computer
+0CAC05 Unitend Technologies
+B4B859 Texa Spa
+045C8E Gosund Group
+54B753 Hunan Fenghui Yinjia Science And Technology
+4826E8 Tek-Air Systems
+14C126 Nokia
+A012DB Tabuchi Electric
+ACB859 Uniband Electronic,
+100F18 Fu Gang Electronic(KunShan)CO.
+C8D590 Flight Data Systems
+709383 Intelligent Optical Network High Tech
+3CCD93 LG Electronics
+6047D4 Forics Electronic Technology
+C09D26 Topicon HK Lmd.
+B061C7 Ericsson-LG Enterprise
+B05706 Vallox Oy
+C8D429 Muehlbauer AG
+20EAC7 Shenzhen Riopine Electronics
+80618F Shenzhen sangfei consumer communications
+5CF50D Institute of microelectronic applications
+10DEE4 automationNEXT GmbH
+444891 Hdmi Licensing
+FC923B Nokia
+38F708 National Resource Management
+C4C919 Energy Imports
+88A73C Ragentek Technology Group
+B0D7C5 Logipix
+38C9A9 Smart High Reliability Solutions
+BC1A67 YF Technology
+B024F3 Progeny Systems
+8C4DB9 Unmonday
+D87CDD Sanix Incorporated
+F8A2B4 Rhewa-waagenfabrik August Freudewald Gmbh &amp;co. KG
+84FE9E RTC Industries
+403067 Conlog (Pty)
+98DA92 Vuzix
+5C2AEF Open Access
+E40439 TomTom Software
+90AE1B Tp-link Technologies
+441E91 Arvida Intelligent Electronics Technology 
+6C14F7 Erhardt+Leimer GmbH
+70F96D Hangzhou H3C Technologies, Limited
+CC07E4 Lenovo Mobile Communication Technology
+B4430D Broadlink
+A4BBAF Lime Instruments
+7CE1FF Computer Performance, DBA Digital Loggers
+D069D0 Verto Medical Solutions
+ACE069 Isaac Instruments
+E8EA6A StarTech.com
+C4E984 Tp-link Technologies
+8059FD Noviga
+18FF2E Shenzhen Rui Ying Da Technology
+1CAB01 Innovolt
+68856A OuterLink
+30F42F ESP
+C816BD Hisense Electric
+746A8F VS Vision Systems GmbH
+B068B6 Hangzhou OYE Technology
+9C65F9 AcSiP Technology
+487604 Private
+D057A1 Werma Signaltechnik GmbH & KG
+3C89A6 Kapelse
+90F1B0 Hangzhou Anheng Info&Tech
+9C86DA Phoenix Geophysics
+48FEEA Homa
+10DDF4 Maxway Electronics
+080371 KRG Corporate
+B43A28 Samsung Electronics
+ACC595 Graphite Systems
+3413A8 Mediplan Limited
+4CD9C4 Magneti Marelli Automotive Electronics (Guangzhou)
+743ECB Gentrice tech
+7071B3 Brain
+208986 zte
+3CD4D6 WirelessWERX
+64E625 Woxu Wireless
+7C444C Entertainment Solutions
+501AC5 Microsoft
+609620 Private
+F8572E Core Brands
+E0E631 SNB Technologies Limited
+9401C2 Samsung Electronics
+20C60D Shanghai annijie Information technology
+7C9763 Openmatics s.r.o.
+0444A1 Telecon Galicia
+C03FD5 Elitegroup Computer Systems
+84569C Coho Data
+78AE0C Far South Networks
+38CA97 Contour Design
+84A783 Alcatel Lucent
+2C5D93 Ruckus Wireless
+1CC11A Wavetronix
+4CF02E Vifa Denmark A/S
+3051F8 BYK-Gardner GmbH
+94C3E4 SCA Schucker Gmbh & KG
+FC19D0 Cloud Vision Networks Technology
+20E791 Siemens Healthcare Diagnostics
+68764F Sony Mobile Communications AB
+D4D919 GoPro
+50C9A0 Skipper Electronics AS
+A49F89 Shanghai Rui Rui Communication TechnologyLtd.
+D850E6 Asustek Computer
+94103E Belkin International
+B4750E Belkin International
+346178 The Boeing Company
+187ED5 shenzhen kaism technology
+8844F6 Nokia
+841B38 Shenzhen Excelsecu Data Technology
+EC2AF0 Ypsomed AG
+044F8B Adapteva
+9CE7BD Winduskorea
+3842A6 Ingenieurbuero Stahlkopf
+A0BF50 S.C. Add-production S.r.l.
+7CB733 Askey Computer
+705957 Medallion Instrumentation Systems
+6C8366 Nanjing SAC Power Grid Automation
+88576D XTA Electronics
+F83D4E Softlink Automation System
+FCD817 Beijing Hesun TechnologiesLtd.
+909F43 Accutron Instruments
+C42795 Technicolor USA
+50C006 Carmanah Signs
+98FB12 Grand Electronics (HK)
+3C1040 daesung network
+B04545 Yacoub Automation Gmbh
+701D7F Comtech Technology
+60DB2A HNS
+7CBF88 Mobilicom
+90028A Shenzhen Shidean Legrand Electronic Products
+4C3C16 Samsung Electronics
+90356E Vodafone Omnitel N.V.
+3CCA87 Iders Incorporated
+08CA45 Toyou Feiji Electronics
+9CA9E4 zte
+E47723 zte
+C098E5 University of Michigan
+B8DF6B SpotCam
+742B62 Fujitsu Limited
+A0143D Parrot SA
+58BDF9 Sigrand
+344F3F IO-Power Technology
+C0C687 Cisco Spvtg
+142BD2 Armtel
+D4AD2D Fiberhome Telecommunication Tech.Co.
+F845AD Konka Group
+54A54B NSC Communications Siberia
+BC2B6B Beijing Haier IC Design
+642184 Nippon Denki Kagaku
+EC3E09 Performance Designed Products
+EC219F VidaBox
+98D331 Shenzhen Bolutek Technology
+3C1A57 Cardiopulmonary
+6CF97C Nanoptix
+58E02C Micro Technic A/S
+E481B3 Shenzhen ACT Industrial
+BC8556 Hon Hai Precision Ind.
+E4F3E3 Shanghai iComhome
+04CF25 Manycolors
+D41090 iNFORM Systems AG
+3495DB Logitec
+88142B Protonic Holland
+B8241A Sweda Informatica Ltda
+3806B4 A.D.C. GmbH
+341B22 Grandbeing Technology
+B4346C Matsunichi Digital Technology (hong Kong) Limited
+4C55CC ACKme Networks
+9C1465 Edata Elektronik San. ve Tic. A..
+C45444 Quanta Computer
+587A4D Stonesoft
+E89218 Arcontia International AB
+58F387 Hccp
+B0793C Revolv
+D022BE Samsung Electro Mechanics
+20CEC4 Peraso Technologies
+04848A 7inova Technology Limited
+94D771 Samsung Electronics
+20C6EB Panasonic AVC Networks Company
+700FEC Poindus Systems
+78D5B5 Navielektro KY
+E067B3 C-Data Technology
+B887A8 Step Ahead Innovations
+140D4F Flextronics International
+B847C6 SanJet Technology
+CC3540 Technicolor USA
+4CDF3D Team Engineers Advance Technologies India PVT
+B85E7B Samsung Electronics
+70F176 Data Modul AG
+205721 Salix Technology
+704CED TMRG
+E8516E Tsmart
+A067BE Sicon s.r.l.
+7C1AFC Dalian-Edifice Video Technology
+C034B4 Gigastone
+587E61 Hisense Electric
+74ADB7 China Mobile Group Device
+C462EA Samsung Electronics
+DC6F00 Livescribe
+D0737F Mini-Circuits
+A4D094 Erwin Peters Systemtechnik GmbH
+0488E2 Beats Electronics
+D00EA4 Porsche Cars North America
+F415FD Shanghai Pateo Electronic Equipment Manufacturing
+2C9464 Cincoze
+B050BC Shenzhen Basicom Electronic
+DC7014 Private
+40BC73 Cronoplast  S.L.
+78303B Stephen Technologies,Limited
+78F5E5 Bega Gantenbrink-leuchten KG
+804B20 Ventilation Control
+4007C0 Railtec Systems GmbH
+94B8C5 RuggedCom
+8C3C07 Skiva Technologies
+784B08 f.robotics acquisitions
+0C2D89 QiiQ Communications
+34BF90 Fiberhome Telecommunication Tech.Co.
+D467E7 Fiberhome Telecommunication Tech.Co.
+604A1C Suyin
+3423BA Samsung Electro Mechanics
+A4D3B5 Glitel Stropkov, S.r.o.
+A4F3C1 Open Source Robotics Foundation
+6C8B2F zte
+B863BC Robotis,
+C8DDC9 Lenovo Mobile Communication Technology
+CC1AFA zte
+8C5AF0 Exeltech Solar Products
+F8DADF EcoTech
+30AE7B Deqing Dusun Electron
+1441E2 Monaco Enterprises
+F07765 Sourcefire
+E4F7A1 Datafox GmbH
+601E02 EltexAlatau
+E47D5A Beijing Hanbang Technology
+4C6255 Sanmina-sci System DE Mexico S.A. DE C.V.
+381766 Promzakaz
+204C6D Hugo Brennenstuhl Gmbh & KG.
+D49524 Clover Network
+DC825B Janus, spol. s r.o.
+B08807 Strata Worldwide
+9893CC LG Electronics
+74D02B Asustek Computer
+A4E0E6 Filizola S.A. Pesagem E Automacao
+60E00E Shinsei Electronics
+30D46A Autosales Incorporated
+30AABD Shanghai Reallytek Information Technology
+A4B818 Penta Gesellschaft Fr Elektronische Industriedatenverarbeitung mbH
+106682 NEC Platforms
+102831 Morion
+D81EDE B&W Group
+6897E8 Society of Motion Picture &amp; Television Engineers
+24EA40 Systeme Helmholz GmbH
+FC58FA Shen Zhen Shi Xin Zhong Xin Technology
+60601F SZ DJI Technology
+E0C6B3 MilDef AB
+FCDB96 Enervalley
+74258A Hangzhou H3C Technologies, Limited
+F06BCA Samsung Electronics
+FC8B97 Shenzhen Gongjin Electronics
+882E5A storONE
+D429EA Zimory GmbH
+4C2578 Nokia
+C80E95 OmniLync
+18DC56 Yulong Computer Telecommunication Scientific(shenzhen)Co.
+50ABBF Hoseo Telecom
+8C7716 Longcheer Telecommunication Limited
+C8EEA6 Shenzhen SHX Technology
+28CBEB One
+18E8DD Moduletek
+2C282D BBK Communicatiao Technology
+4CCC34 Motorola Solutions
+F82FA8 Hon Hai Precision Ind.
+F084C9 zte
+E894F6 Tp-link Technologies
+94ACCA trivum technologies GmbH
+7CD844 Enmotus
+40B0FA LG Electronics
+F4C6D7 blackned GmbH
+68A40E BSH Bosch and Siemens Home Appliances GmbH
+4CCA53 Skyera
+081DFB Shanghai Mexon Communication Technology
+D0CDE1 Scientech Electronics
+A84481 Nokia
+98D6F7 LG Electronics
+94756E QinetiQ North America
+543D37 Ruckus Wireless
+905F2E TCT Mobile Limited
+0C5521 Axiros GmbH
+A4D856 Gimbal
+10A743 SK Mtek Limited
+E4A7FD Cellco Partnership
+24F2DD Radiant Zemax
+80CF41 Lenovo Mobile Communication Technology
+7C9A9B VSE valencia smart energy
+A845E9 Firich Enterprises
+78995C Nationz Technologies
+8CC5E1 ShenZhen Konka Telecommunication Technology
+7427EA Elitegroup Computer Systems
+6CB311 Shenzhen Lianrui Electronics
+54115F Atamo
+2411D0 Chongqing Ehs Science and Technology Development
+6C9AC9 Valentine Research
+10F49A T3 Innovation
+1C5A3E Samsung Eletronics, (Visual Display Divison)
+5865E6 Infomark
+BC20A4 Samsung Electronics
+60BD91 Move Innovation
+98473C Shanghai Sunmon Communication Technogy
+CC4BFB Hellberg Safety AB
+ACA22C Baycity Technologies
+6CADEF KZ Broadband Technologies
+044BFF GuangZhou Hedy Digital Technology
+949BFD Trans New Technology
+E4EEFD MR&D Manufacturing
+105CBF DuroByte
+30C82A Wi-Next s.r.l.
+88A3CC Amatis Controls
+EC89F5 Lenovo Mobile Communication Technology
+083AB8 Shinoda Plasma
+A0DD97 PolarLink Technologies
+E05597 Emergent Vision Technologies
+A01917 Bertel
+FC9FAE Fidus Systems
+FC0647 Cortland Research
+20918A Profalux
+7C438F E-Band Communications
+FC626E Beijing MDC Telecom
+C0B339 Comigo
+DCC0DB Shenzhen Kaiboer Technology
+7076DD Oxyguard International A/S
+E89AFF Fujian Landi Commercial Equipment
+683B1E Countwise
+D4136F Asia Pacific Brands
+9C2A70 Hon Hai Precision Ind.
+A0A130 DLI Taiwan Branch office
+38BC1A Meizu technology
+ECE915 STI
+A81FAF Krypton Polska
+087BAA Svyazkomplektservice
+2C26C5 zte
+BC629F Telenet Systems P.
+F47B5E Samsung Eletronics
+B47F5E Foresight Manufacture (S) Pte
+785517 SankyuElectronics
+848E96 Embertec
+CC3A61 Samsung Electro Mechanics
+A00363 Robert Bosch Healthcare GmbH
+4C8FA5 Jastec
+F0F644 Whitesky Science & Technology
+30D357 Logosol
+14F42A Samsung Electronics
+2C441B Spectrum Medical Limited
+1C5A6B Philips Electronics Nederland BV
+A875D6 FreeTek International
+58EB14 Proteus Digital Health
+789F87 Siemens AG I IA PP PRM
+7C0A50 J-MEX
+40F2E9 IBM
+9C0473 Tecmobile (International) 
+CC262D Verifi
+3C8AE5 Tensun Information Technology(Hangzhou)
+7CB232 Hui Zhou Gaoshengda Technology
+54DF63 Intrakey technologies GmbH
+7C0187 Curtis Instruments
+388EE7 Fanhattan
+54F666 Berthold Technologies GmbH andKG
+802FDE Zurich Instruments AG
+08AF78 Totus Solutions
+5C38E0 Shanghai Super Electronics Technology
+A0E534 Stratec Biomedical AG
+2891D0 Stage Tec Entwicklungsgesellschaft fr professionelle Audiotechnik mbH
+A854B2 Wistron Neweb
+98291D Jaguar de Mexico, SA de CV
+8C3C4A Nakayo Telecommunications
+18863A Digital ART System
+F4B72A Time Interconnect
+34D7B4 Tributary Systems
+F40F9B Wavelink
+144319 Creative&Link Technology Limited
+64F50E Kinion Technology Company Limited
+28A186 enblink
+1C9492 Ruag Schweiz AG
+24694A Jasmine Systems
+C8C791 Zero1.tv GmbH
+60748D Atmaca Elektronik
+78D129 Vicos
+78AB60 ABB Australia
+289A4B SteelSeries ApS
+0CC66A Nokia
+3078C2 Innowireless,
+58986F Revolution Display
+7CFE28 Salutron
+109FA9 Actiontec Electronics
+C0A364 3D Systems Massachusetts
+98A7B0 Mcst ZAO
+88DC96 Senao Networks
+4C0B3A TCT Mobile Limited
+C455C2 Bach-Simpson
+ECA29B Kemppi Oy
+04CE14 Wilocity
+802AFA Germaneers GmbH
+1C8464 Formosa Wireless Communication
+D867D9 Cisco Systems
+B4218A Dog Hunter
+F8A03D Dinstar Technologies
+D08CFF Upwis AB
+9C066E Hytera Communications Limited
+746A89 Rezolt
+68D1FD Shenzhen Trimax Technology
+241B13 Shanghai Nutshell Electronic
+B43564 Fujian Tian Cheng Electron Science & Technical Development
+54D1B0 Universal Laser Systems
+A497BB Hitachi Industrial Equipment Systems
+FC52CE Control iD
+E804F3 Throughtek
+B85810 Numera
+2CAB25 Shenzhen Gongjin Electronics
+AC6E1A Shenzhen Gongjin Electronics
+9886B1 Flyaudio (China)
+28B3AB Genmark Automation
+44E8A5 Myreka Technologies Sdn. Bhd.
+AC14D2 wi-daq
+9C4CAE Mesa Labs
+7CD9FE New Cosmos Electric
+E49069 Rockwell Automation
+B48910 Coster T.E.
+183919 Unicoi Systems
+A4B1E9 Technicolor
+30AEF6 Radio Mobile Access
+58343B Glovast Technology
+54A04F t-mac Technologies
+E44F5F EDS Elektronik Destek San.Tic.Ltd.Sti
+08B738 Lite-On Technogy
+702526 Alcatel-Lucent
+9C6650 Glodio Technolies,Ltd Tianjin Branch
+503955 Cisco Spvtg
+90CF6F Dlogixs
+68AF13 Futura Mobility
+B82410 Magneti Marelli Slovakia s.r.o.
+A8EF26 Tritonwave
+F0D3E7 Sensometrix SA
+7CC8D0 Tianjin Yaan Technology
+88E917 Tamaggo
+80AAA4 Usag
+5C2479 Baltech AG
+E8CBA1 Nokia
+F85F2A Nokia
+286094 Capelec
+60E956 Ayla Networks
+287184 Spire Payments
+1CB094 HTC
+FC5090 Simex Sp. z o.o.
+209BA5 Jiaxing Glead Electronics
+60843B Soladigm
+508C77 Dirmeier Schanktechnik Gmbh &Co KG
+6089B1 Key Digital Systems
+080CC9 Mission Technology Group, dba Magma
+3C970E Wistron InfoComm(Kunshan)Co.
+A0F450 HTC
+44D15E Shanghai Kingto Information Technology
+545EBD NL Technologies
+C8BBD3 Embrane
+ECD19A Zhuhai Liming Industries
+346E8A Ecosense
+ACEE3B 6harmonics
+04C1B9 Fiberhome Telecommunication Tech.Co.
+681605 Systems And Electronic Development Fzco
+04F17D Tarana Wireless
+A0DC04 Becker-Antriebe GmbH
+B85510 Zioncom Electronics (Shenzhen)
+8CC121 Panasonic AVC Networks Company
+2CBE97 Ingenieurbuero Bickele und Buehler GmbH
+045A95 Nokia
+B40E96 Heran
+BC851F Samsung Electronics
+0CAF5A Genus Power Infrastructures Limited
+D0699E Luminex Lighting Control Equipment
+64AE88 Polytec GmbH
+2C542D Cisco Systems
+709E86 X6D Limited
+946124 Pason Systems
+DC309C Heyrex Limited
+E81324 GuangZhou Bonsoninfo System
+0036F8 Conti Temic microelectronic GmbH
+443839 Cumulus Networks
+20F002 MTData Developments
+CC912B TE Connectivity Touch Solutions
+785262 Shenzhen Hojy Software
+40336C Godrej & Boyce Mfg.
+FC1D59 I Smart Cities HK
+EC0ED6 Itech Instruments SAS
+D0D212 K2NET
+9C8EDC Teracom Limited
+146A0B Cypress Electronics Limited
+B0750C QA Cafe
+B4E1EB Private
+FC2A54 Connected Data
+A090DE Veedims
+AC1461 Ataw 
+508A42 Uptmate Technology
+8C57FD LVX Western
+002A6A Cisco Systems
+B88F14 Analytica GmbH
+94FAE8 Shenzhen Eycom Technology
+4844F7 Samsung Electronics
+3CA315 Bless Information & Communications
+F8DB4C PNY Technologies
+F83094 Alcatel-Lucent Telecom Limited
+2817CE Omnisense
+28E608 Tokheim
+E477D4 Minrray Industry
+A4B980 Parking Boxx
+002D76 Titech Gmbh
+DC7144 Samsung Electro Mechanics
+78A183 Advidia
+F85063 Verathon
+400E67 Tremol
+901B0E Fujitsu Technology Solutions GmbH
+5C6F4F S.A. Sistel
+B058C4 Broadcast Microwave Services
+B820E7 Guangzhou Horizontal Information & Network Integration
+98588A Sysgration
+842B50 Huria
+0C5A19 Axtion Sdn Bhd
+606BBD Samsung Electronics
+A00CA1 Sktb Skit
+E09579 Orthosoft, D/b/a Zimmer CAS
+307ECB SFR
+90A783 JSW Pacific
+000830 Cisco Systems
+CCEF48 Cisco Systems
+78A5DD Shenzhen Smarteye Digital Electronics
+28B0CC Xenya d.o.o.
+94D723 Shanghai DareGlobal Technologies
+ECE744 Omntec mfg.
+80427C Adolf Tedsen GmbH & KG
+F8F7D3 International Communications
+B89AED OceanServer Technology
+E455EA Dedicated Computing
+00FC58 WebSilicon
+64A0E7 Cisco Systems
+18E80F Viking Electronics
+EC6264 Global411 Internet Services
+00F051 KWB Gmbh
+44DC91 Planex Communications
+F0DEB9 ShangHai Y&Y Electronics
+AC54EC Ieee P1823 Standards Working Group
+C8292A Barun Electronics
+E0DADC JVC Kenwood
+C894D2 Jiangsu Datang  Electronic Products
+A0423F Tyan Computer
+5C18B5 Talon Communications
+78BAD0 Shinybow Technology
+306CBE Skymotion Technology (HK) Limited
+40D559 Micro S.e.r.i.
+F82F5B eGauge Systems
+3499D7 Universal Flow Monitors
+7C336E MEG Electronics
+D0C1B1 Samsung Electronics
+D4D249 Power Ethernet
+10C2BA UTT
+F0DA7C RLH Industries
+40984C Casacom Solutions AG
+B8975A Biostar Microtech Int'l
+4833DD Zennio Avance Y Tecnologia
+D4D748 Cisco Systems
+9CCAD9 Nokia
+F8313E endeavour GmbH
+10FC54 Shany Electronic
+D4CA6D Routerboard.com
+D8E743 Wush
+A0F3E4 Alcatel Lucent IPD
+908FCF UNO System
+903CAE Yunnan Ksec Digital Technology
+000831 Cisco Systems
+F0620D Shenzhen Egreat Tech
+843611 hyungseul publishing networks
+DC9FDB Ubiquiti Networks
+B8FD32 Zhejiang Roicx Microelectronics
+D8052E Skyviia
+F83553 Magenta Research
+DC3C2E Manufacturing System Insights
+40BC8B itelio GmbH
+903AA0 Alcatel-Lucent
+88C36E Beijing Ereneben lnformation Technology Limited
+8CDE52 Issc Technologies
+A8776F Zonoff
+FC4DD4 Universal Global Scientific Industrial
+902B34 Giga-byte Technology
+48E1AF Vity
+245FDF Kyocera
+C0A0DE Multi Touch Oy
+943AF0 Nokia
+B826D4 Furukawa Industrial S.A. Produtos Eltricos
+14E4EC mLogic
+FC0A81 Zebra Technologies
+AC0DFE Ekon GmbH - myGEKKO
+005CB1 Gospell Digital Technology
+186751 Komeg Industrielle Messtechnik Gmbh
+B467E9 Qingdao GoerTek Technology
+B49EE6 Shenzhen Technology
+7041B7 Edwards Lifesciences
+A849A5 Lisantech
+94DB49 Sitcorp
+30144A Wistron Neweb
+8CD17B CG Mobile
+144978 Digital Control Incorporated
+FC8FC4 Intelligent Technology
+F04A2B Pyramid Computer Gmbh
+CC9093 Hansong Tehnologies
+78F7D0 Silverbrook Research
+F04B6A Scientific Production Association Siberian Arsenal
+30DE86 Cedac Software S.r.l.
+F013C3 Shenzhen Fenda Technology
+CCE7DF American Magnetics
+E44E18 Gardasoft VisionLimited
+D41C1C RCF
+8C94CF Encell Technology
+149090 KongTop industrial(shen zhen)CO.
+F008F1 Samsung Electronics
+CCF8F0 Xi'an Hisu Multimedia Technology
+30F9ED Sony
+28C718 Altierre
+2046A1 Vecow
+8C271D QuantHouse
+9C8BF1 The Warehouse Limited
+147DC5 Murata Manufacturing
+944696 BaudTec
+90342B Gatekeeper Systems
+D45251 IBT Ingenieurbureau Broennimann Thun
+3071B2 Hangzhou Prevail Optoelectronic Equipment
+B82ADC EFR Europische Funk-Rundsteuerung GmbH
+B09BD4 GNH Software India Private Limited
+7CF429 Nuuo
+B8CDA7 Maxeler Technologies
+F49461 NexGen Storage
+402CF4 Universal Global Scientific Industrial
+804731 Packet Design
+C4CAD9 Hangzhou H3C Technologies, Limited
+ACCB09 Hefcom Metering (Pty)
+10EED9 Canoga Perkins
+240BB1 Kostal Industrie Elektrik Gmbh
+20EEC6 Elefirst Science & Tech
+807A7F ABB Genway Xiamen Electrical Equipment
+14373B Procom Systems
+B81999 Nesys
+4C5585 Hamilton Systems
+8CCF5C Befega Gmbh
+A0133B HiTi Digital
+448E12 DT Research
+9C5711 Feitian Xunda(Beijing) Aeronautical Information Technology
+18AD4D Polostar Technology
+4CA74B Alcatel Lucent
+549478 Silvershore Technology Partners
+F4B164 Lightning Telecommunications Technology
+0CFC83 Airoha Technology,
+0C51F7 Chauvin Arnoux
+70B035 Shenzhen Zowee Technology
+708105 Cisco Systems
+00082F Cisco Systems
+542018 Tely Labs
+581FEF Tuttnaer
+58BDA3 Nintendo
+F8F25A G-Lab GmbH
+BC779F SBM
+C058A7 Pico Systems
+04D783 Y&H E&C
+00E175 AK-Systems
+843F4E Tri-Tech Manufacturing
+C83232 Hunting Innova
+D059C3 CeraMicro Technology
+EC9681 2276427 Ontario
+B8288B Parker Hannifin Manufacturing (UK)
+5835D9 Cisco Systems
+802E14 azeti Networks AG
+E8944C Cogent Healthcare Systems
+68F895 Redflow Limited
+A88792 Broadband Antenna Tracking Systems
+901900 SCS SA
+AC932F Nokia
+1435B3 Future Designs
+FCF1CD Optex-fa
+B03829 Siliconware Precision Industries
+C86C87 ZyXEL Communications
+E00C7F Nintendo
+BC0F2B Fortune Techgroup
+8CF9C9 Mesada Technology
+E42AD3 Magneti Marelli S.p.A. Powertrain
+FC10BD Control Sistematizado
+443719 2 Save Energy
+E83EB6 RIM
+94FD1D WhereWhen
+0CE82F Bonfiglioli Vectron GmbH
+C0626B Cisco Systems
+74D0DC Ericsson AB
+B4B88D Thuh Company
+60F59C CRU-Dataport
+C4108A Ruckus Wireless
+4C73A5 Kove
+F86971 Seibu Electric,
+44AA27 udworks
+6CAD3F Hubbell Building Automation
+8427CE Corporation of the Presiding Bishop of The Church of Jesus Christ of Latter-day Saints
+D428B2 ioBridge
+90B8D0 Joyent
+909060 RSI Video Technologies
+3859F9 Hon Hai Precision Ind.
+281471 Lantis
+1407E0 Abrantix AG
+DCCF94 Beijing Rongcheng Hutong Technology
+18E288 STT Condigi
+68876B INQ Mobile Limited
+9866EA Industrial Control Communications
+F4A52A Hawa Technologies
+90CF15 Nokia
+B8D49D M Seven System
+B0A10A Pivotal Systems
+48F47D TechVision Holding  Internation Limited
+6C391D Beijing ZhongHuaHun Network Information center
+64D241 Keith & Koep GmbH
+101212 Vivo International
+5087B8 Nuvyyo
+E41289 topsystem Systemhaus GmbH
+A4134E Luxul 
+B09928 Fujitsu Limited
+8C11CB Abus Security-center Gmbh & KG
+806459 Nimbus
+A45A1C smart-electronic GmbH
+8C89A5 Micro-Star INT'L
+3C672C Sciovid
+18D071 Dasan
+38D135 EasyIO Sdn. Bhd.
+184E94 Messoa Technologies
+A8922C LG Electronics
+94D93C Enelps
+DC9B1E Intercom
+5C7757 Haivision Network Video
+3816D1 Samsung Electronics
+E8B4AE Shenzhen C&D Electronics
+C45600 Galleon Embedded Computing
+E42FF6 Unicore communication
+B8F4D0 Herrmann Ultraschalltechnik GmbH & Kg
+B4F323 Petatel
+C81E8E ADV Security (S) Pte
+ACCABA Midokura
+9C417C Hame  Technology,  Limited 
+10768A EoCell
+044665 Murata Manufacturing
+D0131E Sunrex Technology
+380197 Tsst Global
+B40142 GCI Science & Technology
+846EB1 Park Assist
+6C504D Cisco Systems
+C0C1C0 Cisco-Linksys
+1CBD0E Amplified Engineering
+F0A764 GST
+A0F217 GE Medical System(China)
+5067F0 ZyXEL Communications
+643409 BITwave Pte
+20D5AB Korea Infocom
+F05849 CareView Communications
+E06995 Pegatron
+BC15A6 Taiwan Jantek Electronics
+241A8C Squarehead Technology AS
+1083D2 Microseven Systems
+F05D89 Dycon Limited
+AC02CF RW Tecnologia Industria e Comercio Ltda
+A0B662 Acutvista Innovation
+9067B5 Alcatel-Lucent
+40987B Aisino
+6C2E33 Accelink Technologies
+4CEDDE Askey Computer
+E8E08F Gravotech Marking SAS
+78B6C1 Aobo Telecom
+B8BA68 Xi'an Jizhong Digital Communication
+BC38D2 Pandachip Limited
+A00BBA Samsung Electro-mechanics
+14EE9D AirNav Systems
+48174C MicroPower technologies
+78471D Samsung Electronics
+F81037 Atopia Systems
+64F987 Avvasi
+3C7437 RIM
+04209A Panasonic AVC Networks Company
+64DC01 Static Systems Group PLC
+90A4DE Wistron Neweb
+1CF5E7 Turtle Industry
+9C4A7B Nokia
+2C8065 Harting of North America
+80C6AB Technicolor USA
+F8F014 RackWare
+889FFA Hon Hai Precision Ind.
+E41C4B V2 Technology
+F0F002 Hon Hai Precision Ind.
+E0143E Modoosis
+5C6984 Nuvico
+204AAA Hanscan Spain
+F02572 Cisco Systems
+8091C0 AgileMesh
+0CF0B4 Globalsat International Technology
+BCC61A Spectra Embedded Systems
+48DF1C Wuhan NEC Fibre Optic Communications industry
+D0D3FC Mios
+989449 Skyworth Wireless Technology
+C8DF7C Nokia
+F8C678 Carefusion
+FC3598 Favite
+A0AAFD EraThink Technologies
+801F02 Edimax Technology
+E03E7D data-complex GmbH
+A4E32E Silicon & Software Systems
+1C19DE eyevis GmbH
+DC07C1 HangZhou QiYang Technology
+CC9E00 Nintendo
+D8FE8F IDFone
+0006F6 Cisco Systems
+ACAB8D Lyngso Marine A/S
+181456 Nokia
+E8995A PiiGAB, Processinformation i Goteborg AB
+18F46A Hon Hai Precision Ind.
+D4E32C S. Siedle & Sohne
+68DCE8 PacketStorm Communications
+78223D Affirmed Networks
+60C980 Trymus
+94CDAC Creowave Oy
+F4DCDA Zhuhai Jiahe Communication Technology, limited
+100D32 Embedian
+D82986 Best Wish Technology
+C03B8F Minicom Digital Signage
+D48890 Samsung Electronics
+A4218A Nortel Networks
+6C0460 RBH Access Technologies
+5C864A Secret Labs
+B8BA72 Cynove
+C00D7E Additech
+68784C Nortel Networks
+6C626D Micro-Star INT'L
+8841C1 Orbisat DA Amazonia IND E Aerol SA
+18B209 Torrey Pines Logic
+3018CF Deos Control Systems Gmbh
+4CF737 SamJi Electronics
+40406B Icomera
+1880CE Barberry Solutions
+CC43E3 Trump
+6C22AB Ainsworth Game Technology
+3C106F Albahith Technologies
+7CE044 Neon
+64D02D Next Generation Integration (NGI)
+A04041 Samwonfa
+788C54 Eltek Technologies
+9411DA ITF Frschl GmbH
+10E8EE PhaseSpace
+A47C1F Cobham plc
+8C1F94 RF Surgical System 
+74A4A7 QRS Music Technologies
+8039E5 Patlite
+BCFFAC Topcon
+602A54 CardioTek
+1C3DE7 Sigma Koki
+482CEA Motorola Business Light Radios
+70E139 3view
+AC6123 Drivven
+3C04BF Pravis Systemsltd.,
+443D21 Nuvolt
+749050 Renesas Electronics
+7CBB6F Cosco Electronics
+D466A8 Riedo Networks GmbH
+98E165 Accutome
+EC66D1 B&W Group
+385FC3 Yu Jeong System,Ltd
+94857A Evantage Industries
+4451DB Raytheon BBN Technologies
+64995D LGE
+585076 Linear Equipamentos Eletronicos SA
+4083DE Zebra Technologies
+8897DF Entrypass Sdn. Bhd.
+0C15C5 Sdtec
+9803A0 ABB n.v. Power Quality Products
+DCFAD5 Strong Ges.m.b.h.
+D84606 Silicon Valley Global Marketing
+5CAC4C Hon Hai Precision Ind.
+689234 Ruckus Wireless
+D0E347 Yoga
+84A991 Cyber Trans Japan
+380DD4 Primax Electronics
+D81C14 Compacta International
+9088A2 Ionics Technology ME Ltda
+B0B8D5 Nanjing Nengrui Auto Equipment
+8497B8 Memjet
+A8556A Pocketnet Technology
+B081D8 I-sys
+206AFF Atlas Elektronik UK Limited
+EC542E Shanghai XiMei Electronic Technology
+B88E3A Infinite Technologies JLT
+74BE08 Atek Products
+E0EE1B Panasonic Automotive Systems Company of America
+E80C38 Daeyoung Information System
+68597F Alcatel Lucent
+2C3068 Pantech
+5C4058 Jefferson Audio Video Systems
+64317E Dexin
+AC9B84 Smak Tecnologia e Automacao
+4C022E CMR Korea
+24A42C Koukaam a.s.
+34F39B WizLAN
+74B9EB JinQianMao Technology
+244597 Gemue Gebr. Mueller Apparatebau
+30694B RIM
+AC5135 MPI Tech
+E4EC10 Nokia
+00D38D Hotel Technology Next Generation
+3C6278 Shenzhen Jetnet Technology
+8081A5 Tongqing Communication Equipment (shenzhen)
+EC8EAD DLX
+ECDE3D Lamprey Networks
+04FE7F Cisco Systems
+E8056D Nortel Networks
+A87B39 Nokia
+00D11C Acetel
+1056CA Peplink International
+E83A97 OCZ Technology Group
+44A689 Promax Electronica SA
+10CCDB Aximum Produits Electroniques
+6C92BF Inspur Electronic Information Industry
+E01CEE Bravo Tech
+3C1915 GFI Chrono Time
+EC5C69 Mitsubishi Heavy Industries Mechatronics Systems
+04E548 Cohda Wireless
+0C1DC2 SeAH Networks
+28CD4C Individual Computers GmbH
+8C53F7 A&D Engineering
+781185 NBS Payment Solutions
+2893FE Cisco Systems
+10B7F6 Plastoform Industries
+2059A0 Paragon Technologies
+487119 SGB Group
+E0ABFE Orb Networks
+CCEA1C Dconworks 
+ACE348 MadgeTech
+687F74 Cisco-Linksys
+8C56C5 Nintendo
+CCB888 AnB Securite
+CC2218 InnoDigital
+B86491 CK Telecom
+80C862 Openpeak
+E43593 Hangzhou GoTo technologyLtd
+E0BC43 C2 Microsystems
+7071BC Pegatron
+7884EE Indra Espacio
+2C3F3E Alge-Timing GmbH
+ECE09B Samsung electronics
+C0CFA3 Creative Electronics & Software
+D4823E Argosy Technologies
+844823 Woxter Technology
+D0F0DB Ericsson
+34C3AC Samsung Electronics
+7C1476 Damall Technologies SAS
+D05875 Active Control Technology
+D81BFE Twinlinx
+D46CBF Goodrich ISR
+5C57C8 Nokia
+4CC602 Radios
+3C05AB Product Creation Studio
+3C39C3 JW Electronics
+547FEE Cisco Systems
+A4C2AB Hangzhou Lead-it Information & Technology
+48AA5D Store Electronic Systems
+1062C9 Adatis GmbH & KG
+D8AE90 Itibia Technologies
+904716 Rorze
+28E794 Microtime Computer
+8894F9 Gemicom Technology
+0CA42A OB Telecom Electronic Technology
+5850E6 Best Buy
+AC9A96 Lantiq Deutschland GmbH
+E86CDA Supercomputers and Neurocomputers Research Center
+24B6B8 Friem SPA
+F86ECF Arcx
+8C8401 Private
+6C7039 Novar GmbH
+C44619 Hon Hai Precision Ind.
+A4561B Mcot
+80EE73 Shuttle
+10C73F Midas Klark Teknik
+408A9A Titeng
+702B1D E-Domus International Limited
+F077D0 Xcellen
+785C72 Hioso Technology
+94236E Shenzhen Junlan Electronic
+88BA7F Qfiednet
+E02636 Nortel Networks
+4456B7 Spawn Labs
+0C6076 Hon Hai Precision Ind.
+0CEEE6 Hon Hai Precision Ind.
+A09805 OpenVox Communication
+00271D Comba Telecom Systems (China)
+002721 Shenzhen Baoan Fenda Industrial
+A09A5A Time Domain
+64A837 Juni Korea
+B4B5AF Minsung Electronics
+044FAA Ruckus Wireless
+44568D PNC Technologies 
+ACD180 Crexendo Business Solutions
+AC8317 Shenzhen Furtunetel Communication
+E80B13 Akib Systems Taiwan
+44C9A2 Greenwald Industries
+9CB206 Procentec
+44F459 Samsung Electronics
+646E6C Radio Datacom
+E4751E Getinge Sterilization AB
+F8811A Overkiz
+042BBB PicoCELA
+FC0877 Prentke Romich Company
+ECD00E MiraeRecognition
+747E1A Red Embedded Design Limited
+C47D4F Cisco Systems
+4C9EE4 Hanyang Navicom
+3CDF1E Cisco Systems
+BCB181 Sharp
+78B81A Inter Sales A/S
+78192E Nascent Technology
+2C0623 Win Leader
+C82E94 Halfa Enterprise
+0C2755 Valuable Techologies Limited
+C038F9 Nokia Danmark A/S
+F46349 Diffon
+5C8778 Cybertelbridge
+9C5E73 Calibre UK
+F06281 ProCurve Networking by HP
+003A9B Cisco Systems
+2C9127 Eintechno
+C09C92 Coby
+849000 Arnold & Richter Cine Technik
+C87248 Aplicom Oy
+74D850 Evrisko Systems
+6CAC60 Venetex
+DC0265 Meditech Kft
+986DC8 Toshiba Mitsubishi-electric Industrial Systems
+68A1B7 Honghao Mingchuan Technology (Beijing)
+7CCFCF Shanghai Seari Intelligent System
+EC3091 Cisco Systems
+3032D4 Hanilstm
+0026EE TKM GmbH
+0026E7 Shanghai Onlan Communication Tech.
+0026E1 Stanford University, OpenFlow Group
+0026DB Ionics EMS
+0026CE Kozumi USA
+0026D5 Ory Solucoes em Comercio de Informatica Ltda.
+0026C8 System Sensor
+002711 LanPro
+00270D Cisco Systems
+002707 Lift Complex DS
+002700 Shenzhen Siglent Technology
+0026FA BandRich
+0026F4 Nesslab
+0025D7 Cedo
+0025D2 InpegVision
+0025D1 Eastern Asia Technology Limited
+0025CB Reiner SCT
+0025C4 Ruckus Wireless
+0025BF Wireless Cables
+0025B1 Maya-Creation
+0025B8 Agile Communications
+0025B2 Mbda Deutschland Gmbh
+0025AC I-Tech
+0026C2 Scdi
+0026BC General Jack Technology
+0026B4 Ford Motor Company
+0026AE Wireless Measurement
+0026AA Kenmec Mechanical Engineering
+0026A4 Novus Produtos Eletronicos Ltda
+00269E Quanta Computer
+002697 Cheetah Technologies
+002698 Cisco Systems
+00269D M2Mnet
+00268B Guangzhou Escene Computer Technology Limited
+002685 Digital Innovation
+00267E Parrot SA
+002678 Logic Instrument SA
+002672 Aamp of America
+00266C Inventec
+00266B Shine Union Enterprise Limited
+002666 EFM Networks
+002665 ProtectedLogic
+00265F Samsung Electronics
+002659 Nintendo
+002651 Cisco Systems
+002652 Cisco Systems
+002646 Shenyang Tongfang Multimedia Technology Company Limited
+002640 Baustem Broadband Technologies
+00263A Digitec Systems
+002634 Infineta Systems
+002633 MIR - Medical International Research
+00262E Chengdu Jiuzhou Electronic Technology
+002627 Truesell
+002621 InteliCloud Technology
+00261B Laurel Bank Machines
+002614 Ktnf
+00260E Ablaze Systems
+00260F Linn Products
+002602 Smart Temps
+002601 Cutera
+0025F7 Ansaldo STS USA
+0025FC Enda Endustriyel Elektronik STI.
+0025ED NuVo Technologies
+0025EE Avtex
+0025E8 Idaho Technology
+0025E3 Hanshinit
+0025DE Probits
+002579 J & F Labs
+00257E NEW POS Technology Limited
+002572 Nemo-Q International AB
+002566 Samsung Electronics
+00256B Atenix E.E. S.r.l.
+00256C Azimut Production Association JSC
+00255F SenTec AG
+00255A Tantalus Systems
+002559 Syphan Technologies
+0025A5 Walnut Media Network
+0025A0 Nintendo
+00259F TechnoDigital Technologies GmbH
+002599 Hedon e.d.
+002592 Guangzhou Shirui Electronic
+00258D Haier
+002588 Genie Industries
+002583 Cisco Systems
+00254C Videon Central
+002547 Nokia Danmark A/S
+002536 Oki Electric Industry
+00253D DRS Consolidated Controls
+002540 Quasar Technologies
+002533 Wittenstein AG
+00252C Entourage Systems
+002502 NaturalPoint
+0024FB Private
+0024F6 Miyoshi Electronics
+0024EA iris-GmbH infrared & intelligent sensors
+0024E3 CAO Group
+002527 Bitrode
+002524 Lightcomm Technology
+00251F Zynus Vision
+00251A Psiber Data Systems
+002515 SFR
+00250E gt german telematics gmbh
+002507 Astak
+002509 Sharetronic Group
+002437 Motorola - BSG
+00243C S.a.a.a.
+002430 Ruby Tech
+0023FB IP Datatel
+0023F3 Glocom
+0023EF Zuend Systemtechnik AG
+0023E9 F5 Networks
+0023E3 Microtronic AG
+0023E2 SEA Signalisation
+0023DD Elgin
+0023D0 Uniloc USA
+0023CA Behind The Set
+0023D6 Samsung Electronics
+0024B0 Esab AB
+0024A9 Ag Leader Technology
+0024A2 Hong Kong Middleware Technology Limited
+0024A4 Siklu Communication
+00249D NES Technology
+00248A Kaga Electronics
+00248F Do-monix
+002491 Samsung Electronics
+002496 Ginzinger electronic systems
+00247E Universal Global Scientific Industrial
+002483 LG Electronics
+002477 Tibbo Technology
+002470 Aurotech Ultrasound AS.
+002472 ReDriven Power
+00246B Covia
+002464 Bridge Technologies AS
+00245F Vine Telecom
+002420 NetUP
+002426 Nohmi Bosai
+00241A Red Beetle
+002413 Cisco Systems
+00240D OnePath Networks
+00240E Inventec Besta
+002407 Telem SAS
+002400 Nortel Networks
+0024D0 Shenzhen Sogood Industry
+0024D5 Winward Industrial Limited
+0024C9 Broadband Solutions Group
+0024C4 Cisco Systems
+0024BF Ciat
+0024B5 Nortel Networks
+00245A Nanjing Panda Electronics Company Limited
+002453 Initra d.o.o.
+00244D Hokkaido Electronics
+002452 Silicon Software GmbH
+002446 MMB Research
+002441 Wanzl Metallwarenfabrik GmbH
+002368 Zebra Technologies
+00236F DAQ System
+002362 Goldline Controls
+002361 Unigen
+00235C Aprius
+002355 Kinco Automation(Shanghai)
+00234F Luminous Power Technologies Pvt.
+002350 LynTec
+002349 Helmholtz Centre Berlin for Material and Energy
+002244 Chengdu Linkon Communications Device
+00224F Byzoro Networks
+002248 Microsoft
+00223E IRTrans GmbH
+002239 Indiana Life Sciences Incorporated
+002232 Design Design Technology
+00222C Ceton
+00230E Gorba AG
+002307 Future Innovation Tech
+002302 Cobalt Digital
+0022EB Data Respons A/S
+0022EC Idealbt Technology
+0022F1 Private
+00239E Jiangsu Lemote Technology Limited
+002398 Vutlan sro
+00238A Ciena
+002384 GGH Engineering s.r.l.
+002342 Coffee Equipment Company
+002336 Metel S.r.o.
+00233D Novero holding
+002330 Dizipia
+00232C Senticare
+002320 Nicira Networks
+00231D Deltacom Electronics
+00231E Cezzer Multimedia Technologies
+0022B8 Norcott
+0022B7 GSS Grundig SAT-Systems GmbH
+0022B2 4RF Communications
+0022AB Shenzhen Turbosight Technology
+0022A6 Sony Computer Entertainment America
+00229F Sensys Traffic AB
+0022E5 Fisher-Rosemount Systems
+0022DE Oppo Digital
+0022D9 Fortex Industrial
+0022D2 All Earth Comrcio de Eletrnicos LTDA.
+0022CC SciLog
+0022C8 Applied Instruments
+0022BE Cisco Systems
+00228C Photon Europe GmbH
+002286 Astron
+002285 Nomus Comm Systems
+002280 A2B Electronics AB
+002276 Triple EYE
+00227B Apogee Labs
+002262 BEP Marine
+00226C LinkSprite Technologies
+00225E Uwin Technologies
+002258 Taiyo Yuden
+0023C3 LogMeIn
+0023BD Digital Ally
+0023B7 Q-Light
+0023B1 Longcheer Technology (Singapore) Pte
+0023B0 Comxion Technology
+0023AB Cisco Systems
+0023A4 New Concepts Development
+001FC0 Control Express Finland Oy
+001FBB Xenatech
+001FB4 SmartShare Systems
+001FAD Brown Innovations
+001FAF NextIO
+001FAE Blick South Africa (Pty)
+001FA8 Smart Energy Instruments
+001FA3 T&W Electronics(Shenzhen)Co.
+002142 Advanced Control Systems doo
+002140 EN Technologies
+002138 Cepheid
+00212E dresden-elektronik
+002128 Oracle
+002122 Chip-pro
+00211B Cisco Systems
+002115 Phywe Systeme Gmbh & KG
+002116 Transcon Electronic Systems, spol. s r. o.
+00210F Cernium
+00210B Gemini Traze Rfid PVT.
+00210C Cymtec Systems
+002105 Alcatel-Lucent
+001FFC Riccius+Sohn GmbH
+001FF7 Nakajima All Precision
+00216E Function ATI (Huizhou) Telecommunications
+002168 iVeia
+002161 Yournet
+00215B Inotive
+002155 Cisco Systems
+00214E GS Yuasa Power Supply
+002149 China Daheng Group 
+001FF0 Audio Partnership
+001FE9 Printrex
+001FEB Trio Datacom
+001FEA Applied Media Technologies
+001FDD GDI
+001FD8 A-trust Computer
+001FD3 Riva Networks
+001FCE Qtech
+00219D Adesys BV
+0021A1 Cisco Systems
+002198 Thai Radio
+002193 Videofon MV
+00218D AP Router Ind. Eletronica Ltda
+00218E Mekics
+002187 Imacs GmbH
+002181 Si2 Microsystems Limited
+00217B Bastec AB
+002174 AvaLAN Wireless
+0021F8 Enseo
+0021F3 Si14 SpA
+0021EC Solutronic GmbH
+0021E6 Starlight Video Limited
+0021E0 CommAgility
+0021D3 Bocom Security(asia Pacific) Limited
+0021D4 Vollmer Werke GmbH
+0021D9 Sekonic
+0021CD LiveTV
+0021C7 Russound
+0021C6 CSJ Global
+0021C1 ABB Oy / Medium Voltage Products
+0021B4 Apro Media
+0021AE Alcatel-lucent France - WTD
+0021A2 EKE-Electronics
+0021A7 Hantle System
+00221F eSang Technologies
+002226 Avaak
+00221A Audio Precision
+002213 PCI
+00220D Cisco Systems
+00220C Cisco Systems
+002207 Inteno Broadband Technology AB
+002202 Excito Elektronik i Skne AB
+0021FD Dsta S.L.
+0021F9 Wirecom Technologies
+001F46 Nortel
+001F40 Speakercraft
+001F38 Positron
+001F3D Qbit GmbH
+001F37 Genesis I&C
+001F2A Accm
+001F31 Radiocomp
+001F25 MBS GmbH
+001F1E Astec Technology
+001F17 IDX Company
+001F18 Hakusan.Mfg.Co
+001E61 Itec Gmbh
+001E5C RB GeneralEkonomik
+001E5B Unitron Company
+001E55 Cowon Systems
+001E4E Dako Edv-ingenieur- und Systemhaus Gmbh
+001E49 Cisco Systems
+001E44 Santec
+001E3F TrellisWare Technologies
+001E38 Bluecard Software Technology
+001E31 Infomark
+001E32 Zensys
+001E2C CyVerse
+001E20 Intertain
+001E25 Intek Digital
+001E19 Gtri
+001E1F Nortel
+001E0F Briot International
+001EE4 ACS Solutions France
+001EEB Talk-A-Phone
+001EDF Master Industrialization Center Kista
+001EDA Wesemann Elektrotechniek
+001ED5 Tekon-Automatics
+001ECE Bisa Technologies (hong Kong) Limited
+001EC8 Rapid Mobile (Pty)
+001EBB Bluelight Technology
+001EB6 TAG Heuer SA
+001EB5 Ever Sparkle Technologies
+001EAF Ophir Optronics
+001EA4 Nokia Danmark A/S
+001EA9 Nintendo
+001EAA E-Senza Technologies GmbH
+001E9D Recall Technologies
+001E98 GreenLine Communications
+001E97 Medium Link System Technology
+001E91 Kimin Electronic
+001E8A eCopy
+001E85 Lagotek
+001E7E Nortel
+001E78 Owitek Technology,
+001E6D IT R&D Center
+001E6E Shenzhen First Mile Communications
+001E68 Quanta Computer
+001F71 xG Technology
+001F72 QingDao Hiphone Technology
+001F76 AirLogic Systems
+001F6C Cisco Systems
+001F60 Compass Systems
+001F65 Korea Electric Terminal
+001F5F Blatand GmbH
+001F59 Kronback Tracers
+001F4D Segnetics
+001F52 UVT Unternehmensberatung fur Verkehr und Technik GmbH
+001F0A Nortel
+001F03 NUM AG
+001EFE Level S.r.o.
+001F04 Granch
+001EF2 Micro Motion
+001EF7 Cisco Systems
+001EF1 Servimat
+001F9E Cisco Systems
+001F92 VideoIQ
+001F97 Bertana srl
+001F8B Cache IQ
+001F84 Gigle Semiconductor
+001F7F Phabrix Limited
+001CFF Napera Networks
+001CF8 Parade Technologies
+001CF1 SUPoX Technology 
+001CF2 Tenlon Technology
+001CEC Mobilesoft (Aust.)
+001CE7 Rocon PLC Research Centre
+001CE2 Attero Tech
+001CDB Carpoint
+001CD6 Nokia Danmark A/S
+001CD5 ZeeVee
+001CCF Limetek
+001E08 Centec Networks
+001E03 LiComm
+001DFC Ksic
+001DF5 Sunshine
+001DF6 Samsung Electronics
+001DF0 Vidient Systems
+001DE9 Nokia Danmark A/S
+001DDC HangZhou DeChangLong Tech&Info
+001DE4 Visioneered Image Systems
+001DE2 Radionor Communications
+001CC8 Industronic Industrie-electronic Gmbh & KG
+001CBC CastGrabber
+001CB2 BPT SPA
+001CA6 Win4NET
+001CAB Meyer Sound Laboratories
+001CAC Qniq Technology
+001CA1 Akamai Technologies
+001C9C Nortel
+001C95 Opticomm
+001C90 Empacket
+001C8F Advanced Electronic Design
+001C89 Force Communications
+001C7F Check Point Software Technologies
+001C75 Segnet
+001C6E Newbury Networks
+001C69 Packet Vision
+001C62 LG Electronics
+001DA5 WB Electronics
+001DA6 Media Numerics Limited
+001DA0 Heng Yu Electronic Manufacturing Company Limited
+001D99 Cyan Optic
+001D94 Climax Technology
+001D93 Modacom
+001D8D Raytek GmbH
+001D86 Shinwa Industries(China)
+001DC9 GainSpan
+001DC2 Xortec OY
+001DBD Versamed
+001DB6 BestComm Networks
+001DB0 FuJian HengTong Information Technology
+001DAC Gigamon Systems
+001D81 Guangzhou Gateway Electronics
+001D69 Knorr-Bremse IT-Services GmbH
+001D70 Cisco Systems
+001D77 NSGate
+001D7C ABE Elettronica
+001D64 Adam Communications Systems Int
+001D5D Control Dynamics
+001D2E Ruckus Wireless
+001D21 Alcad SL
+001D1C Gennet
+001D17 Digital Sky
+001D12 Rohm
+001D11 Analogue & Micro
+001D0B Power Standards Lab
+001D04 Zipit Wireless
+001D58 CQ
+001D57 Caetec Messtechnik
+001D51 Babcock & Wilcox Power Generation Group
+001D47 Covote GmbH & KG
+001D40 Intel  GE Care Innovations
+001D3B Nokia Danmark A/S
+001D34 Syris Technology
+001D2D Pylone
+001B2A Cisco Systems
+001B1D Phoenix International
+001B22 Palit Microsystems ( H.K.)
+001B1B Siemens AG,
+001B16 Celtro
+001B0A Intelligent Distributed Controls
+001B0F Petratec
+001AFE Sofacreal
+001B03 Action Technology (SZ)
+001B68 Modnnet
+001B62 JHT Optoelectronics
+001B61 Digital Acoustics
+001B5C Azuretec
+001B55 Hurco Automation
+001B50 Nizhny Novgorod Factory Named After M.frunze, Fsue (nzif)
+001B44 SanDisk
+001B49 Roberts Radio limited
+001B42 Wise & Blue
+001B3D EuroTel Spa
+001B36 Tsubata Engineering,Ltd. (Head Office)
+001B31 Neural Image.
+001C56 Pado Systems
+001C5B Chubb Electronic Security Systems
+001C5D Leica Microsystems
+001C5C Integrated Medical Systems
+001C51 Celeno Communications
+001C52 Visionee SRL
+001C45 Chenbro Micom
+001C4C Petrotest Instruments
+001C39 S Netsystems
+001C40 VDG-Security bv
+001C32 Telian
+001AC7 Unipoint
+001AC2 YEC
+001AB8 Anseri
+001ABD Impatica
+001AB1 Asia Pacific Satellite Industries
+001B8C JMicron Technology
+001B91 Efkon AG
+001B87 Deepsound Tech.
+001B82 Taiwan Semiconductor
+001B7B The Tintometer
+001B74 MiraLink
+001B6F Teletrak
+001AFC ModusLink
+001AF2 Dynavisions Schweiz AG
+001AF7 dataschalt e+a GmbH
+001AED Incotec Gmbh
+001ADF Interactivetv Limited
+001AE1 Edge Access
+001AE6 Atlanta Advanced Communications Holdings Limited
+001AD3 Vamp
+001ADA Biz-2-Me
+001ACE Yupiteru
+001BC8 Miura
+001BC1 Holux Technology
+001BB7 Alta Heights Technology
+001BAB Telchemy, Incorporated
+001BB0 Bharat Electronics
+001BA4 S.A.E Afikim
+001B9F Calyptech
+001B98 Samsung Electronics
+001B9D Novus Security Sp. z o.o.
+001BF6 Conwise Technology
+001BF1 Nanjing SilverNet Software
+001BEC Netio Technologies
+001BE7 Postek Electronics
+001BE0 Telenot Electronic Gmbh
+001BD9 Edgewater Computer Systems
+001BDB Valeo Vecs
+001BDA UTStarcom
+001BD4 Cisco Systems
+001BCD Daviscomms (S) PTE
+001C2D FlexRadio Systems
+001C1C Center Communication Systems GmbH
+001C21 Nucsafe
+001C20 CLB Benelux
+001C17 Nortel
+001C15 iPhotonix
+001C16 ThyssenKrupp Elevator
+001C10 Cisco-Linksys
+001C09 SAE Electronic
+001C04 Airgain
+001BFD Dignsys
+00192B Aclara RF Systems
+001930 Cisco Systems
+00191D Nintendo
+00191F Microlink communications
+001924 Lbnl  Engineering
+001911 Just In Mobile Information Technologies (Shanghai)
+001918 Interactive Wear AG
+00190C Encore Electronics
+001900 Intelliverese - DBA Voicecom
+001905 Schrack Seconet AG
+0018F4 EO Technics
+0018F6 Thomson Telecom Belgium
+0018FB Compro Technology
+0019EE Carlo Gavazzi Controls Spa-controls Division
+0019F0 Unionman Technology
+0019F5 Imagination Technologies
+0019E9 S-Information Technolgy,
+0019DB Micro-star International
+0019DD FEI-Zyfer
+0019CA Broadata Communications
+0019CF Salicru
+0019D6 LS Cable and System
+0019B4 Intellio
+001A6E Impro Technologies
+001A67 Infinite QL Sdn Bhd
+001A69 Wuhan Yangtze Optical Technology
+001A62 Data Robotics, Incorporated
+001A58 CCV Deutschland GmbH - Celectronic eHealth Div.
+001A5D Mobinnova
+001A4C Crossbow Technology
+001A51 Alfred Mann Foundation
+001AAA Analogic
+001AA1 Cisco Systems
+001A9C RightHand Technologies
+001A8B Chunil Electric IND.
+001A95 Hisense Mobile Communications Technoligy
+001A84 V One Multimedia Pte
+0019A1 LG Information & COMM.
+0019AD Bobst SA
+0019B2 XYnetsoft
+00199A Edo-evi
+00199F DKT A/S
+001995 Jurong Hi-Tech (Suzhou)Co.ltd
+001990 ELM Data
+001989 Sonitrol
+001A45 GN Netcom as
+001A3E Faster Technology
+001A40 A-four Tech
+001A2D The Navvo Group
+001A32 Activa Multimedia
+001A39 Merten GmbH&CoKG
+001A28 Aswt, Taiwan Branch H.K.
+001A1C GT&T Engineering Pte
+001A21 Indac
+001A23 Ice Qube
+001A15 gemalto e-Payment
+001A10 Lucent Trans Electronics
+001A09 Wayfarer Transit Systems
+001A02 Secure Care Products
+001A04 Interay Solutions BV
+0019FD Nintendo
+001984 Estic
+001976 Xipher Technologies
+001978 Datum Systems
+00196A MikroM GmbH
+001971 Guangzhou Unicomp Technology
+001965 YuHua TelTech (ShangHai)
+001960 DoCoMo Systems
+001954 Leaf
+001959 Staccato Communications
+00194D Avago Technologies Sdn Bhd
+001948 AireSpider Networks
+001941 Pitney Bowes
+001935 Duerr Dental AG
+00193A Oesolutions
+00193C HighPoint Technologies Incorporated
+001773 Laketune Technologies
+001778 Central Music
+00177A Assa Abloy AB
+00176F PAX Computer Technology(Shenzhen)
+00176A Avago Technologies
+001763 Essentia
+00175E Zed-3
+001750 GSI Group, MicroE Systems
+001752 DAGS
+001757 RIX Technology Limited
+00183D Vertex Link
+001844 Heads Up Technologies
+001838 PanAccess Communications
+001827 NEC Unified Solutions Nederland
+00182C Ascend Networks
+00182E XStreamHD
+00181B TaiJin Metal
+001814 Mitutoyo
+001819 Cisco Systems
+001820 w5networks
+001808 SightLogix
+00180D Terabytes Server Storage Tech
+001803 ArcSoft Shanghai
+0017F0 Szcom Broadband Network Technology
+0017F7 CEM Solutions Pvt
+0017FE Talos System
+0017D8 Magnum Semiconductor
+0017DD Clipsal Australia
+0017DF Cisco Systems
+0018C6 OPW Fuel Management Systems
+0018CB Tecobest Technology Limited
+0018BF Essence Technology Solution
+0018BA Cisco Systems
+0018B8 New Voice International AG
+0018B3 TEC WizHome
+0018AC Shanghai Jiao Da Hisys Technology
+0018A5 ADigit Technologies
+0018A7 Yoggie Security Systems
+001896 Great Well Electronic
+00189B Thomson
+00179E Sirit
+0017A3 MIX s.r.l.
+0017A8 EDM
+001792 Falcom Wireless Comunications Gmbh
+001797 Telsy Elettronica
+001799 SmarTire Systems
+00178B Teledyne Technologies Incorporated
+00177F Worldsmart Retech
+001786 wisembed
+001877 Amplex A/S
+00186B Sambu Communics
+001870 E28 Shanghai Limited
+00185C EDS Lab Pte
+001863 Veritech Electronics Limited
+001850 Secfone Kft
+001855 Aeromaritime Systembau GmbH
+001857 Unilever R&D
+001849 Pigeon Point Systems
+0017C7 Mara Systems Consulting AB
+0017CE Screen Service Spa
+0017D3 Etymotic Research
+0017BB Syrinx Industrial Electronics
+0017B4 Remote Security Systems
+0017B6 Aquantia
+0017AF Enermet
+0018E8 Hacetron
+0018EF Escape Communications
+0018E3 Visualgate Systems
+0018DC Prostar
+0018E1 Verkerk Service Systemen
+0018D0 AtRoad,  A Trimble Company
+0018D5 Reigncom
+0018A0 Cierma Ascenseurs
+001883 Formosa21
+00188A Infinova
+00188F Montgomery Technology
+00187C Intercross
+00187E RGB Spectrum
+00164A Vibration Technology Limited
+001644 Lite-on Technology
+001645 Power Distribution
+00163B VertexRSI/General Dynamics
+001640 Asmobile Communication
+001639 Ubiquam
+00163A Yves Technology
+001634 Mathtech
+00162D STNet
+001628 Ultra Electronics Manufacturing and Card Systems
+001621 Colorado Vnet
+00161A Dametric AB
+001615 Nittan Company, Limited
+0016C4 SiRF Technology
+0016C6 North Atlantic Industries
+0016D2 Caspian
+0016BF PaloDEx Group Oy
+0016B3 Photonicbridges (China)
+0016AC Toho Technology
+0016B1 KBS
+0016A7 Aweta G&P
+001724 Studer Professional Audio GmbH
+001718 Vansco Electronics Oy
+00171D Digit
+001711 GE Healthcare Bio-Sciences AB
+00170C Twig Com
+001707 InGrid
+0016FB Shenzhen MTC
+001702 Osung Midicom
+001744 Araneo
+00174B Nokia Danmark A/S
+00173C Extreme Engineering Solutions
+001737 Industrie Dial Face
+00172B Global Technologies
+001730 Automation Electronics
+001729 UbicodLTD
+00169B Alstom Transport
+0016A2 CentraLite Systems
+00168F GN Netcom as
+001696 QDI Technology (H.K.) Limited
+001688 ServerEngines
+00168A id-Confirm
+001683 Webio International
+00167C iRex Technologies BV
+001610 Carina Technology
+00160B TVWorks
+001604 Sigpro
+0015FE Schilling Robotics
+0015FD Complete Media Systems
+0015FF Novatel Wireless
+0015F8 Kingtronics Industrial
+0015EC Boca Devices
+0015F1 Kylink Communications
+001677 Bihl + Wiedemann GmbH
+001670 Sknet
+001664 Prod-El SpA
+001669 MRV Communication (Networks)
+00165D AirDefense
+001656 Nintendo
+001651 Exeo Systems
+0015E5 Cheertek
+0015DB Canesta
+0015D4 Emitor AB
+0015C8 FlexiPanel
+0015C3 Ruf Telematik AG
+0015C2 3M Germany
+0015BE Iqua
+0015B7 Toshiba
+0015B9 Samsung Electronics
+0016EF Koko Fitness
+0016F4 Eidicom
+0016E8 Sigma Designs
+0016ED Digital Safety Technologies
+0016DC Archos
+0016E1 SiliconStor
+0016D7 Sunways AG
+0014CB LifeSync
+0014D0 BTI Systems
+0014C4 Vitelcom Mobile Technology
+0014BE Wink communication technologyLTD
+0014BD incNETWORKS
+0014B8 Hill-Rom
+0014AE Wizlogics
+0014B3 CoreStar International
+0014A7 Nokia Danmark A/S
+00149B Nokota Communications
+00143F Hotway Technology
+001431 PDL Electronics
+001433 Empower Technologies(Canada)
+001432 Tarallax Wireless
+00142C Koncept International
+001425 Galactic Computing
+001420 G-Links networking company
+00141B Cisco Systems
+00146D RF Technologies
+00146F Kohler
+00146E H. Stoll GmbH & KG
+001468 CelPlan International
+001461 Corona
+00145C Intronics
+001455 Coder Electronics
+001444 Grundfos Holding
+00144B Hifn
+001589 D-MAX Technology
+00157D Posdata
+001582 Pulse Eight Limited
+00157C Dave Networks
+001578 Audio / Video Innovations
+001573 NewSoft  Technology
+00156C Sane System
+001571 Nolan Systems
+001572 Red-Lemon
+001565 Xiamen Yealink Network Technology
+001559 Securaplane Technologies
+0014A2 Core Micro Systems
+001494 ESU AG
+00148F Protronic (Far East)
+001488 Akorri
+001483 eXS
+001480 Hitachi-LG Data Storage Korea
+00147B Iteris
+001474 K40 Electronics
+0015B8 Tahoe
+0015B2 Advanced Industrial Computer
+0015AE kyung il
+0015AD Accedian Networks
+00E0A8 SAT GmbH
+0015A1 Eca-sinters
+00159C B-kyung System
+001595 Quester Tangent
+00158E Plustek.INC
+001552 Wi-Gear
+001548 Cube Technologies
+00154D Netronome Systems
+00153C Kprotech
+001543 Aberdeen Test Center
+001535 OTE Spa
+001537 Ventus Networks
+001536 Powertech
+001530 EMC
+001529 N3
+0014F9 Vantage Controls
+0014FB Technical Solutions
+0014FA AsGa
+0014F4 DekTec Digital Video
+0014ED Airak
+0014DE Sage Instruments
+0014E3 mm-lab GmbH
+0014D7 Datastore Technology
+001524 Numatics
+00151D M2I
+001513 EFS sas
+001507 Renaissance Learning
+00129E Surf Communications
+001297 O2Micro
+001298 Mico Electric(shenzhen) Limited
+00128D STB Datenservice GmbH
+00128E Q-Free ASA
+001292 Griffin Technology
+00127C Swegon AB
+001281 March Networks
+00127B VIA Networking Technologies
+001327 Data Acquisitions limited
+00131D Scanvaegt International A/S
+001322 DAQ Electronics
+001316 L-S-B Broadcast Technologies GmbH
+00130A Nortel
+00130F Egemen Bilgisayar Muh San ve Tic STI
+0012F7 Xiamen Xinglian Electronics
+0012FE Lenovo Mobile Communication Technology
+001303 GateConnect
+0012FD Optimus IC
+00140F Federal State Unitary Enterprise Leningrad R&D Institute of
+001416 Scosche Industries
+001406 Go Networks
+001407 Sperian Protection Instrumentation
+00140C GKB Cctv
+0013FF Dage-MTI of MC
+001400 Minerva Korea
+0013FA LifeSize Communications
+0013F3 Giga-byte Communications
+0013EE JBX Designs
+0013ED Psia
+00135A Project T&E Limited
+00135F Cisco Systems
+001360 Cisco Systems
+001352 Naztec
+00134B ToGoldenNet Technology
+00134C YDT Technology International
+00133A VadaTech
+00133F Eppendorf Instrumente GmbH
+00132C MAZ Brandenburg GmbH
+001339 CCV Deutschland GmbH
+0013AD Sendo
+0013B4 Appear TV
+0013A8 Tanisys Technology
+0013A7 Battelle Memorial Institute
+0013A1 Crow Electronic Engeneering
+00139A K-ubique ID
+001395 congatec AG
+00138E Foab Elektronik AB
+001388 WiMedia Alliance
+0013E4 Yangjae Systems
+0013E9 VeriWave
+0013E3 CoVi Technologies
+0013DD Abbott Diagnostics
+0013D6 TII Network Technologies
+0013D1 Kirk Telecom A/S
+0013CA Pico Digital
+0013C3 Cisco Systems
+0013C4 Cisco Systems
+0013BA ReadyLinks
+0013BE Virtual Conexions
+0013B9 BM SPA
+0012F3 connectBlue AB
+0012ED AVG Advanced Technologies
+0012E6 Spectec Computer
+0012E1 Alliant Networks
+0012D3 Zetta Systems
+0012DA Cisco Systems
+0012D4 Princeton Technology
+0012C7 Securay Technologiesco.
+0012CE Advanced Cybernetics Group
+0012C2 Apex Electronics Factory
+0012C1 Check Point Software Technologies
+0012B8 G2 Microsystems
+0012BD Avantec Manufacturing Limited
+0012B7 PTW Freiburg
+0012B1 Dai Nippon Printing
+0012A5 Stargen
+0012AA IEE
+001379 Ponder Information Industries
+001380 Cisco Systems
+001385 Add-On Technology
+00137F Cisco Systems
+00136D Tentaculus AB
+001366 Neturity Technologies
+001258 Activis Polska
+001251 Silink
+001252 Citronix
+001245 Zellweger Analytics
+00124C Bbwm
+001239 S Net Systems
+001240 Amoi Electronics
+00122D SiNett
+001232 LeWiz Communications
+0011C5 TEN Technology
+0011C8 Powercom
+0011CD Axsun Technologies
+0011C6 Seagate Technology
+0011B4 Westermo Teleindustri AB
+0011B9 Inner Range
+0011C0 Aday Technology
+0011B3 Yoshimiya
+0011AD Shanghai Ruijie Technology
+001138 Taishin
+00113F Alcatel DI
+001133 Siemens Austria Simea
+001132 Synology Incorporated
+001129 Paradise Datacom
+00112E Ceicom
+001128 Streamit
+00111B Targa Systems Div L-3 Communications Canada
+001122 Cimsys
+001171 Dexter Communications
+001165 Znyx Networks
+00116A Domo
+001160 Artdio Company
+001154 Webpro Technologies
+00115B Elitegroup Computer System (ECS)
+00114B Francotyp-Postalia GmbH
+001145 ValuePoint Networks
+0011A1 Vision Netware
+0011A6 Sypixx Networks
+00119A Alkeria srl
+001190 Digital Design
+00118A Viewtran Technology Limited
+001194 Chi Mei Communication Systems
+001189 Aerotech
+001184 Humo Laboratory
+00117D ZMD America
+001178 Chiron Technology
+001177 Coaxial Networks
+001223 Pixim
+001228 Data
+00121C Parrot
+001210 WideRay
+001215 iStor Networks
+001216 ICP Internet Communication Payment AG
+001209 Fastrax
+001204 u10 Networks
+0011FD Korg
+001203 ActivNetworks
+0011F3 NeoMedia Europe AG
+0011E7 Worldsat - Texas de France
+0011EC Avix
+0011E0 U-media Communications
+0011DA Vivaas Technology
+0011D4 NetEnrich
+0011D9 TiVo
+00111C Pleora Technologies
+00110F netplat
+001116 Coteau Vert
+001109 Micro-Star International
+001103 kawamura electric
+000FFD Glorytek Network
+000FEE XTec, Incorporated
+000FF4 Guntermann & Drunck GmbH
+001275 Sentilla
+00126E Seidel Elektronik GmbH Nfg.KG
+001269 Value Electronics
+001262 Nokia Danmark A/S
+00125C Green Hills Software
+000F15 Kjaerulff1 A/S
+000F1A Gaming Support
+000F0E WaveSplitter Technologies
+000F08 Indagon Oy
+000F07 Mangrove Systems
+000F02 Digicube Technology
+000EFB Macey Enterprises
+000EF5 iPAC Technology
+000EF6 E-TEN Information Systems
+000E8A Avara Technologies
+000E83 Cisco Systems
+000E73 Tpack A/S
+000E7D Electronics Line 3000
+000E77 Decru
+000E7E ionSign Oy
+000E6F Iris Berhad
+000E6A 3Com
+000E69 China Electric Power Research Institute
+000E63 Lemke Diagnostics GmbH
+000EBC Paragon Fidelity GmbH
+000EB0 Solutions Radio BV
+000EB5 Ecastle Electronics
+000EAF Castel
+000EA9 Shanghai Xun Shi Communications Equipment
+000E9D Tiscali UK
+000EA2 McAfee
+000E90 Ponico
+000E8F Sercomm
+000E96 Cubic Defense Applications
+000F4E Cellink
+000F41 Zipher
+000F48 Polypix
+000F4D TalkSwitch
+000F39 Iris Sensors
+000F3C Endeleo Limited
+000F34 Cisco Systems
+000F2D Chung-hsin Electric & Machinery Mfg.corp.
+000F27 Teal Electronics
+000F28 Itronix
+000F21 Scientific Atlanta
+000EE8 zioncom
+000EEF Private
+000EDC Tellion
+000EE3 Chiyu Technology
+000EC8 Zoran
+000ECF Profibus Nutzerorganisation e.V.
+000ED4 Cresitt Industrie
+000EC2 Lowrance Electronics
+000EC1 Mynah Technologies
+000F92 Microhard Systems
+000F99 Apac Opto Electronics
+000F8D Fast Tv-server AG
+000F80 Trinity Security Systems
+000F7F Ubstorage
+000FC2 Uniwell
+000FC9 Allnet GmbH
+000FBC Onkey Technologies
+000FBB Nokia Siemens Networks GmbH & KG.
+000FB6 Europlex Technologies
+000FA9 PC Fabrik
+000FAA Nexus Technologies
+000FAF Dialog
+000FE8 Lobos
+000FED Anam Electronics
+000FDB Westell Technologies
+000FDC Ueda Japan  Radio
+000FE1 ID Digital
+000FD5 Schwechat - Rise
+000FCE Kikusui Electronics
+000F73 RS Automation
+000F7A BeiJing NuQX Technology
+000F6D Midas Engineering
+000F67 West Instruments
+000F6E BBox
+000F60 Lifetron
+000F5B Delta Information Systems
+000F54 Entrelogic
+000D75 Kobian Pte - Taiwan Branch
+000D7C Codian
+000D6F Ember
+000D69 TMT&D
+000D70 Datamax
+000D5D Raritan Computer
+000D62 Funkwerk Dabendorf GmbH
+000D50 Galazar Networks
+000D4A Steag ETA-Optik
+000DAB Parker Hannifin GmbH Electromechanical Division Europe
+000DA7 Private
+000DA1 Mirae ITS
+000DA2 Infrant Technologies
+000D9B Heraeus Electro-Nite International N.V.
+000D8F King Tsushin Kogyo
+000D94 Afar Communications
+000D82 PHS srl
+000D81 Pepperl+Fuchs GmbH
+000DCE Dynavac Technology Pte
+000DC8 AirMagnet
+000DC2 Private
+000DC7 Cosmic Engineering
+000DBB Nippon Dentsu
+000DB5 Globalsat Technology
+000DAF Plexus (UK)
+000D29 Cisco Systems
+000D23 Smart Solution
+000D17 Turbo NetworksLtd
+000D1C Amesys Defense
+000D0A Projectiondesign as
+000D09 Yuehua(Zhuhai) Electronic
+000D10 Embedtronics Oy
+000D04 Foxboro Eckardt Development GmbH
+000CF7 Nortel Networks
+000CF8 Nortel Networks
+000CFD Hyundai ImageQuest
+000D4F Kenwood
+000D46 Parker SSD Drives
+000D42 Newbest Development Limited
+000D3C i.Tech Dynamic
+000D36 Wu Han Routon Electronic
+000D3B Microelectronics Technology
+000D2A Scanmatic AS
+000D2F AIN Comm.Tech.Co.
+000DFA Micro Control Systems
+000DF4 Watertek
+000DF9 NDS Limited
+000E00 Atrie
+000DE7 Snap-on OEM Group
+000DE8 Nasaco Electronics Pte.
+000DED Cisco Systems
+000DE1 Control Products
+000DD5 O'rite Technology
+000DDA Allied Telesis K.K.
+000E20 Access Systems Americas
+000E27 Crere Networks
+000E14 Visionary Solutions
+000E1B IAV GmbH
+000E57 Iworld Networking
+000E50 Thomson Telecom Belgium
+000E4A Changchun Huayu Webpad
+000E49 Forsway Scandinavia AB
+000E3D Televic N.V.
+000E44 Digital
+000E33 Shuko Electronics
+000E3A Cirrus Logic
+000E2D Hyundai Digital Technology
+000E2E Edimax Technology
+000CEA aphona Kommunikationssysteme
+000CD9 Itcare
+000CD3 Prettl Elektronik Radeberg GmbH
+000CDA FreeHand Systems
+000CDF Pulnix America
+000CC7 Intelligent Computer Solutions
+000CCC Aeroscout
+000C13 MediaQ
+000C05 RPA Reserch
+000C0C Appro Technology
+000BF4 Private
+000BF9 Gemstone Communications
+000C00 BEB Industrie-Elektronik AG
+000BF3 BAE Systems
+000C63 Zenith Electronics
+000C68 SigmaTel
+000C6F Amtek system
+000C50 Seagate Technology
+000C55 Microlink Communications
+000C5C GTN Systems
+000C61 AC Tech DBA Advanced Digital
+000C49 Dangaard Telecom RTC Division A/S
+000CBA Jamex
+000CB9 LEA
+000CC0 Genera Oy
+000CB4 AutoCell Laboratories
+000C34 Vixen
+000CA2 Harmonic Video Network
+000CA7 Metro (Suzhou) Technologies
+000CA9 Ebtron
+000CAE Ailocom Oy
+000C42 Routerboard.com
+000C44 Automated Interfaces
+000C39 Sentinel Wireless
+000C3B Orion Electric
+000C40 Altech Controls
+000C3A Oxance
+000C2F SeorimTechnology
+000C31 Cisco Systems
+000C2A Octtel Communication
+000C27 Sammy
+000C18 Zenisu Keisoku
+000C20 Fi WIn
+000BED ELM
+000BF2 Chih-Kan Technology
+000BE1 Nokia NET Product Operations
+000BE6 Datel Electronics
+000BDA EyeCross
+000BD1 Aeronix
+000BC5 SMC Networks
+000BCC Jusan
+000BB9 Imsys AB
+000BBE Cisco Systems
+000BB2 Smallbig Technology
+000BB7 Micro Systems
+000C96 OQO
+000C9B EE Solutions
+000C8A Bose
+000C8F Nergal s.r.l.
+000C83 Logical Solutions
+000C88 Apache Micro Peripherals
+000C74 Rivertec
+000C76 Micro-star International
+000C7B Alpha Project
+000B85 Cisco Systems
+000B7F Align Engineering
+000B84 Bodet
+000B73 Kodeos Communications
+000B78 Taifatech
+000B6C Sychip
+000B60 Cisco Systems
+000B65 Sy.A.C. srl
+000B57 Silicon Laboratories
+000B5C Newtech
+000B4F Verifone
+000B43 Microscan Systems
+000B48 sofrel
+000B4A Visimetrics (UK)
+000B35 Quad Bit System
+000B37 Manufacture DES Montres Rolex SA
+000B3C Cygnal Integrated Products
+000B29 LS(LG) Industrial Systems
+000B30 Beijing Gongye Science & Technology
+000BA1 Syscom
+000BA8 Hanback Electronics
+000B92 Ascom Danmark A/S
+000B97 Matsushita Electric Industrial
+000B9C TriBeam Technologies
+000B8B Kerajet
+0009D6 KNC One GmbH
+0009D5 Signal Communication
+0009DC Galaxis Technology AG
+0009C9 BlueWINC
+0009D0 Solacom Technologies
+0009BC Digital Safety Technologies
+0009C1 Proces-data A/S
+0009C4 Medicore
+00098F Cetacean Networks
+00097D SecWell Networks Oy
+00097E IMI Technology
+000983 GlobalTop Technology
+000970 Vibration Research
+000977 Brunner Elektronik AG
+000964 Hi-Techniques
+00096B IBM
+000957 Supercaller
+00095C Philips Medical Systems - Cardiac and Monitoring Systems (CM
+000AE3 Yang MEI Technology
+000AEA Adam Elektronik ti
+000ADE Happy Communication
+000AD7 Origin Electric
+000ACB Xpak MSA Group
+000AD0 Niigata Develoment Center,  F.I.T.
+000AD2 Jepico
+000ABD Rupprecht & Patashnick
+000ABF Hirota SS
+000AC4 Daewoo Teletech
+000AAC TerraTec Electronic GmbH
+000AB1 Genetec
+000AB8 Cisco Systems
+000AA5 Maxlink Industries Limited
+000A8D Eurotherm Limited
+000A9E BroadWeb Corportation
+000AA0 Cedar Point Communications
+000A98 M+F Gwinner GmbH
+000A92 Presonus
+000A7E The Advantage Group
+000A85 Plat'c2
+000A8A Cisco Systems
+0009B5 3J Tech.
+0009AF e-generis
+0009B0 Onkyo
+0009A9 Ikanos Communications
+00099D Haliplex Communications
+0009A2 Interface
+000990 Acksys Communications & Systems
+000996 RDI
+00098A EqualLogic
+000A77 Bluewire Technologies
+000A79 corega K.K
+000A72 STEC
+000A5F almedio
+000A66 Mitsubishi Electric System & Service
+000A6B Tadiran Telecom Business Systems
+000A5A GreenNET Technologies
+000A53 Intronics, Incorporated
+000A58 Freyer & Siegel Elektronik GmbH & KG
+000A4C Molecular Devices
+000B24 AirLogic
+000B1D LayerZero Power Systems
+000B16 Communication Machinery
+000B18 Private
+000B11 Himeji ABC Trading
+000B0A dBm Optics
+000B05 Pacific Broadband Networks
+000AFE NovaPal
+000B03 Taekwang Industrial
+000AEF Otrum ASA
+000AF2 NeoAxiom
+000A05 Widax
+000A08 Alpine Electronics
+000A0A Sunix
+000A0F Ilryung Telesys
+0009FF X.net 2000 GmbH
+0009FE Daisy Technologies
+000A00 Mediatek
+0009F6 Shenzhen Eastern Digital Tech
+0009F5 Emerson Network Power
+0009E8 Cisco Systems
+0009EF Vocera Communications
+0009E3 Angel Iglesias
+000A39 LoPA Information Technology
+000A40 Crown Audio -- Harmanm International
+000A45 Audio-Technica
+000A47 Allied Vision Technologies
+000A34 Identicard Systems Incorporated
+000A2D Cabot Communications Limited
+000A22 Amperion
+000A16 Lassen Research
+000A1B Stream Labs
+000878 Benchmark Storage Innovations
+000872 Sorenson Communications
+00087E Bon Electro-Telecom
+00086B Mipsys
+000865 Jascom
+000866 DSX Access Systems
+00085F Picanol N.V.
+000859 ShenZhen Unitone Electronics
+000853 Schleicher GmbH & Relaiswerke KG
+000858 Novatechnology
+00081D Ipsil, Incorporated
+000829 Aval Nagasaki
+000823 Texa
+00082A Powerwallz Network Security
+000817 EmergeCore Networks
+00091E Firstech Technology
+000925 VSN Systemen BV
+000918 Samsung Techwin
+000917 WEM Technology
+000912 Cisco Systems
+00090B MTL  Instruments PLC
+000905 iTEC Technologies
+0008FF Trilogy Communications
+000906 Esteem Networks
+0008FB SonoSite
+0008F1 Voltaire
+0008F2 C&S Technology
+0008F7 Hitachi, Semiconductor & Integrated Circuits Gr
+0008ED ST&T Instrument
+0007D1 Spectrum Signal Processing
+0007CE Cabletime Limited
+0007C8 Brain21
+0007BC Identix
+00047C Skidata AG
+0007BB Candera
+0007C2 Netsys Telecom
+0007B5 Any One Wireless
+0007AF Red Lion Controls
+0007A2 Opteon
+0007A7 A-Z
+0007A1 Viasys Healthcare Gmbh
+0007A8 Haier Group Technologies
+00094A Homenet Communications
+000949 Glyph Technologies
+000950 Independent Storage
+000944 Cisco Systems
+00093D Newisys
+000937 Inventec Appliance
+000931 Future Internet
+000938 Allot Communications
+00092A Mytecs
+0008B1 ProQuent Systems
+0008AB EnerLinx.com
+0008AC Eltromat GmbH
+0008A5 Peninsula Systems
+00089F EFM Networks
+000899 Netbind
+00089E Beijing Enter-NetLTD
+000895 Dirc Technologie Gmbh &KG
+000891 Lyan
+00088B Tropic Networks
+00088A Minds@Work
+000885 EMS Dr. Thomas Wnsche
+0008E8 Excel Master
+0008E7 SHI ControlSystems
+0008E1 Barix AG
+0008DA SofaWare Technologies
+0008D5 Vanguard Networks Solutions
+0008CE IPMobileNet
+0008C8 Soneticom
+0008C4 Hikari
+0008BE Xenpak MSA Group
+0008B8 E.F. Johnson
+00079B Aurora Networks
+000795 Elitegroup Computer System (ECS)
+00078F Emkay Innovative Products
+000788 Clipcomm
+000782 Oracle 
+000779 Sungil Telecom
+000778 Gerstel Gmbh & KG
+000772 Alcatel Shanghai Bell
+00076C Daehanet
+00075C Eastman Kodak Company
+000761 Logitech Europe SA
+000768 Danfoss A/S
+000762 Group Sense Limited
+000755 Lafon
+00074F Cisco Systems
+000741 Sierra Automated Systems
+000749 CENiX
+000735 Flarion Technologies
+00073B Tenovis GmbH & KG
+000729 Kistler Instrumente AG
+00072E North Node AB
+000728 Neo Telecom
+000718 iCanTek
+00080D Toshiba
+000806 Raonet Systems
+0007FD LANergy
+0007F6 Qqest Software Systems
+0007FC Adept Systems
+0007EA Massana
+0007F0 LogiSync
+0007E3 Navcom Technology
+0007E4 SoftRadio
+0007DD Cradle Technologies
+0007D7 Caporis Networks AG
+0006E3 Quantitative Imaging
+0006DD AT & T Laboratories - Cambridge
+0006A4 Innowell
+0006D3 Alpha Telecom, U.S.A.
+0006D2 Tundra Semiconductor
+000647 Etrali
+0006D9 IPM-Net
+0005EA Rednix
+0006CD Leaf Imaging
+0006BC Macrolink
+0006C6 lesswire AG
+000654 Winpresa Building Automation Technologies GmbH
+0006B6 Nir-Or Israel
+0006B0 Comtech EF Data
+00071F European Systems Integration
+000724 Telemax
+000707 Interalia
+00070C SVA-Intrusion.com
+000711 Acterna
+000712 JAL Information Technology
+0006FA IP Square
+0006EF Maxxan Systems
+0006EA Elzet80 Mikrocomputer Gmbh&co. KG
+0006E9 Intime
+0005EB Blue Ridge Networks
+0005F7 Analog Devices
+0005E4 Red Lion Controls
+0005F1 Vrcom
+0005FD PacketLight Networks
+0005E2 Creativ Network Technologies
+0005DC Cisco Systems
+0005E1 Trellis Photonics
+0005D8 Arescom
+0005D7 Vista Imaging
+0005C5 Flaga HF
+0005D1 Metavector Technologies
+0005D2 DAP Technologies
+0005CB Rois Technologies
+00057F Acqis Technology
+000579 Universal Control Solution
+000575 CDS-Electronics BV
+00056F Innomedia Technologies Pvt.
+000569 VMware
+000568 Piltofish Networks AB
+000562 Digital View Limited
+00055C Kowa Company
+000556 360 Systems
+000550 Vcomms Connect Limited
+000545 Internet Photonics
+00053F VisionTek
+000546 Kddi Network & Solultions
+0006AA VT Miltope
+0006A9 Universal Instruments
+0006A0 Mx Imaging
+00069F Kuokoa Networks
+000699 Vida Design
+000693 Flexus Computer Technology
+00069A e & Tel
+00068D Sepaton
+000687 Omnitron Systems Technology
+000680 Card Access
+000539 A Brand New World in Sweden AB
+000526 Ipas Gmbh
+00052D Zoltrix International Limited
+00052C Supreme Magic
+000520 Smartronix
+00051A 3com Europe
+000510 Infinite Shanghai Communication Terminals
+000514 KDT Systems
+000509 Avoc Nishimura
+000503 Iconag
+00050A ICS Spa
+0004FF Acronet
+000500 Cisco Systems
+000641 Itcn
+00063D Microwave Data Systems
+000631 Calix
+000630 Adtranz Sweden
+000637 Toptrend-Meta Information (ShenZhen)
+000620 Serial System
+00061A Zetari
+00060C Melco Industries
+000614 Prism Holdings
+000606 RapidWAN
+000677 Sick AG
+000673 TKH Security Solutions USA
+000666 Roving Networks
+00066D Compuprint
+00066C Robinson
+000653 Cisco Systems
+00065A Strix Systems
+00064D Sencore
+000660 Nadex
+0005B8 Electronic Design Associates
+0005BF JustEzy Technology
+0005AE Mediaport USA
+0005B2 Medison
+00059E Zinwell
+0005A5 Kott
+000598 Cronos S.r.l.
+0005A4 Lucid Voice
+000592 Pultek
+00058B IPmental
+00058C Opentech
+00037E Portech Communications
+000383 Metera Networks
+000377 Gigabit Wireless
+00037B Idec Izumi
+00036B Cisco Systems
+000372 Ulan
+000367 Jasmine Networks
+00036A Mainnet
+000364 Scenix Semiconductor
+00035F Prftechnik Condition Monitoring GmbH & KG
+00035C Saint Song
+000358 Hanyang Digitech
+00034D Chiaro Networks
+0003FA TiMetra Networks
+0003F5 Chip2Chip
+0003EE MKNet
+0003E8 Wavelength Digital Limited
+0003E3 Cisco Systems
+0003DC Lexar Media
+0003D7 NextNet Wireless
+0003D4 Alloptic
+00030B Hunter Technology
+0003D0 Koankeiso
+0003C9 Tecom
+0003C4 Tomra Systems ASA
+0004FA NBS Technologies
+0004F9 Xtera Communications
+0004F3 FS Forth-systeme Gmbh
+0004E7 Lightpointe Communications
+0004ED Billion Electric
+0004DD Cisco Systems
+0004D6 Takagi Industrial
+0004D0 Softlink s.r.o.
+0004CA FreeMs
+0004BE OptXCon
+0004C3 Castor Informatique
+0004C4 Allen & Heath Limited
+0004B7 AMB i.t. Holding
+0004B1 Signal Technology
+0004AD Malibu Networks
+0004AA Jetstream Communications
+0004A3 Microchip Technology
+00049D Ipanema Technologies
+000497 MacroSystem Digital Video AG
+000490 Optical Access
+00048B Poscon
+000341 Axon Digital Design
+00033E Tateyama System Laboratory
+00033A Silicon Wave
+000333 Digitel
+00032B GAI Datenfunksysteme GmbH
+000327 Act'l
+00032E Scope Information Management
+000322 Idis
+00031E Optranet
+00B052 Atheros Communications
+000319 Infineon AG
+000316 Nobell Communications
+000312 TR-Systemtechnik GmbH
+000447 Acrowave Systems
+00043B Lava Computer Mfg.
+000440 cyberPIXIE
+00043A Intelligent Telecommunications
+000434 Accelent Systems
+00042D Sarian Systems
+00042E Netous Technologies
+000428 Cisco Systems
+000421 Ocular Networks
+000417 Elau AG
+000411 Inkra Networks
+00040B 3com Europe
+000404 Makino Milling Machine
+000481 Econolite Control Products
+000486 ITTC, University of Kansas
+000477 Scalant Systems
+000476 3 Com
+000469 Innocom
+000470 ipUnplugged AB
+00046A Navini Networks
+000464 Pulse-Link
+00045D Beka Elektronik
+0003B2 Radware
+000457 Universal Access Technology
+000451 Medrad
+0003C1 Packet Dynamics
+0003BD OmniCluster Technologies
+0003B8 NetKit Solutions
+0003B6 QSI
+0003A6 Traxit Technology
+0003AB Bridge Information Systems
+0003A3 Mavix
+00039F Cisco Systems
+00039A SiConnect
+00038C Total Impact
+000384 Aeta
+000387 Blaze Network Products
+000306 Fusion In Tech
+000303 Jama Electronics
+0002FF Handan BroadInfoCom
+0002F3 Media Serve
+0002FA DX Antenna
+0002ED DXO Telecom
+0002E5 Timeware
+0002E8 E.d.&a.
+0002DC Fujitsu General Limited
+0002E1 Integrated Network
+0002D5 ACR
+0002C9 Mellanox Technologies
+0002CE FoxJet
+00B0DB Nextcell
+00B08E Cisco Systems
+00B01C Westport Technologies
+00B02D ViaGate Technologies
+00B03B HiQ Networks
+0030A9 Netiverse
+00B0F0 Caly Networks
+00B086 LocSoft Limited
+0030C4 Canon Imaging Systems
+00309D Nimble Microsystems
+003037 Packard Bell Nec Services
+00302E Hoft & Wessel AG
+00301B Shuttle
+003028 Fase Saldatura srl
+0030FB AZS Technology AG
+003048 Supermicro Computer
+0001DA Wincomm
+0001E1 Kinpo Electronics
+0001DD Avail Networks
+0001CE Custom Micro Products
+0001CA Geocast Network Systems
+0001B8 Netsensity
+0001BD Peterson Electro-Musical Products
+0001B4 Wayport
+0001C3 Acromag
+0001BF Teleforce
+0001AD Coach Master International  d.b.a. CMI Worldwide
+00017E Adtek System Science
+00018A ROI Computer AG
+000119 RTUnet (Australia)
+000125 Yaesu Musen
+000121 Watchguard Technologies
+000128 EnjoyWeb
+000106 Tews Datentechnik GmbH
+000112 Shark Multimedia
+000102 3com
+000115 Extratech
+000109 Nagano Japan Radio
+081443 Unibrain
+00B0F5 NetWorth Technologies
+00B019 UTC CCS
+00B02A Orsys Gmbh
+00B0AE Symmetricom
+000181 Nortel Networks
+00018D AudeSi Technologies
+00019A Leunig Gmbh
+000193 Hanbyul Telecom
+0001A2 Logical
+000196 Cisco Systems
+0001A6 Scientific-Atlanta Arcodan A/S
+000172 TechnoLand
+00303F TurboComm Tech
+003073 International Microsystems
+00014D Shin Kin Enterprises
+00016B LightChip
+000167 Hioki E.E.
+00020E ECI Telecom
+000215 Cotas Computer Technology A/B
+000211 Nature Worldwide Technology
+000209 Shenzhen SED Information Technology
+000205 Hitachi Denshi
+000202 Amino Communications
+0001F6 Association of Musical Electronics Industry
+0001ED Seta
+0001E9 Litton Marine Systems
+0002C6 Data Track Technology PLC
+0002C2 Net Vision Telecom
+0002B9 Cisco Systems
+0002B4 Daphne
+0002AD Hoya
+0002A6 Effinet Systems
+0002A1 World Wide Packets
+00029B Kreatel Communications AB
+00029E Information Equipment
+000296 Lectron
+00028F Globetek
+000289 DNE Technologies
+000285 Riverstone Networks
+00027E Cisco Systems
+000280 Mu Net
+000279 Control Applications
+000272 CC&C Technologies
+00026B BCM Computers
+00026D Adept Telecom
+000262 Soyo Group Soyo Com Tech
+000260 Accordion Networks
+00025B Cambridge Silicon Radio
+000087 Hitachi
+000252 Carrier
+00024B Cisco Systems
+000246 All-Win Tech
+00017A Chengdu Maipu Electric Industrial
+000235 Paragon Networks International
+000238 Serome Technology
+000230 Intersoft Electronics
+000229 Adtec
+000225 One Stop Systems
+00021C Network Elements
+000221 DSP Application
+00016E Conklin
+00015B Italtel S.p.a/rf-up-i
+000154 G3M
+000150 Gilat Communications
+00012E PC Partner
+00013A Shelcad Communications
+000141 Cable Print
+000131 Bosch Security Systems
+00013D RiscStation
+000149 T.D.T. Transfer Data Test GmbH
+00D047 XN Technologies
+00D018 QWES. COM
+00D048 Ecton
+00D028 Harmonic
+00D02F Vlsi Technology
+00D025 Xrosstech
+00D085 Otis Elevator Company
+00D077 Lucent Technologies
+00D093 TQ - Components Gmbh
+00D013 Primex Aerospace Company
+00D056 Somat
+00D017 Syntech Information
+00D036 Technology Atlanta
+00D0D6 Aethra Telecomunicazioni
+003078 Cisco Systems
+003003 Phasys
+0030D5 DResearch GmbH
+0030CE Zaffire
+003095 Procomp Informatics
+003055 Renesas Technology America
+0030B0 Convergenet Technologies
+0030CC Tenor Networks
+003013 NEC
+003061 MobyTEL
+00D0AB Deltakabel Telecom CV
+00D0A8 Network Engines
+00D01C SBS Technologies,
+00D0C0 Cisco Systems
+00D051 O2 Micro
+00D06D Acrison
+0050A1 Carlo Gavazzi
+00D06C Sharewave
+00D03A Zoneworx
+0050C1 Gemflex Networks
+0050FB VSK Electronics
+005033 Mayan Networks
+0030A0 Tyco Submarine Systems
+0030CB Omni Flow Computers
+00306B Cmos Systems
+003068 Cybernetics TECH.
+0030E3 Sedona Networks
+00D007 MIC Associates
+00D07F Strategy & Technology, Limited
+003085 Cisco Systems
+003026 HeiTel Digital Video GmbH
+0030A6 Vianet Technologies
+003047 Nissei Electric
+00D0FC Granite Microsystems
+00D042 Mahlo Gmbh & UG
+00D046 Dolby Laboratories
+00D0BA Cisco Systems
+00D0BC Cisco Systems
+00D0D8 3Com
+00D06B SR Telecom
+0030AA Axus Microsystems
+003043 Idream Technologies, PTE.
+003010 Visionetics International
+003096 Cisco Systems
+003084 Allied Telesyn Internaional
+0030CF TWO Technologies
+00D0E3 Ele-chem Engineering
+00D0ED Xiox
+00D0C2 Balthazar Technology AB
+00D0FB TEK Microsystems, Incorporated
+00D082 Iowave
+00D0AD TL Industries
+00D0DB Mcquay International
+00D06A Linkup Systems
+00D065 Toko Electric
+00D08F Ardent Technologies
+00D0E7 Vcon Telecommunication
+00D087 Microfirst
+00D008 Mactell
+003005 Fujitsu Siemens Computers
+00304E Bustec Production
+0030E0 Oxford Semiconductor
+0030A1 Webgate
+00303D IVA
+0030C3 Flueckiger Elektronik AG
+009047 Giga Fast E.
+0090CB Wireless OnLine
+00903F Aztec Radiomedia
+001043 A2
+00108D Johnson Controls
+00108E Hugh Symons Concept Technologies
+001052 Mettler-toledo (albstadt) Gmbh
+00100E Micro Linear Coporation
+0010D7 Argosy Research
+001059 Diablo Research
+0010B6 Entrata Communications
+001019 Sirona Dental Systems Gmbh & KG
+001013 Kontron America
+0090A4 Altiga Networks
+00906C Sartorius Hamburg GmbH
+0090FC Network Computing Devices
+0090A3 Corecess
+009022 Ivex
+0090A5 Spectra Logic
+0090BA Valid Networks
+0090EE Personal Communications Technologies
+0090CD Ent-empresa Nacional DE Telecommunicacoes
+0090D0 Thomson Telecom Belgium
+009075 NEC DO Brasil
+00902E Namco Limited
+0090A0 8X8
+00907C Digitalcast
+0090DF Mitsubishi Chemical America
+009023 Zilog
+00908A Bayly Communications
+009063 Coherent Communications Systems
+009041 Applied Digital Access
+0090D8 Whitecross Systems
+009011 Wavtrace
+009040 Siemens Network Convergence
+0090C7 Icom
+009035 Alpha Telecom
+009087 Itis
+00906E Praxon
+009039 Shasta Networks
+00909A ONE World Systems
+009053 Daewoo Electronics
+00909E Critical IO
+0090C2 JK microsystems
+009091 DigitalScape
+0090ED Central System Research
+00901B Digital Controls
+00905C Edmi
+0090D2 Artel Video Systems
+00508C RSI Systems
+00502D Accel
+0050B8 Inova Computers Gmbh & KG
+00503A Datong Electronics
+00508E Optimation
+0050BB CMS Technologies
+005051 Iwatsu Electric
+0050BE Fast Multimedia AG
+0050AD CommUnique Wireless
+005016 Sst/woodhead Industries
+005003 Xrite
+005023 PG Design Electronics
+005039 Mariner Networks
+00505A Network Alchemy
+005071 Aiwa
+B01F81 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+58FCDB Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+7C70BC Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+2C265F Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+009071 Applied Innovation
+009031 Mysticom
+00901F Adtec Productions
+009081 Aloha Networks
+0090B3 Agranat Systems
+00500D Satori Electoric
+0050EC Olicom A/S
+005083 Gilbarco
+0050CF Vanlink Communication Technology Research Institute
+005008 Tiva Microcomputer (tmc)
+005001 Yamashita Systems
+0050B5 Fichet-bauche
+0050B0 Technology Atlanta
+00504E Sierra Monitor
+00504D Tokyo Electron Device Limited
+0050F7 Venture Manufacturing (singapore)
+005029 1394 Printer Working Group
+00E08D Pressure Systems
+00E040 DeskStation Technology
+00E0D6 Computer & Communication Research LAB.
+00E07E Walt Disney Imagineering
+00E094 Osai SRL
+00E032 Misys Financial Systems
+00E06B W&G Special Products
+00E01C Cradlepoint
+00E076 Development Concepts
+00E0A7 IPC Information Systems
+00E0A4 Esaote
+00E080 Control Resources
+00E0CC Hero Systems
+00E099 Samson AG
+0010E9 Raidtec
+001003 Imatron
+00105A 3com
+0010A9 Adhoc Technologies
+000400 Lexmark International
+00101A PictureTel
+001097 WinNet Metropolitan Communications Systems
+00106F Trenton Technology
+0010C6 Universal Global Scientific Industrial
+00104F Oracle 
+0010DA Kollmorgen
+0010DF Rise Computer
+00109E Aware
+001072 GVN Technologies
+00E019 ING. Giordano Elettronica
+00E0D7 Sunshine Electronics
+00E0DA Alcatel North America ESD
+00E068 Merrimac Systems
+00E01D Webtv Networks
+00E01F Avidia Systems
+00E056 Holontech
+00E0C9 AutomatedLogic
+00E030 Melita International
+00E0BA Berghof Automationstechnik Gmbh
+00E0B2 Telmax Communications
+00E0EF Dionex
+00E0BD Interface Systems
+00E071 Epis Microcomputer
+00E0A6 Telogy Networks
+00E026 Redlake Masd
+00E0B8 Gateway 2000
+00E088 Ltx-credence
+00E07C Mettler-toledo
+00E08C Neoparadigm LABS
+00E061 EdgePoint Networks
+00E06E FAR Systems
+00E01B Sphere Communications
+00E0AE Xaqti
+00E0C8 Virtual Access
+00101D Winbond Electronics
+00105F Zodiac Data Systems
+0010CB Facit K.K.
+00108C Fujitsu Telecommunications Europe
+001075 Segate Technology
+001058 ArrowPoint Communications
+0010A8 Reliance Computer
+0010AA Media4
+0010E8 Telocity, Incorporated
+001010 Initio
+00E007 Avaya ECS
+001022 SatCom Media
+0010C7 Data Transmission Network
+001098 Starnet Technologies
+001096 Tracewell Systems
+001082 JNA Telecommunications Limited
+001021 Encanto Networks
+0010CE Volamp
+0010B2 Coactive Aesthetics
+00109A Netline
+0010EA Adept Technology
+0010BD THE Telecommunication Technology Committee (ttc)
+0060D5 Miyachi Technos
+006099 SBE
+0060FD NetICs
+0060B5 Keba Gmbh
+006027 Superior Modular Products
+0060DC Toyo Network Systems  & System Integration
+0060C1 WaveSpan
+006041 Yokogawa Electric
+006005 Feedback Data
+00607B Fore Systems
+00609C Perkin-Elmer Incorporated
+006007 Acres Gaming
+006035 Dallas Semiconductor
+0060F1 EXP Computer
+006040 Netro
+006034 Robert Bosch Gmbh
+0060BA Sahara Networks
+006096 T.S. Microtech
+00603A Quick Controls
+0060AC Resilience
+0060EB Fourthtrack Systems
+00606D Digital Equipment
+006014 Edec
+0060E1 Orckit Communications
+006062 Telesync
+006038 Nortel Networks
+006095 Accu-time Systems
+00A016 Micropolis
+00A01C Nascent Networks
+00A0FC Image Sciences
+00A0B7 Cordant
+00A037 Mindray DS USA
+00A04C Innovative Systems & Technologies
+00A0E9 Electronic Retailing Systems International
+006078 Power Measurement
+00600D Digital Logic GmbH
+00608A Citadel Computer
+00A05D CS Computer Systeme Gmbh
+00A0BD I-tech
+00A0B9 Eagle Technology
+00A069 Symmetricom
+00A07A Advanced Peripherals Technologies
+00A04E Voelker Technologies
+00A05A Kofax Image Products
+00A093 B/E Aerospace
+00A0BF Wireless Data Group Motorola
+00609F Phast
+006067 Acer Netxus
+00600C Eurotech
+006025 Active Imaging PLC
+006071 Midas LAB
+0060A7 Microsens Gmbh & KG
+0060FC Conservation Through Innovation
+0060D4 Eldat Communication
+006085 Storage Concepts
+0060D3 At&t
+006018 Stellar ONE
+00602B Peak Audio
+00606F Clarion OF America
+0060ED Ricardo Test Automation
+0060F6 Nextest Communications Products
+0060DD Myricom
+006092 Micro/sys
+006080 Microtronix Datacom
+006068 Dialogic
+0060DB NTP Elektronik A/S
+00A002 Leeds & Northrup Australia
+00A0E4 Optiquest
+00A01F Tricord Systems
+00A0C0 Digital Link
+00A043 American Technology LABS
+00A047 Integrated Fitness
+00A00E Visual Networks
+00A07C Tonyang Nylon
+00A0EC Transmitton
+00A07E Avid Technology
+00A035 Cylink
+00A028 Conner Peripherals
+00A0C7 Tadiran Telecommunications
+00E0BE Genroco International
+00E010 Hess Sb-automatenbau Gmbh
+00E0E9 Data LABS
+00E0A0 Wiltron
+00E024 Gadzoox Networks
+00E017 Exxact Gmbh
+00603B Amtec spa
+00E08B QLogic
+0020E5 Apex DATA
+00207D Advanced Computer Applications
+0020D0 Versalynx
+00206C Evergreen Technology
+002012 Camtronics Medical Systems
+00200B Octagon Systems
+00209E Brown's Operating System Services
+0020D7 Japan Minicomputer Systems
+0020FB Octel Communications
+0020B1 Comtech Research
+002033 Synapse Technologies
+002099 BON Electric
+0020AE Ornet Data Communication TECH.
+0020EA Efficient Networks
+0020FF Symmetrical Technologies
+00208B Lapis Technologies
+002069 Isdn Systems
+0020BA Center FOR High Performance
+002006 Garrett Communications
+00A0A2 Digicom
+00A09B Qpsx Communications
+00A054 Private
+00A030 Captor Nv/sa
+00A0B1 First Virtual
+0020CB Pretec Electronics
+0020AB Micro Industries
+00202D Taiyo
+00A088 Essential Communications
+00A0FA Marconi Communication GmbH
+00A014 Csir
+00A045 Phoenix Contact Gmbh
+00A064 Kvb/analect
+00A07F Gsm-syntel
+00A03E ATM Forum
+00A050 Cypress Semiconductor
+00A098 NetApp
+00A021 General Dynamics
+00A0A8 Renex
+002049 Comtron
+002050 Korea Computer
+00203C Eurotime AB
+002028 West EGG Systems
+002014 Global View
+002053 Huntsville Microsystems
+002001 DSP Solutions
+00209C Primary Access
+0020C5 Eagle Technology
+002009 Packard Bell Elec.
+002095 Riva Electronics
+00203F Juki
+00C014 Telematics Calabasas Int'l
+00C045 Isolation Systems
+00C000 Lanoptics
+00AA3C Olivetti Telecom SPA (olteco)
+00C079 Fonsys
+002011 Canopus
+00C00B Norcontrol A.S.
+00C0C0 Shore Microsystems
+00C00C Relia Technolgies
+00A0E7 Central Data
+00A068 BHP Limited
+00A0B3 Zykronix
+00A06E Austron
+00A0BB Hilan Gmbh
+00A0C8 Adtran
+00A017 J B
+0020D5 Vipa Gmbh
+002079 Mikron Gmbh
+0020FA GDE Systems
+002007 SFA
+002062 Scorpion Logic
+00200A Source-comm
+002000 Lexmark International
+002003 Pixel Power
+0020B4 Terma Elektronik AS
+00205B Kentrox
+002030 Analog & Digital Systems
+0020A8 Sast Technology
+002066 General Magic
+002036 BMC Software
+0040BE Boeing Defense & Space
+004036 Zoom Telephonics
+004046 UDC Research Limited
+00406A Kentek Information Systems
+0040F2 Janich & Klass Computertechnik
+004082 Laboratory Equipment
+004022 Klever Computers
+0040A2 Kingstar Technology
+0040B4 Nextcom K.K.
+0040D4 Gage Talker
+004038 Talent Electric Incorporated
+004018 Adobe Systems
+0040B0 Bytex, Engineering
+004040 Ring Access
+0080D7 Fantum Engineering
+0080D9 EMK Elektronik GmbH & KG
+00806A ERI (empac Research)
+00403B Synerjet International
+0040AB Roland DG
+0040D5 Sartorius Mechatronics T&H GmbH 
+004027 SMC Massachusetts
+00409C Transware
+00405C Future Systems
+00008C Alloy Computer Products (Australia)
+004000 PCI Componentes DA Amzonia
+0040C5 Micom Communications
+0040AA Metso Automation
+004023 Logic
+0040A4 Rose Electronics
+004048 SMD Informatica
+004025 Molecular Dynamics
+004010 Sonic Systems
+0040CA First Internat'l Computer
+004050 Ironics, Incorporated
+00402B Trigem Computer
+00C08C Performance Technologies
+00C02B Gerloff Gesellschaft FUR
+00C0A7 Seel
+0040B3 ParTech
+00407D Extension Technology
+004079 Juko Manufacture Company
+0040D9 American Megatrends
+004011 Andover Controls
+0040C1 Bizerba-werke Wilheim Kraut
+00C06B OSI Plus
+00C06A Zahner-elektrik Gmbh & KG
+00C097 Archipel SA
+00C072 KNX
+00C0EC Dauphin Technology
+00C066 Docupoint
+00C028 Jasco
+00C0DC EOS Technologies
+00C02D Fuji Photo Film
+00C0BD Inex Technologies
+00C054 Network Peripherals
+00C0D5 Werbeagentur Jrgen Siebert
+00C044 Emcom
+00C050 Toyo Denki Seizo K.K.
+00408A TPS Teleprocessing SYS. Gmbh
+0040FD LXE
+00403D Teradata
+0040E0 Atomwide
+00408C Axis Communications AB
+004068 Extended Systems
+0040BA Alliant Computer Systems
+004069 Lemcom Systems
+0040F8 Systemhaus Discom
+004077 Maxton Technology
+0040E7 Arnos Instruments & Computer
+0040AC Super Workstation
+00C0AC Gambit Computer Communications
+00C02C Centrum Communications
+00C0ED US Army Electronic
+00C0F0 Kingston Technology
+00C0D1 Comtree Technology
+00C0D2 Syntellect
+00C0FB Advanced Technology Labs
+00C092 Mennen Medical
+00C06C Svec Computer
+00C02E Netwiz
+00C05B Networks Northwest
+00C0BF Technology Concepts
+00C0C9 Elsag Bailey Process
+00809D Commscraft
+008017 PFU Limited
+0080F8 Mizar
+008024 Kalpana
+008074 Fisher Controls
+008021 Alcatel Canada
+000055 Commissariat A L`energie ATOM.
+000086 Megahertz
+000092 Cogent Data Technologies
+008068 Yamatech Scientific
+0080F2 Raycom Systems
+0080EA Adva Optical Networking
+008025 Stollmann Gmbh
+000067 Soft * RITE
+0000E8 Accton Technology
+0000B2 Televideo Systems
+0000EE Network Designers
+000089 Cayman Systems
+0000F0 Samsung Electronics
+000021 Sureman COMP. & Commun.
+0000CF Hayes Microcomputer Products
+0000A4 Acorn Computers Limited
+000018 Webster Computer
+008033 EMS Aviation
+008052 Technically Elite Concepts
+00804F Daikin Industries
+00806D Century Systems
+00802D Xylogics
+008048 Compex Incorporated
+008085 H-three Systems
+008014 Esprit Systems
+0080B4 Sophia Systems
+00807F Dy-4 Incorporated
+0000E4 IN2 Groupe Intertechnique
+000079 Networth Incorporated
+000075 Nortel Networks
+004009 Tachibana Tectron
+00409E Concurrent Technologies 
+008092 Silex Technology
+008011 Digital Systems Int'l.
+008044 Systech Computer
+00808A Summit Microsystems
+0080E3 Coral Network
+008072 Microplex Systems
+008054 Frontier Technologies
+0080AE Hughes Network Systems
+0080AF Allumer
+0080EC Supercomputing Solutions
+0080A4 Liberty Electronics
+008073 DWB Associates
+00802B Integrated Marketing
+0080BE Aries Research
+008027 Adaptive Systems
+0080E2 T.d.i.
+0040EE Optimem
+00405E North Hills Israel
+004072 Applied Innovation
+004031 Kokusai Electric
+00400C General Micro Systems
+0040E6 C.a.e.n.
+0040FC IBR Computer Technik Gmbh
+004001 Zero One Technology
+004002 Perle Systems Limited
+0080DB Graphon
+0080B1 Softcom A/S
+0080D8 Network Peripherals
+0080AB Dukane Network Integration
+00809B Justsystem
+008089 Tecnetics (pty)
+000039 Toshiba
+0000CB Compu-shack Electronic Gmbh
+0000D1 Adaptec Incorporated
+0000B6 Micro-matic Research
+000066 Talaris Systems
+000014 Netronix
+000072 Miniware Technology
+0000AB Logic Modeling
+000029 IMC Networks
+0080CD Micronics Computer
+008083 Amdahl
+008003 Hytec Electronics
+00801B Kodiak Technology
+0080CC Microwave Bypass Systems
+080079 THE Droid Works
+080077 TSL Communications
+080071 Matra (dsie)
+08006A ATT Bell Laboratories
+08005F Saber Technology
+08005C Four Phase Systems
+08005B VTA Technologies
+080058 Systems Concepts
+080050 Daisy Systems
+080052 Insystec
+080047 Sequent Computer Systems
+080045 Concurrent Computer
+080044 David Systems
+080041 Racal-milgo Information SYS..
+080038 Bulls.
+08003C Schlumberger Well Services
+080034 Filenet
+08002C Britton LEE
+0000B9 Mcdonnell Douglas Computer SYS
+00002D Chromatics
+00004A ADC Codenoll Technology
+0000C0 Western Digital
+000040 Applicon
+00005D CS Telecom
+08008E Tandem Computers
+080086 Konica Minolta Holdings
+080083 Seiko Instruments
+080080 AES Data
+080030 Royal Melbourne Inst OF Tech
+080064 Sitasys AG
+00DD09 Ungermann-bass
+08008A PerfTech
+00DD04 Ungermann-bass
+080066 Agfa
+08001A Tiara/ 10net
+080090 Sonoma Systems
+08000B Unisys
+080017 National Semiconductor
+00005E Icann, Iana Department
+0000AF Canberra Industries
+0000EC Microprocess
+00009E Marli
+000042 Metier Management Systems
+00008D Cryptek
+000065 Network General
+00004D DCI
+080024 10net Communications/dca
+08001E Apollo Computer
+08001B EMC
+00DD0D Ungermann-bass
+AA0002 Digital Equipment
+080005 Symbolics
+000000 Xerox
+0040D6 Locamation
+800010 ATT Bell Laboratories
+AA0003 Digital Equipment
+080008 Bolt Beranek AND Newman
+08000E NCR
+00006F Madge
+00005A SysKonnect GmbH
+0000C9 Emulex
+000023 ABB Industrial Systems AB
+000045 Ford Aerospace & COMM.
+0000BC Rockwell Automation
+0000C3 Harris Computer SYS DIV
+000004 Xerox
+000009 Xerox
+00003D Unisys
+F82C18 2Wire
+00173F Belkin International
+388602 Flexoptix GmbH
+F4EB38 Sagemcom Broadband SAS
+001E74 Sagemcom Broadband SAS
+00604C Sagemcom Broadband SAS
+002691 Sagemcom Broadband SAS
+C0D044 Sagemcom Broadband SAS
+6C2E85 Sagemcom Broadband SAS
+CC33BB Sagemcom Broadband SAS
+681590 Sagemcom Broadband SAS
+5464D9 Sagemcom Broadband SAS
+00023F Compal Electronics
+0080C2 Ieee 802.1
+C46699 vivo Mobile Communication
+F80278 Ieee Registration Authority
+D02212 Ieee Registration Authority
+002067 Private
+74E14A Ieee Registration Authority
+383BC8 2Wire
+DC7FA4 2Wire
+1100AA Private
+001288 2Wire
+001EC7 2Wire
+28162E 2Wire
+3CEA4F 2Wire
+848F69 Dell
+90B11C Dell
+F8CAB8 Dell
+24B6FD Dell
+000D56 Dell
+00123F Dell
+001372 Dell
+74867A Dell
+3417EB Dell
+EC8892 Motorola Mobility, a Lenovo Company
+B07994 Motorola Mobility, a Lenovo Company
+141AA3 Motorola Mobility, a Lenovo Company
+CCC3EA Motorola Mobility, a Lenovo Company
+34BB26 Motorola Mobility, a Lenovo Company
+40786A Motorola Mobility, a Lenovo Company
+0019B9 Dell
+002219 Dell
+00B0D0 Dell
+5C260A Dell
+B083FE Dell
+141877 Dell
+0024E8 Dell
+A48E0A DeLaval International AB
+00215C Intel Corporate
+002315 Intel Corporate
+001500 Intel Corporate
+104A7D Intel Corporate
+A4C494 Intel Corporate
+902E1C Intel Corporate
+3CFDFE Intel Corporate
+B8BF83 Intel Corporate
+001DE1 Intel Corporate
+0022FB Intel Corporate
+081196 Intel Corporate
+6036DD Intel Corporate
+A0369F Intel Corporate
+502DA2 Intel Corporate
+4C79BA Intel Corporate
+4CEB42 Intel Corporate
+606720 Intel Corporate
+84A6C8 Intel Corporate
+5891CF Intel Corporate
+88532E Intel Corporate
+0024D7 Intel Corporate
+C40938 Fujian Star-net Communication
+00AA02 Intel
+5CD2E4 Intel Corporate
+04BD88 Aruba Networks
+000B86 Aruba Networks
+8896F2 Valeo Schalter und Sensoren GmbH
+80A589 AzureWave Technology
+0CCC26 Airenetworks
+4CB0E8 Beijing RongZhi xinghua technology
+4C14A3 TCL Technoly Electronics (Huizhou)
+F48E38 Dell
+74DAEA Texas Instruments
+D887D5 Leadcore Technology
+00DA55 Cisco Systems
+80D21D AzureWave Technology
+705A0F Hewlett Packard
+586356 Fn-link Technology Limited
+B046FC MitraStar Technology
+08A95A AzureWave Technology
+6CADF8 AzureWave Technology
+54271E AzureWave Technology
+008C54 ADB Broadband Italia
+F0842F ADB Broadband Italia
+8CB864 AcSiP Technology
+0020E0 Actiontec Electronics
+0004E3 Accton Technology
+409558 Aisino
+00D0C9 Advantech
+002553 ADB Broadband Italia
+00238E ADB Broadband Italia
+001CA2 ADB Broadband Italia
+0017C2 ADB Broadband Italia
+D0D412 ADB Broadband Italia
+000FA3 Alpha Networks
+001D6A Alpha Networks
+0000F4 Allied Telesis
+10AE60 Private
+F04F7C Private
+70F1A1 Liteon Technology
+6CFAA7 Ampak Technology
+0015C1 Sony Computer Entertainment
+0019C5 Sony Computer Entertainment
+0024EF Sony Mobile Communications AB
+6C0E0D Sony Mobile Communications AB
+B4527D Sony Mobile Communications AB
+280DFC Sony
+E063E5 Sony Mobile Communications AB
+000E07 Sony Mobile Communications AB
+001A75 Sony Mobile Communications AB
+0016B8 Sony Mobile Communications AB
+001D28 Sony Mobile Communications AB
+001FE4 Sony Mobile Communications AB
+002298 Sony Mobile Communications AB
+0019A6 Arris Group
+001700 Arris Group
+0015A8 Arris Group
+000E5C Arris Group
+000CE5 Arris Group
+0004BD Arris Group
+00E06F Arris Group
+386BBB Arris Group
+0015CF Arris Group
+0014E8 Arris Group
+24FD52 Liteon Technology
+2016D8 Liteon Technology
+9CB70D Liteon Technology
+1C659D Liteon Technology
+F80BBE Arris Group
+DC4517 Arris Group
+74F612 Arris Group
+74E7C6 Arris Group
+B81619 Arris Group
+B077AC Arris Group
+145BD1 Arris Group
+6CC1D2 Arris Group
+0025F2 Arris Group
+002374 Arris Group
+002641 Arris Group
+0026BA Arris Group
+002180 Arris Group
+0019C0 Arris Group
+001B9E Askey Computer
+E0CA94 Askey Computer
+C0D962 Askey Computer
+00150C AVM GmbH
+744401 Netgear
+E091F5 Netgear
+001B2F Netgear
+00223F Netgear
+E0469A Netgear
+F40B93 BlackBerry RTS
+68ED43 BlackBerry RTS
+34BB1F BlackBerry RTS
+489D24 BlackBerry RTS
+000F86 BlackBerry RTS
+001333 BaudTec
+507E5D Arcadyan Technology
+849CA6 Arcadyan Technology
+1CC63C Arcadyan Technology
+C02506 AVM GmbH
+0896D7 AVM GmbH
+008EF2 Netgear
+4494FC Netgear
+20E52A Netgear
+9CD36D Netgear
+C40415 Netgear
+08BD43 Netgear
+4C09D4 Arcadyan Technology
+DC446D Allwinner Technology
+BC620E Huawei Technologies
+78F557 Huawei Technologies
+E02861 Huawei Technologies
+C4473F Huawei Technologies
+000AF7 Broadcom
+000DB6 Broadcom
+18C086 Broadcom
+80ACAC Juniper Networks
+003146 Juniper Networks
+000585 Juniper Networks
+F01C2D Juniper Networks
+5C4527 Juniper Networks
+44F477 Juniper Networks
+CCE17F Juniper Networks
+3C6104 Juniper Networks
+C03E0F BSkyB
+54E032 Juniper Networks
+78FE3D Juniper Networks
+F8C001 Juniper Networks
+50C58D Juniper Networks
+0024DC Juniper Networks
+001F12 Juniper Networks
+0019E2 Juniper Networks
+0020D4 Cabletron Systems
+00001D Cabletron Systems
+0060BB Cabletron Systems
+D0542D Cambridge Industries(Group)
+001FC7 Casio Hitachi Mobile Communications
+ACEE9E Samsung Electronics
+C08997 Samsung Electronics
+2827BF Samsung Electronics
+F05B7B Samsung Electronics
+7CF90E Samsung Electronics
+AC5A14 Samsung Electronics
+B0C559 Samsung Electronics
+BCD11F Samsung Electronics
+A0B4A5 Samsung Electronics
+80656D Samsung Electronics
+48137E Samsung Electronics
+E83A12 Samsung Electronics
+9C0298 Samsung Electronics
+6C8336 Samsung Electronics
+B8C68E Samsung Electronics
+74458A Samsung Electronics
+A49A58 Samsung Electronics
+B4EF39 Samsung Electronics
+14A364 Samsung Electronics
+3CA10D Samsung Electronics
+206E9C Samsung Electronics
+183F47 Samsung Electronics
+0C715D Samsung Electronics
+0C1420 Samsung Electronics
+A80600 Samsung Electronics
+6CF373 Samsung Electronics
+90F1AA Samsung Electronics
+C4576E Samsung Electronics
+78BDBC Samsung Electronics
+3872C0 Comtrend
+F4068D devolo AG
+000BCA Datavan TC
+00507F DrayTek
+3C8970 Neosfar
+C43655 Shenzhen Fenglian Technology
+78CA83 Ieee Registration Authority
+78CB68 Daehap Hyper-tech
+001A7F GCI Science & Technology
+00054F Private
+D04D2C Roku
+3C6716 Lily Robotics
+3CDD89 Somo Holdings & TECH.
+2C56DC Asustek Computer
+2C3996 Sagemcom Broadband SAS
+0054BD Swelaser AB
+001E4C Hon Hai Precision Ind.
+001830 Texas Instruments
+C0E422 Texas Instruments
+04E451 Texas Instruments
+D00790 Texas Instruments
+28ED6A Apple
+34AB37 Apple
+60A37D Apple
+0056CD Apple
+7081EB Apple
+086698 Apple
+788B77 Standar Telecom
+84ACFB Crouzet Automatismes
+7CBB8A Nintendo
+34BA75 Tembo Systems
+FCFFAA Ieee Registration Authority
+00CB00 Private
+9486CD Seoul Electronics&telecom
+94ABDE OMX Technology - FZE
+806AB0 Shenzhen Tinno Mobile Technology
+A0F895 Shenzhen Tinno Mobile Technology
+0078CD Ignition Design Labs
+40D855 Ieee Registration Authority
+70B3D5 Ieee Registration Authority
+0017E7 Texas Instruments
+0017E9 Texas Instruments
+44C15C Texas Instruments
+1CE2CC Texas Instruments
+985945 Texas Instruments
+1CBA8C Texas Instruments
+BC6A29 Texas Instruments
+2CFD37 Blue Calypso
+0C6127 Actiontec Electronics
+002926 Applied Optoelectronics, Taiwan Branch
+001B11 D-Link
+001E58 D-Link
+002191 D-Link
+0022B0 D-Link
+F07D68 D-Link
+78542E D-Link International
+0057D2 Cisco Systems
+B8AF67 Hewlett Packard
+1CCB99 TCT mobile
+A42BB0 Tp-link Technologies
+9C3426 Arris Group
+188B45 Cisco Systems
+B0C090 Chicony Electronics
+4CD08A Humax
+20906F Shenzhen Tencent Computer System
+1C7839 Shenzhen Tencent Computer System
+D837BE Shanghai Gongjing Telecom Technology
+A4516F Microsoft Mobile Oy
+FC64BA Xiaomi Communications
+902155 HTC
+64A769 HTC
+BCCFCC HTC
+B0F1A3 Fengfan (BeiJing) Technology
+90CDB6 Hon Hai Precision Ind.
+7C7D3D Huawei Technologies
+4482E5 Huawei Technologies
+00265C Hon Hai Precision Ind.
+002556 Hon Hai Precision Ind.
+542758 Motorola (Wuhan) Mobility Technologies Communication
+185E0F Intel Corporate
+C80E77 Le Shi Zhi Xin Electronic Technology (Tianjin) Limited
+4CE676 Buffalo.inc
+B0C745 Buffalo.inc
+CCE1D5 Buffalo.inc
+B8FC9A Le Shi Zhi Xin Electronic Technology (Tianjin) Limited
+2C4138 Hewlett Packard
+2C768A Hewlett Packard
+0018FE Hewlett Packard
+0019BB Hewlett Packard
+002264 Hewlett Packard
+002481 Hewlett Packard
+000D9D Hewlett Packard
+B0C287 Technicolor CH USA
+1CA770 Shenzhen Chuangwei-rgb Electronics
+C42F90 Hangzhou Hikvision Digital Technology
+9C5D12 Aerohive Networks
+B4B52F Hewlett Packard
+843497 Hewlett Packard
+ECB1D7 Hewlett Packard
+3CA82A Hewlett Packard
+480FCF Hewlett Packard
+5820B1 Hewlett Packard
+2C233A Hewlett Packard
+000EB3 Hewlett Packard
+0004EA Hewlett Packard
+00306E Hewlett Packard
+0060B0 Hewlett Packard
+24BE05 Hewlett Packard
+000FCC Arris Group
+000423 Intel
+000E35 Intel
+00207B Intel
+0013CE Intel Corporate
+801934 Intel Corporate
+B8B81E Intel Corporate
+0014C2 Hewlett Packard
+0008C7 Hewlett Packard
+0010E3 Hewlett Packard
+00805F Hewlett Packard
+BCEAFA Hewlett Packard
+5C8A38 Hewlett Packard
+D89D67 Hewlett Packard
+2C44FD Hewlett Packard
+F0921C Hewlett Packard
+001DD2 Arris Group
+94877C Arris Group
+407009 Arris Group
+F8EDA5 Arris Group
+5465DE Arris Group
+6CCA08 Arris Group
+5C8FE0 Arris Group
+BCCAB5 Arris Group
+4C1FCC Huawei Technologies
+486276 Huawei Technologies
+AC4E91 Huawei Technologies
+E468A3 Huawei Technologies
+105172 Huawei Technologies
+9017AC Huawei Technologies
+94049C Huawei Technologies
+001237 Texas Instruments
+948854 Texas Instruments
+A863F2 Texas Instruments
+D0FF50 Texas Instruments
+20C38F Texas Instruments
+A0E6F8 Texas Instruments
+5C313E Texas Instruments
+F4B85E Texas Instruments
+68C90B Texas Instruments
+EC24B8 Texas Instruments
+08181A zte
+002512 zte
+904CE5 Hon Hai Precision Ind.
+CCAF78 Hon Hai Precision Ind.
+1C666D Hon Hai Precision Ind.
+785968 Hon Hai Precision Ind.
+F80D43 Hon Hai Precision Ind.
+F866D1 Hon Hai Precision Ind.
+0071CC Hon Hai Precision Ind.
+B05B67 Huawei Technologies
+38F889 Huawei Technologies
+F4DCF9 Huawei Technologies
+EC26CA Tp-link Technologies
+001FE1 Hon Hai Precision Ind.
+002268 Hon Hai Precision Ind.
+9471AC TCT mobile
+A09347 Guangdong Oppo Mobile Telecommunications
+2C088C Humax
+D42C0F Pace plc
+40F308 Murata Manufacturing
+246081 razberi technologies
+8CAB8E Shanghai Feixun Communication
+9060F1 Apple
+741BB2 Apple
+002586 Tp-link Technologies
+F8D111 Tp-link Technologies
+F4EC38 Tp-link Technologies
+20DCE6 Tp-link Technologies
+5CDAD4 Murata Manufacturing
+000E6D Murata Manufacturing
+0014C9 Brocade Communications Systems
+00010F Brocade Communications Systems
+080088 Brocade Communications Systems
+00051E Brocade Communications Systems
+384608 zte
+B4B362 zte
+B075D5 zte
+904E2B Huawei Technologies
+0C96BF Huawei Technologies
+9CC172 Huawei Technologies
+80D09B Huawei Technologies
+581F28 Huawei Technologies
+8C34FD Huawei Technologies
+90671C Huawei Technologies
+587F66 Huawei Technologies
+BC25E0 Huawei Technologies
+C4072F Huawei Technologies
+0CD6BD Huawei Technologies
+A49947 Huawei Technologies
+346BD3 Huawei Technologies
+689E19 Texas Instruments
+C46AB7 Xiaomi Communications
+68DFDD Xiaomi Communications
+64B473 Xiaomi Communications
+7451BA Xiaomi Communications
+3480B3 Xiaomi Communications
+5006AB Cisco Systems
+0050E2 Cisco Systems
+F873A2 Avaya
+64C354 Avaya
+B4B017 Avaya
+581626 Avaya
+CCF954 Avaya
+703018 Avaya
+B0A37E Qingdao Haier TelecomLtd
+70A8E3 Huawei Technologies
+F84ABF Huawei Technologies
+4CB16C Huawei Technologies
+1C1D67 Huawei Technologies
+84A8E4 Huawei Technologies
+202BC1 Huawei Technologies
+3475C7 Avaya
+6CFA58 Avaya
+64A7DD Avaya
+646A52 Avaya
+28CFE9 Apple
+E425E7 Apple
+080007 Apple
+000A95 Apple
+002241 Apple
+0023DF Apple
+0025BC Apple
+00264A Apple
+0026B0 Apple
+041E64 Apple
+00E0B0 Cisco Systems
+00E0FE Cisco Systems
+00E0A3 Cisco Systems
+00E0F9 Cisco Systems
+001BD7 Cisco Spvtg
+2401C7 Cisco Systems
+04DAD2 Cisco Systems
+F41FC2 Cisco Systems
+4C0082 Cisco Systems
+DCA5F4 Cisco Systems
+7C95F3 Cisco Systems
+745E1C Pioneer
+0006F5 Alps Electric
+0006F7 Alps Electric
+000704 Alps Electric
+1C6E4C Logistic Service & Engineering
+00101F Cisco Systems
+001054 Cisco Systems
+DCEB94 Cisco Systems
+5C838F Cisco Systems
+AC7E8A Cisco Systems
+382056 Cisco Systems
+1C872C Asustek Computer
+C4143C Cisco Systems
+18E728 Cisco Systems
+2C3ECF Cisco Systems
+1005CA Cisco Systems
+1CDEA7 Cisco Systems
+1C6A7A Cisco Systems
+CCD8C1 Cisco Systems
+7C0ECE Cisco Systems
+F09E63 Cisco Systems
+F07F06 Cisco Systems
+84802D Cisco Systems
+E0899D Cisco Systems
+005050 Cisco Systems
+009021 Cisco Systems
+0090B1 Cisco Systems
+00023D Cisco Systems
+00502A Cisco Systems
+005014 Cisco Systems
+0090D9 Cisco Systems
+009092 Cisco Systems
+001029 Cisco Systems
+001007 Cisco Systems
+00605C Cisco Systems
+00E0F7 Cisco Systems
+D49A20 Apple
+9027E4 Apple
+60334B Apple
+5C5948 Apple
+78CA39 Apple
+18E7F4 Apple
+B8FF61 Apple
+DC2B61 Apple
+1093E9 Apple
+442A60 Apple
+E0F847 Apple
+145A05 Apple
+28CFDA Apple
+148FC6 Apple
+283737 Apple
+5017FF Cisco Systems
+E8EDF3 Cisco Systems
+78DA6E Cisco Systems
+24E9B3 Cisco Systems
+1C1D86 Cisco Systems
+E0B7B1 Pace plc
+001A92 Asustek Computer
+001D60 Asustek Computer
+002215 Asustek Computer
+20CF30 Asustek Computer
+E0CB4E Asustek Computer
+A89D21 Cisco Systems
+BCF1F2 Cisco Systems
+C80084 Cisco Systems
+A0F849 Cisco Systems
+88908D Cisco Systems
+A46C2A Cisco Systems
+0021BE Cisco Spvtg
+7CB21B Cisco Spvtg
+002643 Alps Electric
+002433 Alps Electric
+045453 Apple
+F0CBA1 Apple
+7073CB Apple
+9C207B Apple
+842999 Apple
+74E2F5 Apple
+20C9D0 Apple
+488AD2 Shenzhen Mercury Communication Technologies
+04489A Apple
+D8CF9C Apple
+A88E24 Apple
+E8802E Apple
+68AE20 Apple
+E0B52D Apple
+80BE05 Apple
+D8BB2C Apple
+D04F7E Apple
+2C1F23 Apple
+549F13 Apple
+B8098A Apple
+F0DBE2 Apple
+18EE69 Apple
+54EAA8 Apple
+E4C63D Apple
+843835 Apple
+C06394 Apple
+8C006D Apple
+B09FBA Apple
+DC86D8 Apple
+8C2937 Apple
+DC9B9C Apple
+98F0AB Apple
+F0DBF8 Apple
+ACCF5C Apple
+3C15C2 Apple
+748114 Apple
+18F643 Apple
+D0A637 Apple
+A01828 Apple
+D0034B Apple
+A43135 Apple
+9C35EB Apple
+507A55 Apple
+A0999B Apple
+24240E Apple
+903C92 Apple
+341298 Apple
+9C293F Apple
+30F7C5 Apple
+008865 Apple
+40B395 Apple
+3090AB Apple
+1CE62B Apple
+A0EDCD Apple
+A886DD Apple
+C8A2CE Oasis Media Systems
+A4DEC9 QLove Mobile Intelligence Information Technology (W.H.)
+1402EC Hewlett Packard Enterprise
+707938 Wuxi Zhanrui Electronic Technology
+646A74 Auth-servers
+34C9F0 LM Technologies
+E034E4 Feit Electric Company
+681401 Hon Hai Precision Ind.
+98E848 Axiim
+C4EF70 Home Skinovations
+B813E9 Trace Live Network
+746F19 Icarvisions (shenzhen) Technology
+7C7176 Wuxi iData Technology Company
+7C0191 Apple
+70480F Apple
+A4B805 Apple
+587F57 Apple
+80D605 Apple
+68A828 Huawei Technologies
+988744 Wuxi Hongda Science and Technology
+C869CD Apple
+A4A6A9 Private
+0469F8 Apple
+9C7A03 Ciena
+9C8DD3 Leonton Technologies
+246C8A Yukai Engineering
+A43831 RF elements s.r.o.
+D0BAE4 Shanghai Mxchip Information Technology
+A4DCBE Huawei Technologies
+10CC1B Liverock technologies
+BC6C21 Apple
+A0F9E0 Vivatel Company Limited
+0C54B9 Alcatel-Lucent
+F8C372 Tsuzuki Denki
+908D78 D-Link International
+A4CC32 Inficomm
+582BDB Pax AB
+D00F6D T&W Electronics Company
+48BF74 Baicells Technologies
+38F557 Jolata
+280E8B Beijing Spirit Technology Development
+F44D30 Elitegroup Computer Systems
+DC9A8E Nanjing Cocomm electronics
+20D160 Private
+382187 Midea Group
+305A3A Asustek Computer
+A87285 IDT
+AC1FD7 Real Vision Technology
+3C7A8A Arris Group
+48B620 Roli
+380AAB Formlabs
+F41535 Spon Communication Technology
+E41A2C ZPE Systems
+A815D6 Shenzhen Meione Technology
+D09380 Ducere Technologies Pvt.
+84A788 Perples
+6889C1 Huawei Technologies
+845B12 Huawei Technologies
+E0319E Valve
+E4A32F Shanghai Artimen Technology
+D47BB0 Askey Computer
+5045F7 Liuhe Intelligence Technology
+20F510 Codex Digital Limited
+949F3E Sonos
+F02624 Wafa Technologies
+F8F464 Rawe Electonic GmbH
+F4672D ShenZhen Topstar Technology Company
+382B78 ECO Plugs Enterprise
+606DC7 Hon Hai Precision Ind.
+BCEB5F Fujian Beifeng Telecom Technology
+800B51 Chengdu XGimi Technology
+041E7A Dspworks
+143EBF zte
+788E33 Jiangsu Seuic Technology
+94D859 TCT mobile
+E01AEA Allied Telesis
+340CED Moduel AB
+507B9D Lcfc(hefei) Electronics Technology
+6C7220 D-Link International
+38B725 Wistron Infocomm (Zhongshan)
+ACEC80 Arris Group
+80EA23 Wistron Neweb
+4CC681 Shenzhen Aisat Electronic
+28B9D9 Radisys
+E0553D Cisco Meraki
+0894EF Wistron Infocomm (Zhongshan)
+304487 Hefei Radio Communication Technology
+747336 Microdigtal
+0CE725 Microsoft
+FCE1FB Array Networks
+54E140 Ingenico
+D4F9A1 Huawei Technologies
+9CB6D0 Rivet Networks
+D0C0BF Actions Microelectronics
+94F665 Ruckus Wireless
+707781 Hon Hai Precision Ind.
+E04B45 Hi-P Electronics Pte
+6C4598 Antex Electronic
+94A7B7 zte
+3C8375 Microsoft
+C8458F Wyler AG
+CCA4AF Shenzhen Sowell Technology
+84F129 Metrascale
+9C3066 RWE Effizienz GmbH
+FCA22A PT. Callysta Multi Engineering
+247656 Shanghai Net Miles Fiber Optics Technology
+D4D7A9 Shanghai Kaixiang Info Tech
+1CC586 Absolute Acoustics
+C49A02 LG Electronics (Mobile Communicaitons)
+E076D0 Ampak Technology
+24B0A9 Shanghai Mobiletek Communication
+64167F Polycom
+54E2C8 Dongguan Aoyuan Electronics Technology
+08D0B7 Hisense Electric
+20D75A Posh Mobile Limited
+88D37B FirmTek
+10AF78 Shenzhen Atue Technology
+B0966C Lanbowan Technology
+A408EA Murata Manufacturing
+601970 Huizhou Qiaoxing Electronics Technology
+887033 Hangzhou Silan Microelectronic
+8C7967 zte
+D083D4 XTel ApS
+78F944 Private
+D09DAB TCT mobile
+E8F2E3 Starcor Beijing,Limited
+74852A Pegatron
+149A10 Microsoft
+FC9AFA Motus Global
+5CB43E Huawei Technologies
+D048F3 Dattus
+CC19A8 PT Inovao e Sistemas SA
+6C4418 Zappware
+44962B Aidon Oy
+14157C Tokyo Cosmos Electric
+408D5C Giga-byte Technology
+6CE01E Modcam AB
+185D9A BobjGear
+884157 Shenzhen Atsmart Technology
+3CDA2A zte
+00FC8D Hitron Technologies.
+7C534A Metamako
+40D28A Nintendo
+6C2E72 B&B Exporting Limited
+98EECB Wistron InfoComm(ZhongShan)Corporation
+FC3288 Celot Wireless
+BCB308 Hongkong Ragentek Communication Technology,limited
+445ECD Razer
+749637 Todaair Electronic
+2031EB Hdsn
+18F145 NetComm Wireless Limited
+4CA515 Baikal Electronics JSC
+9CE230 Julong
+80F503 Pace plc
+34873D Quectel Wireless Solution
+186882 Beward R&D
+FC3D93 Longcheer Telecommunication Limited
+344CA4 amazipoint technology
+A8F038 Shen Zhen SHI JIN HUA TAI Electronics
+74E277 Vizmonet Pte
+10A659 Mobile Create
+58856E QSC AG
+C4366C LG Innotek
+D85DE2 Hon Hai Precision Ind.
+60D9A0 Lenovo Mobile Communication Technology
+5C3B35 Gehirn
+5CF7C3 Syntech (hk) Technology Limited
+3CC2E1 Xinhua Control Engineering
+6CF5E8 Mooredoll
+C0335E Microsoft
+ACCAAB Virtual Electric
+241B44 Hangzhou Tuners Electronics
+B0E03C TCT mobile
+90C35F Nanjing Jiahao Technology
+FCAFAC Socionext
+F8C397 Nzxt
+48C093 Xirrus
+3C1A0F ClearSky Data
+ACB57D Liteon Technology
+DCE1AD Shenzhen Wintop Photoelectric Technology
+900CB4 Alinket Electronic Technology
+F0FE6B Shanghai High-Flying Electronics Technology
+3CAE69 ESA Elektroschaltanlagen Grimma GmbH
+00F3DB WOO Sports
+08A5C8 Sunnovo International Limited
+848EDF Sony Mobile Communications AB
+CCBDD3 Ultimaker
+A0ADA1 JMR Electronics
+2028BC Visionscape
+B8F080 SPS
+7858F3 Vachen
+FCDC4A G-Wearables
+F42C56 Senor Tech
+50502A Egardia
+A0A3E2 Actiontec Electronics
+48EE0C D-Link International
+883B8B Cheering Connection
+94D417 GPI Korea
+D855A3 zte
+70DA9C Tecsen
+207693 Lenovo (Beijing) Limited.
+70FF5C Cheerzing Communication(Xiamen)Technology
+E0107F Ruckus Wireless
+08115E Bitel
+44CE7D SFR
+0881BC HongKong Ipro Technology, Limited
+4C16F1 zte
+800902 Keysight Technologies
+6872DC Cetory.tv Company Limited
+D8B6B7 Comtrend
+0499E6 Shenzhen Yoostar Technology
+344DF7 LG Electronics
+FC9FE1 Conwin.tech.
+90203A BYD Precision Manufacture
+A81B5D Foxtel Management
+B8BD79 TrendPoint Systems
+2C010B Nascent Technology, - Remkon
+D4EC86 LinkedHope Intelligent Technologies
+20A99B Microsoft
+6C7660 Kyocera
+D0FA1D Qihoo  360  Technology
+046785 scemtec Hard- und Software fuer Mess- und Steuerungstechnik GmbH
+FC6DC0 BME
+784561 CyberTAN Technology
+D896E0 Alibaba Cloud Computing
+104B46 Mitsubishi Electric
+C4BD6A SKF GmbH
+14488B Shenzhen Doov Technology
+70BAEF Hangzhou H3C Technologies, Limited
+CC03FA Technicolor CH USA
+603696 The Sapling Company
+54FFCF Mopria Alliance
+4C0BBE Microsoft
+08EB29 Jiangsu Huitong Group
+D88039 Microchip Technology
+E48C0F Discovery Insure
+587FB7 Sonar Industrial
+E42354 Shenzhen Fuzhi Software Technology
+F4F26D Tp-link Technologies
+5C1515 Advan
+D0A0D6 Chengdu TD Tech
+50294D Nanjing IOT Sensor Technology
+90EF68 ZyXEL Communications
+0CCFD1 Springwave
+58108C Intelbras
+187117 eta plus electronic gmbh
+7CB177 Satelco AG
+8C5D60 UCI
+94BF95 Shenzhen Coship Electronics
+88708C Lenovo Mobile Communication Technology
+F03D29 Actility
+909F33 EFM Networks
+849681 Cathay Communication
+54098D deister electronic GmbH
+BCBC46 SKS Welding Systems GmbH
+A8D88A Wyconn
+00E6E8 Netzin Technology
+64B21D Chengdu Phycom Tech
+70305D Ubiquoss
+78D66F Aristocrat Technologies Australia
+50C7BF Tp-link Technologies
+C06118 Tp-link Technologies
+D0C7C0 Tp-link Technologies
+209AE9 Volacomm
+345D10 Wytek
+58E326 Compass Technologies
+F08CFB Fiberhome Telecommunication Tech.Co.
+848DC7 Cisco Spvtg
+480C49 Nakayo Telecommunications
+5CB8CB Allis Communications
+4C9EFF ZyXEL Communications
+C44BD1 Wallys Communications  Teachnologies
+E85D6B Luminate Wireless
+8C3357 HiteVision Digital Media Technology
+506787 iTellus
+F4D261 Semocon
+B009D3 Avizia
+B01041 Hon Hai Precision Ind.
+3CAA3F iKey
+0C383E Fanvil Technology
+60CDA9 Abloomy
+B40B44 Smartisan Technology
+A056B2 Harman/Becker Automotive Systems GmbH
+40C62A Shanghai Jing Ren Electronic Technology
+E8150E Nokia
+F4D032 Yunnan Ideal Information&Technology.
+44A6E5 Thinking Technology
+A8329A Digicom Futuristic Technologies
+B40AC6 Dexon Systems
+5CF4AB ZyXEL Communications
+EC2E4E Hitachi-lg Data Storage
+505800 WyTec International
+78923E Nokia
+D4CFF9 Shenzhen Sen5 Technology
+D8492F Canon
+D46761 Sahab Technology
+145645 Savitech
+D4E08E ValueHD
+74DA38 Edimax Technology
+D05AF1 Shenzhen Pulier Tech
+481A84 Pointer Telocation
+E4F4C6 Netgear
+DC663A Apacer Technology
+FCF152 Sony
+A0FC6E Telegrafia a.s.
+44D4E0 Sony Mobile Communications AB
+300D2A Zhejiang Wellcom Technology
+C4084A Alcatel-Lucent
+8496D8 Pace plc
+64EAC5 SiboTech Automation
+8CBF9D Shanghai Xinyou Information Technology
+D49398 Nokia
+580528 Labris Networks
+28656B Keystone Microtech
+A8BD3A Unionman Technology
+C44E1F BlueN
+CCA614 Aifa Technology
+B0869E Chloride S.r.L
+344F5C R&amp;M AG
+A46CC1 LTi REEnergy GmbH
+90DB46 E-lead Electronic
+F8A9D0 LG Electronics
+289AFA TCT Mobile Limited
+D42F23 Akenori PTE
+286336 Siemens AG - Industrial Automation - EWA
+E0DB88 Open Standard Digital-if Interface for Satcom Systems
+D86194 Objetivos y Sevicios de Valor Anadido
+FCF8B7 Tronteq Electronic
+589CFC FreeBSD Foundation
+602103 Stcube.inc
+48B977 PulseOn Oy
+AC2DA3 Txtr Gmbh
+C8F68D S.e.technologies Limited
+BC14EF Iton Technology Limited
+14F28E ShenYang ZhongKe-Allwin TechnologyLTD
+C064C6 Nokia
+9C44A6 SwiftTest
+44C4A9 Opticom Communication
+6C3C53 SoundHawk
+400107 Arista
+4C8B30 Actiontec Electronics
+0805CD DongGuang EnMai Electronic ProductLtd.
+0092FA Shenzhen Wisky Technology
+4CF45B Blue Clover Devices
+B06971 DEI Sales
+58493B Palo Alto Networks
+5850AB TLS
+90DFB7 s.m.s smart microwave sensors GmbH
+B843E4 Vlatacom
+8425A4 Tariox Limited
+E07F53 Techboard SRL
+4C0DEE Jabil Circuit (shanghai)
+A07771 Vialis BV
+D0BD01 DS International
+C0C569 Shanghai Lynuc CNC Technology
+200E95 IEC  TC9 Wg43
+085DDD Mercury
+88B1E1 AirTight Networks
+98349D Krauss Maffei Technologies GmbH
+18CC23 Philio Technology
+648D9E IVT Electronic
+44C56F NGN Easy Satfinder (Tianjin) Electronic
+2C5A05 Nokia
+848336 Newrun
+EC71DB Shenzhen Baichuan Digital Technology
+B8266C Anov France
+38F098 Vapor Stone Rail Systems
+CCFA00 LG Electronics
+CC95D7 Vizio
+749C52 Huizhou Desay SV Automotive
+C0F79D Powercode
+3C0C48 Servergy
+68D247 Portalis LC
+FC27A2 Trans Electric
+14C089 Dune HD
+F08A28 Jiangsu Hengsion Electronic S and
+A8574E Tp-link Technologies
+7CCD3C Guangzhou Juzing Technology
+10B26B base
+DCCEBC Shenzhen JSR Technology
+9486D4 Surveillance Pro
+F89550 Proton Products Chengdu
+943BB1 Kaonmedia
+447BC4 DualShine Technology(SZ)Co.
+542F89 Euclid Laboratories
+DC3EF8 Nokia
+706173 Calantec GmbH
+50C271 Securetech
+7C49B9 Plexus Manufacturing Sdn Bhd
+184462 Riava Networks
+9C443D Chengdu Xuguang Technology
+301966 Samsung Electronics
+CC07AB Samsung Electronics
+E84E84 Samsung Electronics
+74A4B5 Powerleader Science and Technology
+64BABD SDJ Technologies
+889166 Viewcooper
+103378 Flectron
+DC0575 Siemens Energy Automation
+342387 Hon Hai Precision Ind.
+5C1193 Seal One AG
+B4527E Sony Mobile Communications AB
+CCFB65 Nintendo
+BC4100 Codaco Electronic S.r.o.
+58B961 Solem Electronique
+F46ABC Adonit
+20180E Shenzhen Sunchip Technology
+80B219 Elektron Technology UK Limited
+D08A55 Skullcandy
+C4D655 Tercel technology
+9CA10A Scle SFE
+78D99F NuCom HK
+50E14A Private
+68FCB3 Next Level Security Systems
+70305E Nanjing Zhongke Menglian Information Technology
+6C98EB Ocedo GmbH
+9C8888 Simac Techniek NV
+180C14 iSonea Limited
+8CAE89 Y-cam Solutions
+940BD5 Himax Technologies
+28BAB5 Samsung Electronics
+44700B Iffu
+8C2F39 IBA Dosimetry GmbH
+B8F828 Changshu Gaoshida Optoelectronic Technology
+58468F Koncar Electronics and Informatics
+985D46 PeopleNet Communication
+446755 Orbit Irrigation
+789F4C Hoerbiger Elektronik Gmbh
+98F8C1 IDT Technology Limited
+F47A4E Woojeon&Handan
+284D92 Luminator
+1C4BB9 SMG Enterprise
+0C5CD8 Doli Elektronik Gmbh
+2C5FF3 Pertronic Industries
+E0AF4B Pluribus Networks
+50FC9F Samsung Electronics
+C85663 Sunflex Europe GmbH
+88FED6 ShangHai WangYong Software
+600347 Billion Electric
+084027 Gridstore
+7C2048 KoamTac
+BCF5AC LG Electronics
+705986 OOO TTV
+9440A2 Anywave Communication Technologies
+20DF3F Nanjing SAC Power Grid Automation
+30786B Tianjin Golden Pentagon Electronics
+4CD637 Qsono Electronics
+8CF945 Power Automation pte
+2C922C Kishu Giken Kogyou Company
+B0FEBD Private
+509871 Inventum Technologies Private Limited
+384233 Wildeboer Bauteile GmbH
+D82D9B Shenzhen G.Credit Communication Technology
+94BF1E eflow / Smart Device Planning and Development Division
+C0A39E EarthCam
+088E4F SF Software Solutions
+E8EADA Denkovi Assembly Electroncs
+DCAE04 Celoxica
+5422F8 zte
+486E73 Pica8
+A0CEC8 CE Link Limited
+907A28 Beijing Morncloud Information And Technology
+28285D ZyXEL Communications
+105C3B Perma-Pipe
+945047 Rechnerbetriebsgruppe
+D8DCE9 Kunshan Erlab ductless filtration system
+54112F Sulzer Pump Solutions Finland Oy
+E0DCA0 Siemens Electrical Apparatus, Suzhou Chengdu Branch
+4C55B8 Turkcell Teknoloji
+088039 Cisco Spvtg
+2C72C3 Soundmatters
+84E4D9 Shenzhen Need Technology
+C44838 Satcom Direct
+CCD29B Shenzhen Bopengfa Elec&Technology
+9C4EBF BoxCast
+34A68C Shine Profit Development Limited
+78DAB3 GBO Technology
+80BBEB Satmap Systems
+6CB7F4 Samsung Electronics
+C06599 Samsung Electronics
+182666 Samsung Electronics
+949FB4 ChengDu JiaFaAnTai Technology
+406826 Thales UK Limited
+5C15E1 Aidc Technology (S) PTE
+048D38 Netcore Technology
+70E027 Hongyu Communication Technology Limited
+E880D8 Gntek Electronics
+889B39 Samsung Electronics
+E432CB Samsung Electronics
+188857 Beijing Jinhong Xi-Dian Information Technology
+287994 Realplay Digital Technology(Shenzhen)
+7CB77B Paradigm Electronics
+28A241 exlar
+9876B6 Adafruit
+2CCC15 Nokia
+AC220B Asustek Computer
+88354C Transics
+709BFC Bryton
+103B59 Samsung Electronics
+746630 T:mi Ytti
+70E284 Wistron InfoComm(Zhongshan)
+1C4AF7 Amon
+78B3CE Elo touch solutions
+A8FB70 WiseSec L.t.d
+30F31D zte
+E4776B Aartesys AG
+5C335C Swissphone Telecom AG
+A4FCCE Security Expert
+30055C Brother industries
+0C8268 Tp-link Technologies
+B01743 Edison Global Circuits
+90DA4E Avanu
+7038B4 Low Tech Solutions
+AC1826 Seiko Epson
+4C804F Armstrong Monitoring
+901D27 zte
+7CD762 Freestyle Technology
+D073D5 Lifi Labs Management
+B8C46F Primmcon Industries
+545414 Digital RF Corea
+24EB65 Saet I.S. S.r.l.
+D0F27F SteadyServ Technoligies
+DC647C C.R.S. iiMotion GmbH
+188410 CoreTrust
+A08A87 HuiZhou KaiYue Electronic
+04BFA8 ISB
+5C8486 Brightsource Industries Israel
+28CD9C Shenzhen Dynamax Software Development
+E0EDC7 Shenzhen Friendcom Technology Development
+2CF203 Emko Elektronik SAN VE TIC AS
+246278 sysmocom - systems for mobile communications GmbH
+F45842 Boxx TV
+A861AA Cloudview Limited
+C89346 Mxchip Company Limited
+F0F260 Mobitec AB
+1423D7 Eutronix
+505AC6 Guangdong Super Telecom
+38A86B Orga BV
+141330 Anakreon UK LLP
+0CF405 Beijing Signalway Technologies
+BC72B1 Samsung Electronics
+78F7BE Samsung Electronics
+1C76CA Terasic Technologies
+649968 Elentec
+D4BF2D SE Controls Asia Pacific
+C45DD8 Hdmi Forum
+C44EAC Shenzhen Shiningworth Technology
+44334C Shenzhen Bilian electronic
+C458C2 Shenzhen Tatfook Technology
+44184F Fitview
+8C76C1 Goden Tech Limited
+0C1105 Ringslink (Xiamen) Network Communication Technologies
+40C4D6 ChongQing Camyu Technology Development
+A0EB76 AirCUVE
+6C6126 Rinicom Holdings
+C04DF7 Serelec
+ECD040 GEA Farm Technologies GmbH
+005907 LenovoEMC Products USA
+1C3E84 Hon Hai Precision Ind.
+3CFB96 Emcraft Systems
+081F3F WondaLink
+DC6F08 Bay Storage Technology
+E492E7 Gridlink Tech.
+60BB0C Beijing HuaqinWorld Technology
+CC2D8C LG Electronics
+00C14F DDL
+5CE0CA FeiTian United (Beijing) System Technology
+9C9811 Guangzhou Sunrise Electronics Development
+A0FE91 Avat Automation Gmbh
+5809E5 Kivic
+74ECF1 Acumen
+F0ACA4 HBC-radiomatic
+14DB85 S NET Media
+D493A0 Fidelix Oy
+AC7236 Lexking Technology
+CCB3F8 Fujitsu Isotec Limited
+3CD7DA SK Mtek microelectronics(shenzhen)limited
+E86D54 Digit Mobile
+9857D3 HON Hai-ccpbg  Precision Ind.co.
+689423 Hon Hai Precision Ind.
+9C8D1A Integ Process Group
+742D0A Norfolk Elektronik AG
+480362 Desay Electronics(huizhou)co.
+B0358D Nokia
+0CF361 Java Information
+34BDFA Cisco Spvtg
+70F927 Samsung Electronics
+A8AD3D Alcatel-Lucent Shanghai Bell
+E0CEC3 Askey Computer
+5C43D2 Hazemeyer
+D819CE Telesquare
+D809C3 Cercacor Labs
+84ED33 Bbmc
+681E8B InfoSight
+C044E3 Shenzhen Sinkna Electronics
+08F1B7 Towerstream Corpration
+20858C Assa
+187A93 Amiccom Electronics
+DC2A14 Shanghai Longjing Technology
+94C962 Teseq AG
+B8763F Hon Hai Precision Ind.
+384369 Patrol Products Consortium
+D08B7E Passif Semiconductor
+6886E7 Orbotix
+547975 Nokia
+2CE871 Alert Metalguard ApS
+58D071 BW Broadcast
+C0A0C7 Fairfield Industries
+98208E Definium Technologies
+704AE4 Rinstrum
+5CA39D Samsung Electro-mechanics
+68B8D9 Act KDE
+F84897 Hitachi
+74E424 Apiste
+58D6D3 Dairy Cheq
+68FB95 Generalplus Technology
+6002B4 Wistron NeWeb
+E4C146 Objetivos y Servicios de Valor
+F45214 Mellanox Technologies
+EC4993 Qihan Technology
+B0ACFA Fujitsu Limited
+1C959F Veethree Electronics And Marine
+18D949 Qvis Labs
+646223 Cellient
+0C191F Inform Electronik
+080FFA KSP
+ECFC55 A. Eberle GmbH & KG
+0C8CDC Suunto Oy
+20B5C6 Mimosa Networks
+AC3CB4 Nilan A/S
+A830AD Wei Fang Goertek Electronics
+8007A2 Esson Technology
+2C3557 Elliy Powerltd
+6C5A34 Shenzhen Haitianxiong Electronic
+485A3F Wisol
+70F1E5 Xetawave
+C0AA68 Osasi Technos
+B829F7 Blaster Tech
+6815D3 Zaklady Elektroniki i Mechaniki Precyzyjnej R&G
+50B7C3 Samsung Electronics
+601929 Voltronic Power Technology(shenzhen)
+C0BD42 ZPA Smart Energy a.s.
+48B253 Marketaxess
+60D2B9 Realand BIO
+2067B1 Pluto
+087D21 Altasec technology
+30FD11 Macrotech (usa)
+F8051C DRS Imaging and Targeting Solutions
+6032F0 Mplus technology
+749975 IBM
+0CDCCC Inala Technologies
+9C611D Omni-ID USA
+78BEBD Stulz Gmbh
+3C9174 Along Communication Technology
+B8E937 Sonos
+E8D0FA MKS Instruments Deutschland GmbH
+98262A Applied Research Associates
+B0D2F5 Vello Systems
+C89F42 Vdii Innovation AB
+A41875 Cisco Systems
+640E94 Pluribus Networks
+6CE983 Gastron
+0CB4EF Digience
+D0DB32 Nokia
+609084 Dssd
+A4E731 Nokia
+0808EA Amsc
+C05E79 Shenzhen Huaxun ARK Technologies
+A4934C Cisco Systems
+E85484 NEO Information Systems
+206432 Samsung Electro Mechanics
+74AE76 iNovo Broadband
+60B933 Deutron Electronics
+38EE9D Anedo
+80CEB1 Theissen Training Systems GmbH
+00E8AB Meggitt Training Systems
+18421D Private
+78617C Mitsumi Electric
+C401B1 SeekTech
+1C5FFF Beijing Ereneben Information Technology,Ltd Shenzhen Branch
+C0C946 Mitsuya Laboratories
+ACC2EC CLT Int'l IND.
+702F4B PolyVision
+741489 SRT Wireless
+F093C5 Garland Technology
+4C09B4 zte
+B8B94E Shenzhen iBaby Labs
+00F403 Orbis Systems Oy
+ACC698 Kohzu Precision
+907025 Garea Microsys
+502ECE Asahi Electronics
+440CFD NetMan
+7CEBEA Asct
+085B0E Fortinet
+4C0FC7 Earda Electronics
+D806D1 Honeywell Fire System (Shanghai)
+8CEEC6 Precepscion
+ECD950 IRT SA
+74273C ChangYang Technology (Nanjing)
+087CBE Quintic
+C4AD21 Mediaedge
+DCBF90 Huizhou Qiaoxing Telecommunication Industry
+E0F5CA Cheng UEI Precision Industry
+1C5C60 Shenzhen Belzon Technology
+2CEDEB Alpheus Digital Company Limited
+381C4A Simcom Wireless Solutions
+C8DE51 Integra Networks
+5CE8EB Samsung Electronics
+901EDD Great Computer
+2C6289 Regenersis (Glenrothes)
+64C944 Lark Technologies
+6869F2 ComAp s.r.o.
+B889CA Iljin Electric
+B85AFE Handaer Communication Technology (Beijing)
+604616 Xiamen Vann Intelligent
+ECD925 Rami
+38AA3C Samsung Electro-mechanics
+049F06 Smobile
+687251 Ubiquiti Networks
+B8D9CE Samsung Electronics
+8C6AE4 Viogem Limited
+20C1AF i Wit Digital, Limited
+D88A3B Unit-em
+BCD940 ASR
+F0E77E Samsung Electronics
+ACF0B2 Becker Electronics Taiwan
+10A932 Beijing Cyber Cloud Technology 
+C47BA3 Navis
+A81758 Elektronik System i Ume AB
+44348F MXT Industrial Ltda
+9C0111 Shenzhen Newabel Electronic
+0CA138 Blinq Wireless
+B0B2DC ZyXEL Communications
+348137 Unicard SA
+64F242 Gerdes Aktiengesellschaft
+60F281 Tranwo Technology
+B0E892 Seiko Epson
+642400 Xorcom
+4CAA16 AzureWave Technologies (Shanghai)
+1C6BCA Mitsunami
+08379C Topaz
+E83EFB Geodesic
+4016FA EKM Metering
+3C363D Nokia
+BC0200 Stewart Audio
+1C973D Pricom Design
+8018A7 Samsung Eletronics
+885C47 Alcatel Lucent
+E0F9BE Cloudena
+3CC1F6 Melange Systems Pvt.
+54E63F ShenZhen LingKeWeiEr Technology
+006B9E Vizio
+F88C1C Kaishun Electronic Technology, Beijing
+940149 AutoHotBox
+C035BD Velocytech Aps
+F897CF Daeshin-information Technology
+383F10 DBL Technology
+8C6878 Nortek-AS
+8016B7 Brunel University
+3C3888 ConnectQuest
+08BE09 Astrol Electronic AG
+D8B8F6 Nantworks
+6044F5 Easy Digital
+AC51EE Cambridge Communication Systems
+00AA70 LG Electronics
+10E4AF APR
+E03005 Alcatel-Lucent Shanghai Bell
+B0BD6D Echostreams Innovative Solutions
+F0D14F Linear
+AC3D75 Hangzhou Zhiway Technologies
+C01885 Hon Hai Precision Ind.
+141A51 Treetech Sistemas Digitais
+845787 DVR C&C
+F436E1 Abilis Systems Sarl
+587FC8 S2M
+C49805 Minieum Networks
+90F4C1 Rand McNally
+18193F Tamtron Oy
+F8F7FF Syn-tech Systems
+F473CA Conversion Sound
+F00786 Shandong Bittel Electronics
+3C4E47 Etronic A/S
+C8F9F9 Cisco Systems
+F0F755 Cisco Systems
+10F96F LG Electronics
+B01C91 Elim
+ECA86B Elitegroup Computer Systems
+0CA2F4 Chameleon Technology (UK) Limited
+846AED Wireless Tsukamoto.
+D8E952 Keopsys
+3CB9A6 Belden Deutschland GmbH
+94CA0F Honeywell Analytics
+848D84 Rajant
+D8337F Office FA.com
+7CEF8A Inhon International
+84AF1F Beat System Service
+100D2F Online Security
+408B07 Actiontec Electronics
+980284 Theobroma Systems GmbH
+1CB17F NEC Platforms
+942E17 Schneider Electric Canada
+B89674 AllDSP GmbH & KG
+6CA682 Edam Information & Communications
+E03C5B Shenzhen Jiaxinjie Electron
+48A22D Shenzhen Huaxuchang Telecom Technology
+50ED94 Egatel SL
+B87447 Convergence Technologies
+70A66A Prox Dynamics AS
+645563 Intelight
+C467B5 Libratone A/S
+A4EF52 Telewave
+F4044C ValenceTech Limited
+1CBBA8 Ojsc Ufimskiy Zavod Promsvyaz
+34AA99 Alcatel-Lucent
+506028 Xirrus
+24B657 Cisco Systems
+940B2D NetView Technologies(Shenzhen)
+306E5C Validus Technologies
+E843B6 Qnap Systems
+5CC9D3 Palladium Energy Eletronica DA Amazonia Ltda
+407B1B Mettle Networks
+64E161 DEP
+C8A620 Nebula
+989080 Linkpower Network System
+0064A6 Maquet CardioVascular
+9CF67D Ricardo Prague, s.r.o.
+BC764E Rackspace US
+C4EEAE VSS Monitoring
+2437EF EMC Electronic Media Communication SA
+CCF9E8 Samsung Electronics
+D4F63F IEA S.r.l.
+4C0289 LEX Computech
+C0E54E Denx Computer Systems Gmbh
+386077 Pegatron
+E435FB Sabre Technology (Hull)
+146308 Jabil Circuit (shanghai)
+28BE9B Technicolor USA
+F01C13 LG Electronics
+00CD90 MAS Elektronik AG
+A8BD1A Honey Bee (Hong Kong) Limited
+ACCC8E Axis Communications AB
+187C81 Valeo Vision Systems
+DC1EA3 Accensus
+A40130 ABIsystems
+68F125 Data Controls
+3440B5 IBM
+90D74F Bookeen
+905682 Lenbrook Industries Limited
+CC6DEF TJK Tietolaite Oy
+3CE624 LG Display 
+D8F0F2 Zeebo
+B0CF4D MI-Zone Technology Ireland
+BCB1F3 Samsung Electronics
+143605 Nokia
+B87424 Viessmann Elektronik GmbH
+C81AFE Dlogic Gmbh
+9C53CD Engicam S.r.l.
+DCC101 SOLiD Technologies
+2C10C1 Nintendo
+AC6FBB Tatung Technology
+1803FA IBT Interfaces
+608645 Avery Weigh-Tronix
+541DFB Freestyle Energy
+C46044 Everex Electronics Limited
+645422 Equinox Payments
+D412BB Quadrant Components
+40E793 Shenzhen Siviton Technology
+2C67FB ShenZhen Zhengjili Electronics
+D89760 C2 Development
+A0E201 AVTrace(China)
+38ECE4 Samsung Electronics
+04EE91 x-fabric GmbH
+183825 Wuhan Lingjiu High-tech
+5404A6 Asustek Computer
+F83376 Good Mind Innovation
+CC501C KVH Industries
+AC6FD9 Valueplus
+A4E391 Deny Fontaine
+04A82A Nokia
+7C4C58 Scale Computing
+FCC23D Atmel
+7C1E52 Microsoft
+DCB4C4 Microsoft XCG
+74FDA0 Compupal (Group) 
+C029F3 XySystem
+48F317 Private
+B07D62 Dipl.-Ing. H. Horstmann GmbH
+68974B Shenzhen Costar Electronics
+B8BB6D Eneres
+645DD7 Shenzhen Lifesense Medical Electronics,
+9034FC Hon Hai Precision Ind.
+5C076F Thought Creator
+3C0FC1 KBC Networks
+58E636 EVRsafe Technologies
+90D11B Palomar Medical Technologies
+CC60BB Empower RF Systems
+24497B Innovative Converged Devices
+ECBD09 Fusion Electronics
+54847B Digital Devices GmbH
+705CAD Konami Gaming
+788973 CMC
+DCCE41 FE Global Hong Kong Limited
+4C774F Embedded Wireless Labs 
+203706 Cisco Systems
+706F81 Private
+9CDF03 Harman/Becker Automotive Systems GmbH
+30E4DB Cisco Systems
+742B0F Infinidat
+280CB8 Mikrosay Yazilim ve Elektronik A.S.
+A06CEC RIM
+443EB2 Deotron
+8CB82C IPitomy Communications
+807DE3 Chongqing Sichuan Instrument MicrocircuitLTD.
+1C8E8E DB Communication & Systems
+F0022B Chrontel
+DC175A Hitachi High-Technologies
+D45AB2 Galleon Systems
+C40142 MaxMedia Technology Limited
+A06E50 Nanotek Elektronik Sistemler Sti.
+182C91 Concept Development
+EC4670 Meinberg Funkuhren GmbH & KG
+B40B7A Brusa Elektronik AG
+A4B36A JSC SDO Chromatec
+905F8D modas GmbH
+E0C922 Jireh Energy Tech.
+28401A C8 MediSensors
+007F28 Actiontec Electronics
+0C924E Rice Lake Weighing Systems
+40040C A&T
+A0165C Triteka
+90B97D Johnson Outdoors Marine Electronics d/b/a Minnkota
+8821E3 Nebusens
+DC3C84 Ticom Geomatics
+E8CC32 Micronet 
+9C6ABE Qees ApS.
+3429EA MCD Electronics SP. Z O.O.
+D43AE9 Dongguan ipt Industrial
+ACC935 Ness
+B0F1BC Dhemax Ingenieros Ltda
+3C096D Powerhouse Dynamics
+CCD9E9 SCR Engineers
+F0DB30 Yottabyte
+9C31B6 Kulite Semiconductor Products
+BC3E13 Accordance Systems
+0455CA BriView (Xiamen)
+D45D42 Nokia
+BC2846 NextBIT Computing Pvt.
+4425BB Bamboo Entertainment
+B8A8AF Logic
+648125 Alphatron Marine BV
+042605 GFR Gesellschaft fr Regelungstechnik und Energieeinsparung mbH
+48D8FE ClarIDy Solutions
+70B265 Hiltron s.r.l.
+84D9C8 Unipattern,
+1C955D I-lax Electronics
+94AAB8 Joview(Beijing) Technology
+18B3BA Netlogic AB
+F43E9D Benu Networks
+6469BC Hytera Communications
+64094C Beijing Superbee Wireless Technology
+30EB25 Intek Digital
+F0AE51 Xi3
+782EEF Nokia
+78510C LiveU
+306118 Paradom
+C84529 IMK Networks
+A88CEE MicroMade Galka i Drozdz sp.j.
+204005 feno GmbH
+CC52AF Universal Global Scientific Industrial
+6C81FE Mitsuba
+E8F928 Rftech SRL
+703AD8 Shenzhen Afoundry Electronic
+4C98EF Zeo
+DCA6BD Beijing Lanbo Technology
+D0667B Samsung Electronics
+58E808 Autonics
+B8C716 Fiberhome Telecommunication Technologies
+8058C5 NovaTec Kommunikationstechnik GmbH
+F8A9DE Puissance Plus
+D4F027 Navetas Energy Management
+5C0CBB Celizion
+B8871E Good Mind Industries
+F8EA0A Dipl.-Math. Michael Rauch
+BC5FF4 ASRock Incorporation
+906EBB Hon Hai Precision Ind.
+D44F80 Kemper Digital GmbH
+34684A Teraworks
+0CC6AC Dags
+D82A7E Nokia
+5CBD9E Hongkong Miracle Eagle Technology(group) Limited
+743889 Annax Anzeigesysteme Gmbh
+E89A8F Quanta Computer
+647FDA Tektelic Communications
+609E64 Vivonic GmbH
+7C4A82 Portsmith
+2C0033 EControls
+E0F211 Digitalwatt
+0432F4 Partron
+AC199F Sungrow Power Supply
+1CAA07 Cisco Systems
+308CFB Dropcam
+CCF841 Lumewave
+701404 Limited Liability Company
+1C35F1 NEW Lift Neue Elektronische Wege Steuerungsbau GmbH
+C0EAE4 Sonicwall
+90610C Fida International (S) Pte
+3C5F01 Synerchip
+708B78 citygrow technology
+74CD0C Smith Myers Communications
+B8EE79 YWire Technologies
+40C245 Shenzhen Hexicom Technology
+7076F0 LevelOne Communications (India) Private Limited
+48C8B6 SysTec GmbH
+303855 Nokia
+9C4563 Dimep Sistemas
+E42771 Smartlabs
+C4EEF5 Oclaro
+CC09C8 Imaqliq
+0876FF Thomson Telecom Belgium
+401D59 Biometric Associates
+4C2C80 Beijing Skyway Technologies
+08D29A Proformatique
+90D852 Comtec
+28061E Ningbo Global Useful Electric
+4037AD Macro Image Technology
+64E8E6 global moisture management system
+34A183 AWare
+740ABC Jsjs Designs (europe) Limited
+E8E0B7 Toshiba
+588D09 Cisco Systems
+5C6A7D Kentkart EGE Elektronik SAN. VE TIC. STI.
+04FF51 Novamedia Innovision SP. Z O.O.
+FCD4F2 The Coca Cola Company
+C471FE Cisco Systems
+340804 D-Link
+B44CC2 NR Electric
+084EBF Broad Net Mux
+18ABF5 Ultra Electronics - Electrics
+48CB6E Cello Electronics (UK)
+EC3BF0 NovelSat
+A86A6F RIM
+4022ED Digital Projection
+0CA402 Alcatel Lucent IPD
+0817F4 IBM
+C4D489 JiangSu Joyque Information Industry
+1C7C11 EID
+F43E61 Shenzhen Gongjin Electronics
+B0B32B Slican Sp. z o.o.
+5842E4 Baxter International
+8CA048 Beijing NeTopChip Technology
+804F58 ThinkEco
+B06563 Shanghai Railway Communication Factory
+349A0D ZBD Displays
+A0B5DA Hongkong Thtf
+CCCD64 SM-Electronic GmbH
+E82877 TMY
+AC8112 Gemtek Technology
+C4B512 General Electric Digital Energy
+E02538 Titan Pet Products
+CC7A30 Cmax Wireless
+D8760A Escort
+101DC0 Samsung Electronics
+F49F54 Samsung Electronics
+6063FD Transcend Communication Beijing
+E08A7E Exponent
+80C6CA Endian s.r.l.
+F8B599 Guangzhou Chnavs Digital Technology
+9C645E Harman Consumer Group
+78CD8E SMC Networks
+5C9AD8 Fujitsu Limited
+144C1A Max Communication GmbH
+FCE557 Nokia
+BC6E76 Green Energy Options
+108CCF Cisco Systems
+74E06E Ergophone GmbH
+18AF9F Digitronic Automationsanlagen Gmbh
+EC4644 TTK SAS
+DCD87F Shenzhen JoinCyber Telecom Equipment
+B08991 LGE
+6CA906 Telefield
+3C02B1 Creation Technologies LP
+E46C21 messMa GmbH
+0470BC Globalstar
+E05FB9 Cisco Systems
+081735 Cisco Systems
+20FECD System In Frontier
+94D019 Cydle
+9C220E Tascan Service Gmbh
+2CA157 acromate
+70DDA1 Tellabs
+44DCCB Semindia Systems PVT
+90D92C Hug-witschi AG
+B428F1 E-Prime
+B4749F Askey Computer
+AC2FA8 Humannix
+7C4AA8 MindTree Wireless PVT
+C8A70A Verizon Business
+304EC3 Tianjin Techua Technology
+BC4377 Hang Zhou Huite Technology
+A81B18 XTS
+04E2F8 AEP Ticketing solutions srl
+8C5105 Shenzhen ireadygo Information Technology
+28E297 Shanghai InfoTM Microelectronics
+D093F8 Stonestreet One
+1C334D ITS Telecom
+1C17D3 Cisco Systems
+E8E5D6 Samsung Electronics
+ACBE75 Ufine Technologies
+D87157 Lenovo Mobile Communication Technology
+806629 Prescope Technologies
+90F278 Radius Gateway
+68CA00 Octopus Systems Limited
+4C3089 Thales Transportation Systems GmbH
+342109 Jensen Scandinavia AS
+08FAE0 Fohhn Audio AG
+B439D6 ProCurve Networking by HP
+506F9A Wi-Fi Alliance
+7CF098 Bee Beans Technologies
+9C7514 Wildix srl
+BC7DD1 Radio Data Comms
+28068D ITL
+F0D767 Axema Passagekontroll AB
+A4AE9A Maestro Wireless Solutions
+5CD135 Xtreme Power Systems
+9C28BF Continental Automotive Czech Republic s.r.o.
+C848F5 Medison Xray
+64A232 OOO Samlight
+A082C7 P.T.I
+F41F0B Yamabishi
+447C7F Innolight Technology
+FC75E6 Handreamnet
+20B0F7 Enclustra GmbH
+8C90D3 Alcatel Lucent
+4013D9 Global ES
+F4DC4D Beijing CCD Digital Technology
+AC4FFC Svs-vistek Gmbh
+A85BB0 Shenzhen Dehoo Technology
+089F97 Leroy Automation
+4C5DCD Oy Finnish Electric Vehicle Technologies
+10090C Janome Sewing Machine
+ECB106 Acuro Networks
+7C2E0D Blackmagic Design
+08F6F8 GET Engineering
+6CDC6A Promethean Limited
+9055AE Ericsson, EAB/RWI/K
+0097FF Heimann Sensor GmbH
+F0BDF1 Sipod
+288915 CashGuard Sverige AB
+180675 Dilax Intelcom Gmbh
+40618E Stella-Green
+9C4E20 Cisco Systems
+408493 Clavister AB
+1C3A4F AccuSpec Electronics
+58E747 Deltanet AG
+D87533 Nokia
+ECFE7E BlueRadios
+7C3920 Ssoma Security
+9C77AA Nadasnv
+D8B6C1 NetworkAccountant
+58D08F Ieee 1904.1 Working Group
+3C99F7 Lansentechnology AB
+94E711 Xirka Dama Persada PT
+507D02 Biodit
+F44227 S & S Research
+D4CBAF Nokia
+14FEAF Sagittar Limited
+F8DAE2 Beta LaserMike
+E80462 Cisco Systems
+70B08C Shenou Communication Equipment
+F0E5C3 Drgerwerk AG & KG aA
+446132 ecobee
+A4B2A7 Adaxys Solutions AG
+F455E0 Niceway CNC Technology,Ltd.Hunan Province
+206FEC Braemac CA
+FC7CE7 FCI USA
+145412 Entis
+A04E04 Nokia
+807D1B Neosystem
+7CB542 Aces Technology
+40CD3A Z3 Technology
+045D56 camtron industrial
+AC83F0 ImmediaTV
+6CE0B0 Sound4
+00336C SynapSense
+E446BD C&C Technic Taiwan
+7415E2 Tri-Sen Systems
+7C7673 Enmas Gmbh
+6C6F18 Stereotaxis
+003532 Electro-Metrics
+44376F Young Electric Sign
+8C640B Beyond Devices d.o.o.
+F04335 DVN(Shanghai)Ltd.
+A479E4 Klinfo
+FCFAF7 Shanghai Baud Data Communication
+003CC5 Wonwoo Engineering
+E85E53 Infratec Datentechnik GmbH
+64DB18 OpenPattern
+0C7D7C Kexiang Information Technology
+70D880 Upos System sp. z o.o.
+0CC9C6 Samwin Hong Kong Limited
+B45861 CRemote
+AC6706 Ruckus Wireless
+B8653B Bolymin
+B0973A E-Fuel
+A05DC1 Tmct
+E0CA4D Shenzhen Unistar Communication
+E497F0 Shanghai VLC Technologies
+44A42D TCT Mobile Limited
+204E6B Axxana(israel)
+50F003 Open Stack
+0C17F1 Telecsys
+5492BE Samsung Electronics
+98BC99 Edeltech
+E8E1E2 Energotest
+FC683E Directed Perception
+6C1811 Decatur Electronics
+94592D EKE Building Technology Systems
+9CC077 PrintCounts
+4487FC Elitegroup Computer System
+00BD3A Nokia
+B8B1C7 Bt&com
+A0BFA5 Coresys
+D411D6 ShotSpotter
+7CCB0D Antaira Technologies
+ECE9F8 Guang Zhou TRI-SUN Electronics Technology 
+E89D87 Toshiba
+9CAFCA Cisco Systems
+784476 Zioncom technology
+34CE94 Parsec (Pty)
+ACE9AA Hay Systems
+082AD0 SRD Innovations
+E0E751 Nintendo
+C8D1D1 AGAiT Technology
+3CF52C Dspecialists Gmbh
+040EC2 ViewSonic Mobile China Limited
+5403F5 EBN Technology
+7C2F80 Gigaset Communications GmbH
+446C24 Reallin Electronic
+A0593A V.D.S. Video Display Systems srl
+A8F94B Eltex Enterprise
+2C3A28 Fagor Electrnica
+90A7C1 Pakedge Device and Software
+80F593 Irco Sistemas de Telecomunicacin
+6CFDB9 Proware Technologies
+6CFFBE MPB Communications
+583CC6 Omneality
+34BA51 Se-Kure Controls
+44A8C2 Sewoo Tech
+8CD628 Ikor Metering
+481BD2 Intron Scientific
+444E1A Samsung Electronics
+009363 Uni-Link Technology
+7C6F06 Caterpillar Trimble Control Technologies
+AC583B Human Assembler
+A05DE7 Directv
+10CA81 Precia
+003A98 Cisco Systems
+705AB6 Compal Information (kunshan)
+003A9A Cisco Systems
+ACBEB6 Visualedge Technology
+580556 Elettronica GF S.r.L.
+88B627 Gembird Europe BV
+D41F0C JAI Oy
+3C4C69 Infinity System S.L.
+44E49A Omnitronics
+74F07D BnCOM
+1065A3 Core Brands
+20415A Smarteh d.o.o.
+703C39 Seawing Kft
+14A86B ShenZhen Telacom Science&Technology
+0CC3A7 Meritec
+4C322D Teledata Networks
+48EB30 Eterna Technology
+207C8F Quanta Microsystems
+F8472D X2gen Digital
+8C598B C Technologies AB
+64F970 Kenade Electronics Technology
+A04025 Actioncable
+78998F Mediline Italia SRL
+40ECF8 Siemens AG
+F04BF2 Jtech Communications
+A8CB95 East Best
+40A6A4 PassivSystems
+24828A Prowave Technologies
+6C0F6A JDC Tech
+6CF049 Giga-byte Technology
+D4C766 Acentic GmbH
+0026A0 moblic
+00269A Carina System
+002694 Senscient
+002693 QVidium Technologies
+00268D CellTel
+00268E Alta Solutions
+002687 corega K.K
+002681 Interspiro AB
+00267B GSI Helmholtzzentrum fr Schwerionenforschung GmbH
+906DC8 DLG Automao Industrial Ltda
+48343D IEP GmbH
+C8C13C RuggedTek Hangzhou
+609F9D CloudSwitch
+0CE936 Elimos srl
+A4DE50 Total Walther GmbH
+E8A4C1 Deep Sea Electronics PLC
+701AED Advas
+64C6AF Axerra Networks
+D8D67E GSK CNC Equipment
+A4E7E4 Connex GmbH
+0026FE MKD Technology
+0026F8 Golden Highway Industry Development
+0026F7 Infosys Technologies
+0026F1 ProCurve Networking by HP
+0026EB Advanced Spectrum Technology
+0026E5 AEG Power Solutions
+0026DF TaiDoc Technology
+0026D8 Magic Point
+0026D2 Pcube Systems
+0026CC Nokia Danmark A/S
+0026C5 Guangdong Gosun Telecommunications
+0026C0 EnergyHub
+0026BF ShenZhen Temobi Science&Tech Development
+0026B7 Kingston Technology Company
+0026A6 Trixell
+00271E Xagyl Communications
+002722 Ubiquiti Networks
+002716 Adachi-Syokai
+002715 Rebound Telecom.
+00270A IEE
+002704 Accelerated Concepts
+903D6B Zicon Technology
+7C3BD5 Imago Group
+B894D2 Retail Innovation HTT AB
+DCE71C AUG Elektronik GmbH
+88A5BD Qpcom
+DC3350 TechSAT GmbH
+0025E5 LG Electronics
+0025E1 Shanghai Seeyoo Electronic & Technology
+0025DB ATI Electronics(Shenzhen)
+0025D5 Robonica (Pty)
+0025C9 Shenzhen Huapu Digital
+0025CE InnerSpace
+0025C2 RingBell
+0025BB Innerint
+002674 Electronic Solutions
+00266E Nissho-denki
+002668 Nokia Danmark A/S
+00265B Hitron Technologies.
+002661 Irumtek
+002657 OOO NPP Ekra
+00264E Rail & Road Protec GmbH
+00255D Morningstar
+002551 SE-Elektronic GmbH
+00254A RingCube Technologies
+002543 Moneytech
+002544 LoJack
+002539 IfTA GmbH
+00253B din Dietmar Nocker Facilitymanagement GmbH
+00253A CEVA
+00250B Centrofactor 
+002504 Valiant Communications Limited
+0024FF QLogic
+0024FD Accedian Networks
+0024F8 Technical Solutions Company
+0024F1 Shenzhen Fanhai Sanjiang Electronics
+0024EC United Information Technology
+002580 Equipson
+00257C Huachentel Technology Development
+002575 FiberPlex Technologies
+002576 Neli Technologies
+002570 Eastern Communications Company Limited
+002563 Luxtera
+002611 Licera AB
+002617 OEM Worldwide
+00260A Cisco Systems
+0025FE Pilot Electronics
+002605 CC Systems AB
+002604 Audio Processing Technology
+0025F4 KoCo Connector AG
+0025EB Reutech Radar Systems (PTY)
+0025E6 Belgian Monitoring Systems bvba
+0025B6 Telecom FM
+0025AF Comfile Technology
+0025AA Beijing Soul Technology
+0025A9 Shanghai Embedway Information Technologies
+0025A3 Trimax Wireless
+00259C Cisco-Linksys
+002597 Kalki Communication Technologies
+002590 Super Micro Computer
+002531 Cloud Engines
+00252F Energy
+00252A Chengdu GeeYa Technology
+002521 Logitek Electronic Systems
+00251C EDT
+002517 Venntis
+002510 Pico-Tesla Magnetic Therapies
+00263C Bachmann Technology GmbH & KG
+002637 Samsung Electro-Mechanics
+002630 AcorelS
+002629 Juphoon System Software
+00262A Proxense
+002624 Thomson
+00261D COP Security System
+00242A Hittite Microwave
+00241D Giga-byte Technology
+002424 Axis Network Technology
+002417 Thomson Telecom Belgium
+002418 Nextwave Semiconductor
+002411 PharmaSmart
+00240B Virtual Computer
+00240A US Beverage Net
+0024B8 free alliance sdn bhd
+0024BD Hainzl Industriesysteme GmbH
+0024B3 Graf-Syteco GmbH & KG
+0024AE Morpho
+0024A7 Advanced Video Communications
+0024AC Hangzhou DPtech Technologies
+00249B Action Star Enterprise
+00246E Phihong USA
+002467 AOC International (Europe) GmbH
+002469 Smart Doorphones
+002462 Rayzone
+002458 PA Bastion CC
+00245D Terberg besturingstechniek
+002455 MuLogic BV
+002450 Cisco Systems
+00244B Perceptron
+002444 Nintendo
+002499 Aquila Technologies
+002488 Centre For Development Of Telematics
+002494 Shenzhen Baoxin Tech
+00247C Nokia Danmark A/S
+00247A FU YI Cheng Technology
+002475 Compass System(Embedded Dept.)
+0023AD Xmark
+0023A7 Redpine Signals
+0023A1 Trend Electronics
+0023A6 E-Mon
+00239A EasyData Hardware GmbH
+002394 Samjeon
+002390 Algolware
+002386 Tour & Andersson AB
+002405 Dilog Nordic AB
+0023F5 Wilo SE
+0023F8 ZyXEL Communications
+0023FE Biodevices
+0023F0 Shanghai Jinghan Weighing Apparatus
+0023EB Cisco Systems
+0023E5 IPaXiom Networks
+0023E6 Pirkus
+0023D9 Banner Engineering
+0023CC Nintendo
+0023D3 AirLink WiFi Networking
+0023D8 Ball-It Oy
+0023C6 SMC
+0023C0 Broadway Networks
+0023B9 Eads Deutschland Gmbh
+0023B3 Lyyn AB
+0023B4 Nokia Danmark A/S
+0024E5 Seer Technology
+0024E0 DS Tech
+0024DE Global Technology
+0024D9 Bicom
+0024CB Autonet Mobile
+0024CD Willow Garage
+0024C6 Hager Electro SAS
+00243A Ludl Electronic Products
+002434 Lectrosonics
+00242E Datastrip
+00225A Garde Security AB
+002254 Bigelow Aerospace
+00224C Nintendo
+002251 Lumasense Technologies
+00224B Airtech Technologies
+002245 Leine & Linde AB
+002242 Alacron
+00223B Communication Networks
+002296 LinoWave
+00228F Cnrs
+002290 Cisco Systems
+00228A Teratronik elektronische systeme gmbh
+00227E Chengdu 30Kaitian Communication IndustryLtd
+00227D YE Data
+002278 Shenzhen  Tongfang Multimedia  Technology
+002272 American Micro-Fuel Device
+002271 Jger Computergesteuerte Metechnik GmbH.
+00226E Gowell Electronic Limited
+002358 Systel SA
+002357 Pitronot Technologies and Engineering P.T.E.
+002352 Datasensor
+00234B Inyuan Technology
+002346 Vestac
+00233F Purechoice
+002338 OJ-Electronics A/S
+002333 Cisco Systems
+00232F Advanced Card Systems
+00232A eonas IT-Beratung und -Entwicklung GmbH
+0022C1 Active Storage
+0022C2 Proview Eletrnica do Brasil Ltda
+0022BC Jdsu France SAS
+0022B5 Novita
+0022A9 LG Electronics
+0022AF Safety Vision
+0022A2 Xtramus Technologies
+00229D Pyung-hwa Ind.co.
+002327 Shouyo Electronics
+002323 Zylin AS
+00231A ITF
+002318 Toshiba
+002311 Gloscom
+00230C Clover Electronics
+002305 Cisco Systems
+0022FF Nivis
+0022FE Advanced Illumination
+002300 Cayee Computer
+0022F6 Syracuse Research
+0022F9 Pollin Electronic GmbH
+002209 Omron Healthcare
+002203 Glensound Electronics
+002200 IBM
+0021F6 Oracle
+0021F0 EW3 Technologies
+0021EA Bystronic Laser AG
+0021E3 SerialTek
+0021DE Firepro Wireless
+0021DD Northstar Systems
+0021D7 Cisco Systems
+002235 Strukton Systems bv
+002234 Corventis
+00222F Open Grid Computing
+002228 Breeze Innovations
+002222 Schaffner Deutschland GmbH
+00221C Private
+00220F MoCA (Multimedia over Coax Alliance)
+0022F5 Advanced Realtime Tracking GmbH
+0022EF iWDL Technologies
+0022E8 Applition
+0022E3 Amerigon
+0022D5 Eaton Electrical Group Data Center Solutions - Pulizzi
+0022DC Vigil Health Solutions
+0022D6 Cypak AB
+0022D0 Polar Electro Oy
+0022CB Ionodes
+0022C6 Sutus
+002380 Nanoteq
+00237A RIM
+002377 Isotek Electronics
+002378 GN Netcom A/S
+002371 Soam Systel
+002365 Elka-elektronik Gmbh
+00236A SmartRG
+00235E Cisco Systems
+001F82 Cal-Comp Electronics & Communications
+001F7D embedded wireless GmbH
+001F7B TechNexion
+001F7C Witelcom AS
+001F79 Lodam Electronics A/S
+001F74 Eigen Development
+001F6F Fujian Sunnada Communication
+001F63 JSC Goodwin-Europa
+001F6A PacketFlux Technologies
+001F69 Pingood Technology
+001F5C Nokia Danmark A/S
+001F57 Phonik Innovation
+00214C Samsung Electronics
+002146 Sanmina-SCI
+00213D Cermetek Microelectronics
+00213E TomTom
+002135 Alcatel-lucent
+00213A Winchester Systems
+002130 Keico Hightech
+0021AC Infrared Integrated Systems
+0021AB Nokia Danmark A/S
+0021A5 Erlphase Power Technologies
+00219F Satel OY
+002197 Elitegroup Computer System
+00218A Electronic Design and Manufacturing Company
+00218B Wescon Technology
+002185 Micro-star Int'l
+00217E Telit Communication s.p.a
+002178 Matuschek Messtechnik GmbH
+002172 Seoultek Valley
+002166 NovAtel
+002165 Presstek
+00215F Ihse Gmbh
+002153 SeaMicro
+002158 Style Flying Technology
+001FAA Taseon
+001FA5 Blue-White Industries
+001FA4 ShenZhen Gongjin Electronics
+001FA0 A10 Networks
+001F9A Nortel Networks
+001F99 Seronicsltd
+001F9B Posbro
+001F94 Lascar Electronics
+001F8D Ingenieurbuero Stark GmbH und Ko. KG
+001F89 Signalion GmbH
+001FF9 Advanced Knowledge Associates
+001FF2 VIA Technologies
+001FED Tecan Systems
+001FE6 Alphion
+001FE0 EdgeVelocity
+001FDF Nokia Danmark A/S
+001FDA Nortel Networks
+001FD5 Microrisc S.r.o.
+00212B MSA Auer
+00211D Dataline AB
+002124 Optos Plc
+002118 Athena Tech
+002111 Uniphone
+002107 Seowonintech
+002101 Aplicaciones Electronicas Quasar (AEQ)
+002102 UpdateLogic
+001FD6 Shenzhen Allywll
+001FD0 Giga-byte Technology
+001FC9 Cisco Systems
+001FBD Kyocera Wireless
+001FB1 Cybertech
+001FB6 Chi Lin Technology
+0021D1 Samsung Electronics
+0021D0 Global Display Solutions Spa
+0021CB SMS Tecnologia Eletronica Ltda
+0021C4 Consilium AB
+0021B8 Inphi
+0021B1 Digital Solutions
+001F21 Inner Mongolia Yin An Science & Technology Development
+001F22 Source Photonics
+001F1C Kobishi Electric
+001F15 Bioscrypt
+001F10 Toledo DO Brasil Industria DE Balancas  Ltda
+001F0C Intelligent Digital Services GmbH
+001F00 Nokia Danmark A/S
+001F07 Azteq Mobile
+001DDE Zhejiang Broadcast&Television Technology
+001DE7 Marine Sonic Technology
+001DD7 Algolith
+001DD8 Microsoft
+001DCB Exns Development Oy
+001DC6 SNR
+001DC5 Beijing Jiaxun Feihong Electricial
+001DBF Radiient Technologies
+001DB8 Intoto
+001DB3 HPN Supply Chain
+001E0D Micran
+001E06 Wibrain
+001DFF Network Critical Solutions
+001E00 Shantou Institute of Ultrasonic Instruments
+001DFA Fujian Landi Commercial Equipment
+001DF3 SBS Science & Technology
+001DEE Nextvision Sistemas Digitais DE Televiso LTDA.
+001DED Grid Net
+001ED0 Ingespace
+001ECB RPC Energoautomatika
+001EC4 Celio
+001EBE Cisco Systems
+001EBD Cisco Systems
+001EB8 Fortis
+001EB1 Cryptsoft
+001EA6 Best IT World (India) Pvt.
+001EAC Armadeus Systems
+001E9F Visioneering Systems
+001EA0 XLN-t
+001EF4 L-3 Communications Display Systems
+001EF9 Pascom Kommunikations systeme GmbH.
+001EFA Protei
+001EE8 Mytek
+001EED Adventiq
+001EE7 Epic Systems
+001EE1 Samsung Electronics
+001ED7 H-Stream Wireless
+001E6B Cisco Spvtg
+001E72 PCS
+001E66 Resol Elektronische Regelungen Gmbh
+001E5F KwikByte
+001E53 Further Tech
+001E9A Hamilton Bonaduz AG
+001E93 CiriTech Systems
+001E8E Hunkeler AG
+001E88 Andor System Support
+001E82 SanDisk
+001E81 CNB Technology
+001E7C Taiwick Limited
+001E77 Air2App
+001F50 Swissdis AG
+001F49 Manhattan TV
+001F4A Albentia Systems
+001F44 GE Transportation Systems
+001F2F Berker GmbH & KG
+001F34 Lung Hwa Electronics
+001F28 HPN Supply Chain
+001E42 Teltonika
+001E3C Lyngbox Media AB
+001E3B Nokia Danmark A/S
+001E2F DiMoto
+001E36 Ipte
+001E29 Hypertherm
+001E23 Electronic Educational Devices
+001E17 STN BV
+001E1C SWS Australia Limited
+001E12 Ecolab
+001D02 Cybertech Telecom Development
+001CF6 Cisco Systems
+001CFC Suminet Communication Technologies (Shanghai)
+001CEF Primax Electronics
+001CEA Scientific-Atlanta
+001CE9 Galaxy Technology Limited
+001CE5 MBS Electronic Systems GmbH
+001CE0 Dasan TPS
+001CD9 GlobalTop Technology
+001CD2 King Champion (Hong Kong) Limited
+001CCD Alektrona
+001CC6 ProStor Systems
+001CBA VerScient
+001CB0 Cisco Systems
+001CB5 Neihua Network Technology,LTD.(NHN)
+001CB6 Duzon CNT
+001CA9 Audiomatica Srl
+001D5F Overspeed Sarl
+001D53 S&O Electronics (Malaysia) Sdn. Bhd.
+001D4E TCM Mobile
+001D4D Adaptive Recognition Hungary
+001D49 Innovation Wireless
+001D44 Krohne Messtechnik Gmbh
+001D3D Avidyne
+001D43 Shenzhen G-link Digital Technology
+001D36 Electronics OF India Limited
+001C6B Covax 
+001C64 Landis+Gyr
+001C5F Winland Electronics
+001C53 Synergy Lighting Controls
+001C58 Cisco Systems
+001C4E Tasa International Limited
+001C47 Hangzhou Hollysys Automation
+001C49 Zoltan Technology
+001C48 WiDeFi
+001C3B AmRoad Technology
+001C42 Parallels
+001C9E Dualtech IT AB
+001C97 Enzytek Technology,
+001C98 Lucky Technology (hk) Company Limited
+001C92 Tervela
+001C8B MJ Innovations
+001C86 Cranite Systems
+001C85 Eunicorn
+001C81 NextGen Venturi
+001C72 Mayer & Cie GmbH & KG
+001C77 Prodys
+001D31 Highpro International R&D
+001D2A Shenzhen Bul-tech
+001D23 Sensus
+001D24 Aclara Power-Line Systems
+001D1B Sangean Electronics
+001D1E Kyushu TEN
+001D15 Shenzhen Dolphin Electronic
+001D0E Agapha Technology
+001C36 iNEWiT NV
+001C2F Pfister GmbH
+001C28 Sphairon Technologies GmbH 
+001C1E emtrion GmbH
+001C19 secunet Security Networks AG
+001C0B SmartAnt Telecom
+001C0D G-Technology
+001C0C Tanita
+001DAE Chang Tseng Technology
+001DA9 Castles Technology,
+001DA2 Cisco Systems
+001D9C Rockwell Automation
+001D9B Hokuyo Automatic
+001D96 WatchGuard Video
+001D8F PureWave Networks
+001D8A TechTrex
+001D89 VaultStor
+001D7F Tekron International
+001D83 Emitech
+001D72 Wistron
+001D79 Signamax
+001D66 Hyundai Telecom
+001D6D Confidant International
+001B00 Neopost Technologies
+001AF4 Handreamnet
+001AF9 AeroVIronment (AV)
+001AEF Loopcomm Technology
+001AE3 Cisco Systems
+001AE8 Unify GmbH and KG
+001AEA Radio Terminal Systems
+001AD0 Albis Technologies AG
+001AD5 KMC Chain Industrial
+001AD7 Christie Digital Systems
+001ADC Nokia Danmark A/S
+001A81 Zelax
+001A88 Venergy
+001A7A Lismore Instruments Limited
+001A70 Cisco-Linksys
+001A72 Mosart Semiconductor
+001A6B Universal Global Scientific Industrial
+001A64 IBM
+001A56 ViewTel
+001A5B NetCare Service
+001A5F KitWorks.fi
+001C06 Siemens Numerical Control, Nanjing
+001BFF Millennia Media
+001BFA G.i.N. mbH
+001BF3 Transradio Sendersysteme Berlin AG
+001BEA Nintendo
+001BE3 Health Hero Network
+001BE5 802automation Limited
+001BE4 Townet SRL
+001BDE Renkus-Heinz
+001BD2 Ultra-x Asia Pacific
+001AAC Corelatus AB
+001AAE Savant Systems
+001AB3 Visionite
+001AA7 Torian Wireless
+001A9E Icon Digital International Limited
+001AA3 Delorme
+001AA5 BRN Phoenix
+001AA4 Future University-Hakodate
+001A97 fitivision technology
+001A8D Avecs Bergen Gmbh
+001BA2 IDS Imaging Development Systems GmbH
+001B96 General Sensing
+001B9B Hose-McCann Communications
+001B8F Cisco Systems
+001B85 MAN Diesel SE
+001B7E Beckmann GmbH
+001B79 Faiveley Transport
+001B72 Sicep
+001B6D Midtronics
+001B6B Swyx Solutions AG
+001B6C LookX Digital Media BV
+001B66 Sennheiser electronic GmbH & KG
+001B5F Alien Technology
+001B5A Apollo Imaging Technologies
+001B53 Cisco Systems
+001B47 Futarque A/S
+001B4C Signtech
+001B4E Navman New Zealand
+001B40 Network Automation mxc AB
+001B34 Focus System
+001B39 Proxicast
+001BCB Pempek Systems
+001BC4 Ultratec
+001BBA Nortel
+001BB5 ZF Electronics GmbH
+001BAE Micro Control Systems
+001BA8 Ubi&mobi
+001BA7 Lorica Solutions
+001B3B Yi-Qing
+001B28 Polygon
+001B2D Med-Eng Systems
+001B24 Quanta Computer
+001B1F Delta - Danish Electronics, Light & Acoustics
+001B18 Tsuken Electric Ind.
+001B13 Icron Technologies
+001B0C Cisco Systems
+001B05 YMC AG
+001AC9 Suzuken
+001ABA Caton Overseas Limited
+001ABF Trumpf Laser Marking Systems AG
+001A2B Ayecom Technology
+001A1F Coastal Environmental Systems
+001A1A Gentex/Electro-Acoustic Products
+001A13 Wanlida Group
+001A0E Cheng Uei Precision Industry
+001A0C Swe-Dish Satellite Systems AB
+001A07 Arecont Vision
+001A00 Matrix
+0018F9 Vvond
+0018F2 Beijing Tianyu Communication Equipment
+0018EB Blue Zen Enterprises Private Limited
+0018ED Accutech Ultrasystems
+0018E6 Computer Hardware Design SIA
+0018DA Amber Wireless Gmbh
+0018DF The Morey
+0018CE Dreamtech
+0018D3 Teamcast
+00192E Spectral Instruments
+001932 Gude Analog- und Digialsysteme GmbH
+001922 CM Comandos Lineares
+001927 ImCoSys
+001929 2m2b Montadora de Maquinas Bahia Brasil Ltda
+00190F Advansus
+001916 PayTec AG
+00191B Sputnik Engineering AG
+001908 Duaxes
+00190A Hasware
+001903 Bigfoot Networks
+0019B6 Euro Emme s.r.l.
+0019A3 asteel electronique atlantique
+0019A8 WiQuest Communications
+0019AA Cisco Systems
+0019AF Rigol Technologies
+001992 Adtran
+001997 Soft Device Sdn Bhd
+00199C Ctring
+00198B Novera Optics Korea
+00198D Ocean Optics
+00197F Plantronics
+001986 Cheng Hongjian
+001973 Zeugma Systems
+00197A MAZeT GmbH
+001967 Teldat Sp.J.
+00196C Etrovision Technology
+00196E Metacom (Pty)
+001962 Commerciant
+001A43 Logical Link Communications
+001A48 Takacom
+001A4A Qumranet
+001A3C Technowave
+001A30 Cisco Systems
+001A35 Bartec Gmbh
+001A37 Lear
+001A26 Deltanode Solutions AB
+0019F2 Teradyne K.K.
+0019F7 Onset Computer
+0019DF Thomson
+0019E6 Toyo Medic
+0019EB Pyronix
+0019CC RCG (HK)
+0019D3 Trak Microwave
+0019D8 Maxfor
+0019C2 Equustek Solutions
+0018C2 Firetide
+0018C4 Raba Technologies
+0018C9 EOps Technology Limited
+0018BD Shenzhen Dvbworld Technology
+0018B1 IBM
+0018B6 S3C
+0018AF Samsung Electronics
+0018A3 Zippy Technology
+0018AA Protec Fire Detection plc
+00195D ShenZhen XinHuaTong Opto Electronics
+001951 Netcons, S.r.o.
+001956 Cisco Systems
+00194F Nokia Danmark A/S
+00194A Testo AG
+001943 Belden
+001937 CommerceGuard AB
+001873 Cisco Systems
+001875 AnaCise Testnology Pte
+00187A Wiremold
+00186E 3Com
+00185E Nexterm
+001860 SIM Technology Group Shanghai Simcom,
+001865 Siemens Healthcare Diagnostics Manufacturing
+001755 GE Security
+001747 Trimble
+001749 Hyundae Yong-o-sa
+00174E Parama-tech
+001732 Science-technical Center Rissa
+001734 ADC Telecommunications
+001739 Bright Headphone Electronics Company
+00172D Axcen Photonics
+001852 StorLink Semiconductors
+001859 Strawberry Linux
+00184B Las Vegas Gaming
+001846 Crypto
+00183A Westell Technologies
+001829 Gatsometer
+001835 Thoratec / ITC
+001824 Kimaldi Electronics
+001822 CEC Telecom
+001816 Ubixon
+00181D Asia Electronics
+0017D6 Bluechips Microhouse
+0017DB Canko Technologies
+0017CC Alcatel-Lucent
+0017D1 Nortel
+0017C5 SonicWALL
+0017B9 Gambro Lundia AB
+0017BE Tratec Telecom
+0017C0 PureTech Systems
+0017B2 SK Telesys
+00177D IDT International Limited
+001782 LoBenn
+001789 Zenitron
+00176D Core
+001771 APD Communications
+001776 Meso Scale Diagnostics
+001761 Private
+001768 Zinwave
+00175C Sharp
+00175A Cisco Systems
+0017AB Nintendo
+0017AD AceNet
+0017A6 Yosin Electronics
+0017A1 3soft
+00179C Deprag Schulz Gmbh u.
+001790 Hyundai Digitech
+001795 Cisco Systems
+001721 Fitre
+001726 m2c Electronic Technology
+00171A Winegard Company
+00171F IMV
+001713 Tiger NetCom
+00170E Cisco Systems
+001811 Neuros Technology International
+00180A Meraki
+00180F Nokia Danmark A/S
+001801 Actiontec Electronics
+0017F5 LIG Neoptek
+0017FA Microsoft
+0017FC Suprema
+00189E Omnikey GmbH.
+001894 NPCore
+001899 ShenZhen jieshun Science&Technology Industry
+001886 El-tech
+001888 Gotive a.s.
+00188D Nokia Danmark A/S
+001881 Buyang Electronics Industrial
+0016D4 Compal Communications
+0016D9 Ningbo Bird
+0016C8 Cisco Systems
+0016CD Hiji High-tech
+0016C1 Eleksen
+0016BA Weathernews
+0016BC Nokia Danmark A/S
+00164F World Ethnic Broadcastin
+00164E Nokia Danmark A/S
+00164D Alcatel North America IP Division
+001648 SSD Company Limited
+001643 Sunhillo
+00163E Xensource
+001637 Citel SpA
+001632 Samsung Electronics
+00162B Togami Electric Mfg.co.
+001624 Teneros
+001613 LibreStream Technologies
+001618 Hivion
+00161F Sunwavetec
+00160E Optica Technologies
+001607 Curves International
+001609 Unitech electronics
+001608 Sequans Communications
+001602 Ceyon Technology
+0015FB setex schermuly textile computer gmbh
+0015F6 Science AND Engineering Services
+0015EF NEC Tokin
+0015E8 Nortel
+0015E3 Dream Technologies
+0015D9 PKC Electronics Oy
+0015DE Nokia Danmark A/S
+0015D2 Xantech
+0015CC Uquest
+0015CB Surf Communication Solutions
+0015CD Exartech International
+0015C6 Cisco Systems
+0015BB SMA Solar Technology AG
+001709 Exalt Communications
+001704 Shinco Electronics Group
+0016FD Jaty Electronics
+0016F1 OmniSense
+0016F6 Video Products Group
+0016F8 Aviqtech Technology
+0016E5 Fordley Development Limited
+0016DE Fast
+0016A9 2EI
+0016AE Inventel
+00169D Cisco Systems
+00169F Vimtron Electronics
+0016A4 Ezurio
+001691 Moser-Baer AG
+001698 T&A Mobile Phones
+00168C DSL Partner AS
+001685 Elisa Oyj
+00167E Diboss.co.
+001680 Bally Gaming + Systems
+001679 eOn Communications
+00166E Arbitron
+001667 A-TEC Subsystem
+001660 Nortel
+00165B Grip Audio
+001654 Flex-P Industries Sdn. Bhd.
+0015BF technicob
+0015B4 Polymap  Wireless
+0015AA Rextechnik International,
+0015A5 DCI
+00159E Mad Catz Interactive
+001597 Aeta Audio Systems
+001592 Facom UK (Melksham)
+00158B Park Air Systems
+001584 Schenck Process GmbH
+00157F ChuanG International Holding
+00157A Telefin
+001575 Nevis Networks
+00156E A. W. Communication Systems
+001567 Radwin
+001569 Peco II
+001568 Dilithium Networks
+001562 Cisco Systems
+001441 Innovation Sound Technology
+001448 Inventec Multimedia & Telecom
+00143A Raytalk International SRL
+001435 CityCom
+00142E 77 Elektronika Kft.
+001429 V Center Technologies
+001428 Vocollect
+001427 JazzMutant
+00141E P.A. Semi
+001418 C4Line
+0013F0 Wavefront Semiconductor
+0013EB Sysmaster
+0013E6 Technolution
+0013DF Ryvor
+0013D9 Matrix Product Development
+0013DA Diskware
+0013CD MTI
+0013D3 Micro-star International
+0013C1 Asoka USA
+0013BC Artimi
+001476 MultiCom Industries Limited
+001471 Eastern Asia Technology Limited
+00146A Cisco Systems
+001463 Idcs N.V.
+001465 Novo Nordisk A/S
+001464 Cryptosoft
+00145E IBM
+001457 T-vips AS
+001452 Calculex
+00144D Intelligent Systems
+0014D5 Datang Telecom Technology , LCD,Optical Communication Br
+0014DA Huntleigh Healthcare
+0014CE NF
+0014C8 Contemporary Research
+0014C7 Nortel
+0014BB Open Interface North America
+0014B6 Enswer Technology
+0014AC Bountiful WiFi
+0014B1 Axell Wireless Limited
+001533 Nadam.co.
+00152E PacketHop
+001527 Balboa Instruments
+001520 Radiocrafts AS
+00151B Isilon Systems
+001516 Uriel Systems
+001511 Data Center Systems
+00150A Sonoa Systems
+001503 Proficomms S.r.o.
+001505 Actiontec Electronics
+00155B Sampo
+00154F one RF Technology
+001546 ITG Worldwide Sdn Bhd
+001540 Nortel
+00153F Alcatel Alenia Space Italia
+001541 StrataLight Communications
+00153A Shenzhen Syscan Technology
+001504 Game Plus
+0014FE Artech Electronics
+0014F7 Crevis
+0014F2 Cisco Systems
+0014EB AwarePoint
+0014E1 Data Display AG
+00149E UbONE
+001499 Helicomm
+001492 Liteon, Mobile Media Solution SBU
+00148B Globo Electronic GmbH & KG
+00148D Cubic Defense Simulation Systems
+00148C Fortress Technologies
+001486 Echo Digital Audio
+00147D Aeon Digital International
+00141D LTi Drives Gmbh
+001411 Deutschmann Automation GmbH & KG
+004501 Versus Technology
+001403 Renasis
+0013FC SiCortex
+0013F5 Akimbi Systems
+0013F6 Cintech
+00131F NxtPhase T&D
+001318 Dgstation
+00130C HF System
+001313 GuangZhou Post & Telecom Equipment
+0012F9 Uryu Seisaku
+001300 It-factory
+00127F Cisco Systems
+001278 International Bar Code
+00126C Visonic
+001273 Stoke
+001266 Swisscom Hospitality Services SA
+001265 Enerdyne Technologies
+00125B Kaimei Electroni
+0012C4 Viseon
+0012D0 Gossen-Metrawatt-GmbH
+0012CA Mechatronic Brick Aps
+0012BA FSI Systems
+0012AE HLS Hard-line Solutions
+0012B3 Advance Wireless Technology
+0012AD IDS GmbH
+001358 Realm Systems
+00135D Nttpc Communications
+00134F Tranzeo Wireless Technologies
+001348 Artila Electronics
+001342 Vision Research
+00133C Quintron Systems
+001341 Shandong New Beiyang Information Technology
+001329 Vsst
+001330 Euro Protection Surveillance
+001335 VS Industry Berhad
+00132F Interactek
+001260 Stanton Magnetics
+001256 LG Information & COMM.
+00124F Pentair Thermal Management
+00124A Dedicated Devices
+001249 Delta Elettronica
+001243 Cisco Systems
+00123C Second Rule
+001230 Picaso Infocommunication
+00138C Kumyoung.Co.Ltd
+001391 Ouen
+001377 Samsung Electronics
+00137C Kaicom
+001383 Application Technologies and Engineering Research Laboratory
+001370 Nokia Danmark A/S
+001364 Paradigm Technology.
+001369 Honda Electron
+00136A Hach Lange Sarl
+001354 Zcomax Technologies
+0012A7 ISR Technologies
+0012A0 NeoMeridian Sdn Bhd
+00129B E2S Electronic Engineering Solutions
+001294 Sumitomo Electric Device Innovations
+00128B Sensory Networks
+001285 Gizmondo Europe
+001286 Endevco
+001305 Epicom
+001306 Always On Wireless
+0012F4 Belco International
+0012EF OneAccess SA
+0012EA Trane
+0012E9 Abbey Systems
+0012DC SunCorp Industrial Limited
+0012E3 Agat-RT
+0012D7 Invento Networks
+0013B7 Scantech ID
+0013AB Telemotive AG
+0013B2 Carallon Limited
+0013B1 Intelligent Control Systems (Asia) Pte
+0013A4 KeyEye Communications
+00139F Electronics Design Services,
+001398 TrafficSim
+001392 Ruckus Wireless
+0011D2 Perception Digital
+0011D7 eWerks
+0011D1 Soft Imaging System GmbH
+0011C2 United Fiber Optic Communication
+0011CB Jacobsons AB
+0011BB Cisco Systems
+0011BC Cisco Systems
+0011AA Uniclass Technology,
+0011AF Medialink-i
+00112B NetModule AG
+001120 Cisco Systems
+001125 IBM
+001119 Solteras
+001113 Fraunhofer Fokus
+001106 Siemens NV (Belgium)
+00110D Sanblaze Technology
+001101 CET Technologies Pte
+0011A9 Moimstone
+0011A3 LanReady Technologies
+001197 Monitoring Technologies Limited
+00119C EP&T Energy
+00118D Hanchang System
+001192 Cisco Systems
+001186 Prime Systems
+00117F Neotune Information Technology
+001200 Cisco Systems
+0011FB Heidelberg Engineering GmbH
+0011F6 Asia Pacific Microsystems 
+0011F1 QinetiQ
+0011EA Iwics
+0011E3 Thomson
+0011DE Eurilogic
+0011E4 Danelec Electronics A/S
+00117A Singim International
+00116E PePLink
+001173 Smart Storage Systems
+001167 Integrated System Solution
+00116D American Time and Signal
+001163 System SPA DEPT. Electronics
+001156 Pharos Systems NZ
+00115D Cisco Systems
+000FFB Nippon Denso Industry
+000FF8 Cisco Systems
+000FF2 Loud Technologies
+000FF7 Cisco Systems
+000FE5 Mercury Security
+000FE6 MBTech Systems
+000FEB Cylon Controls
+000FDF Solomon Technology
+000FD8 Force
+001226 Japan Direx
+001220 Cadco Systems
+00121A Techno Soft Systemnics
+00121F Harding Instruments
+001213 Metrohm AG
+00120D Advanced Telecommunication Technologies
+001207 Head Strong International Limited
+00120E AboCom
+001148 Prolon Control Systems
+00114D Atsumi Electric
+00114E 690885 Ontario
+001141 GoodMan
+00113B Micronet Communications
+001135 Grandeye
+001126 Venstar
+000FD3 Digium
+000FC6 Eurocom Industries A/S
+000FC5 KeyMed
+000FC0 Delcomp
+000FB4 Timespace Technology
+000FB9 Adaptive Instruments
+000FB3 Actiontec Electronics
+000EB9 Hashimoto Electronics Industry
+000EBA Hanmi Semiconductor
+000EAC Mintron Enterprise
+000EA0 NetKlass Technology
+000EA7 Endace Technology
+000E9A BOE Technology Group
+000E99 Spectrum Digital
+000F44 Tivella
+000F43 Wasabi Systems
+000F4A Kyushu-kyohan
+000F3E CardioNet
+000F3A Hisharp
+000F30 Raza Microelectronics
+000F2F W-linx Technology
+000F36 Accurate Techhnologies
+000F2A Cableware Electronics
+000F23 Cisco Systems
+000F76 Digital Keystone
+000F70 Wintec Industries
+000F75 First Silicon Solutions
+000F7C ACTi
+000F69 SEW Eurodrive GmbH & KG
+000F63 Obzerv Technologies
+000F64 D&R Electronica Weesp BV
+000F5D Genexis BV
+000F56 Continuum Photonics
+000F51 Azul Systems
+000FA6 S2 Security
+000FAD FMN communications GmbH
+000F9B Ross Video Limited
+000F9E Murrelektronik GmbH
+000FA1 Gigabit Systems
+000F95 Elecom,ltd Laneed Division
+000F96 Telco Systems
+000F8F Cisco Systems
+000F88 Ametek
+000F83 Brainium Technologies
+000EEB Sandmartin(zhong shan)Electronics
+000EEC Orban
+000EF1 Ezquest
+000EDE Remec
+000EE5 bitWallet
+000ECC Tableau
+000ED9 Aksys
+000ECB VineSys Technology
+000ED2 Filtronic plc
+000EBF Remsdaq Limited
+000EC6 Asix Electronics
+000E61 Microtrol Limited
+000E5A Telefield
+000E54 AlphaCell Wireless
+000E4E Waveplus Technology
+000E53 AV Tech
+000E47 NCI System
+000E41 Nihon Mechatronics
+000E42 Motic Incoporation
+000E3C Transact Technologies
+000E36 Heinesys
+000E8D Systems in Progress Holding GmbH
+000E94 Maas International BV
+000E87 adp Gauselmann GmbH
+000E81 Devicescape Software
+000E88 Videotron
+000E75 New York Air Brake
+000E7A GemWon Communications
+000E66 Hitachi Industry & Control Solutions
+000F1D Cosmo Techs
+000F10 RDM
+000F17 Insta Elektro GmbH
+000F1E Chengdu KT Electricof High & New Technology
+000F0B Kentima Technologies AB
+000F04 cim-usa
+000EFE EndRun Technologies
+000EF8 SBC ASI
+000EFD Fujinon
+000E30 Aeras Networks
+000E29 Shester Communications
+000E23 Incipient
+000E24 Huwell Technology
+000E16 SouthWing S.L.
+000E1D Arion Technology
+000E09 Shenzhen Coship Software
+000E11 BDT Bro und Datentechnik GmbH &KG 
+000DF6 Technology Thesaurus
+000CA4 Prompttec Product Management GmbH
+000CAB Commend International
+000C98 Letek Communications
+000C9D UbeeAirWalk
+000C9F NKE
+000C8C Kodicom
+000C91 Riverhead Networks
+000C80 Opelcomm
+000C85 Cisco Systems
+000D7F Midas  Communication Technologies PTE ( Foreign Branch)
+000D79 Dynamic Solutions
+000D73 Technical Support
+000D7A DiGATTO Asia Pacific Pte
+000D6C M-Audio
+000D5A Tiesse SpA
+000D60 IBM
+000D59 Amity Systems
+000D26 Primagraphics Limited
+000D21 Wiscore
+000D14 Vtech Innovation LP dba Advanced American Telephones
+000D13 Wilhelm Rutenbeck GmbH&Co.KG
+000D1A Mustek System
+000D0E Inqnet Systems
+000D01 P&E Microcomputer Systems
+000D02 NEC Platforms
+000D07 Calrec Audio
+000D4D Ninelanes
+000D54 3Com
+000D45 Tottori Sanyo Electric
+000D48 Aewin Technologies
+000D40 Verint Loronix Video Solutions
+000D39 Network Electronics
+000D33 Prediwave
+000D34 Shell International Exploration and Production
+000D2D NCT Deutschland GmbH
+000CDC Becs Technology
+000CC9 Ilwoo Data & Technology
+000CB0 Star Semiconductor
+000CB6 Nanjing SEU Mobile & Internet Technology
+000CBD Interface Masters
+000CC2 ControlNet (India) Private Limited
+000CAF TRI Term
+000DCB Petcomkorea
+000DC4 Emcore
+000DBE Bel Fuse Europe
+000DB8 Schiller AG
+000DBD Cisco Systems
+000DFD Huges Hi-Tech,
+000E02 Advantech AMT
+000DF0 Qcom Technology
+000DEA Kingtel Telecommunication
+000DEF Soc. Coop. Bilanciai
+000DDD Profilo Telra Elektronik Sanayi ve Ticaret. A.
+000DDE Joyteck
+000DE3 AT Sweden AB
+000DD0 TetraTec Instruments GmbH
+000DD7 Bright
+000DB1 Japan Network Service
+000DA9 T.e.a.m. S.L.
+000DAC Japan CBM
+000DA4 Dosch & Amand Systems AG
+000D97 ABB/Tropos
+000D98 S.W.A.C. Schmitt-Walter Automation Consult GmbH
+000D8A Winners Electronics
+000D91 Eclipse (HQ Espana) S.L.
+000CFB Korea Network Systems
+000CEF Open Networks Engineering
+000CF4 Akatsuki Electric Mfg.co.
+000CE8 GuangZhou AnJuBao
+000CE1 The Open Group
+000CCF Cisco Systems
+000CD0 Symetrix
+000CD5 Passave
+000BC3 Multiplex
+000BBC En Garde Systems
+000BC1 Bay Microsystems
+000BB0 Sysnet Telematica srl
+000BB5 nStor Technologies
+000BA6 Miyakawa Electric Works
+000BAB Advantech Technology (china)
+000B99 SensAble Technologies
+000B9A Shanghai Ulink Telecom Equipment
+000B9F Neue Elsa Gmbh
+000B94 Digital Monitoring Products
+000B88 Vidisco
+000C71 Wybron
+000C78 In-Tech Electronics Limited
+000C7D Teikoku Electric MFG.
+000C65 Sunin Telecom
+000C6A Mbari
+000C6C Elgato Systems
+000C52 Roll Systems
+000C57 Mackie Engineering Services Belgium Bvba
+000C59 Indyme Electronics
+000C5E Calypso Medical
+000B51 Micetek International
+000B54 BiTMICRO Networks
+000B45 Cisco Systems
+000B4C Clarion (M) Sdn Bhd
+000B40 Oclaro
+000B32 Vormetric
+000B39 Keisoku Giken
+000B3E BittWare
+000B26 Wetek
+000B2B Hostnet
+000B2D Danfoss
+000C0F Techno-One
+000C16 Concorde Microsystems
+000C0A Guangdong Province Electronic Technology Research Institute
+000BFD Cisco Systems
+000BF7 Nidek
+000BFC Cisco Systems
+000BFE Castel Broadband Limited
+000C03 Hdmi Licensing
+000AED Harting Systems Gmbh & KG
+000AE8 Cathay Roxus Information Technology
+000ADA Vindicator Technologies
+000ADC RuggedCom
+000AE1 EG Technology
+000AC9 Zambeel
+000ACE Radiantech
+000AD5 Brainchild Electronic
+000ABB Taiwan Secom
+000B8D Avvio Networks
+000B7B Test-Um
+000B7A L-3 Linkabit
+000B7C Telex Communications
+000B81 Kaparel
+000B6E Neff Instrument
+000B75 Iosoft
+000B69 Franke Finland Oy
+0091D6 Crystal Group
+000B62 ib-mohnen KG
+000B59 ScriptPro
+000B1A Industrial Defender
+000B1F I CON Computer
+000B13 Zetron
+000B0E Trapeze Networks
+000B0C Agile Systems
+000B07 Voxpath Networks
+000AF9 HiConnect
+000AFB Ambri Limited
+000B00 Fujian Start Computer Equipment
+000AF4 Cisco Systems
+000C4B Cheops Elektronik
+000C46 Allied Telesyn
+000C3D Glsystech
+000C33 Compucase Enterprise
+000C36 Sharp Takaya Electronics Industry
+000C2C Enwiser
+000C1D Mettler & Fuchs AG
+000C22 Double D Electronics
+000BEB Systegra AG
+000BF0 MoTEX Products
+000BDD Tohoku Ricoh
+000BE4 Hosiden
+000BD8 Industrial Scientific
+000BD4 Beijing Wise Technology & Science DevelopmentLtd
+000BC8 AirFlow Networks
+000BCF Agfa NDT
+000A4F Brain Boxes Limited
+000A51 GyroSignal Technology
+000A56 Hitachi Maxell
+000A4A Targa Systems
+000A37 Procera Networks
+000A3E Eads Telecom
+000A43 Chunghwa Telecom
+000A30 Visteon
+000A32 Xsido
+000A2B Etherstuff
+000A29 Pan Dacom Networking AG
+000A1D Optical Communications Products
+000A1F ART Ware Telecommunication
+000A24 Octave Communications
+00095A Racewood Technology
+000954 AMiT spol. s. r. o.
+00094E Bartech Systems International
+000953 Linkage System IntegrationLtd.
+000942 Wireless Technologies
+000947 Aztek
+00093B Hyundai Networks
+000934 Dream-Multimedia-Tv GmbH
+0009E5 Hottinger Baldwin Messtechnik GmbH
+0009D9 Neoscale Systems
+0009DE Samjin Information & Communications
+0009CC Moog GmbH
+0009C6 Visionics
+0009CB HBrain
+0009D2 Mai Logic
+0009BE Mamiya-OP
+0009C2 Onity
+000AC2 FiberHome Telecommunication Technologies
+000AC7 Unication Group
+000AAF Pipal Systems
+000AB6 Compunetix
+000AA3 Shimafuji Electric
+000AA8 ePipe
+000AAA AltiGen Communications
+000A90 Bayside Interactive
+000A9C Server Technology
+000A96 Mewtel Technology
+000986 Metalink
+000985 Auto Telecom Company
+00098C Option Wireless Sweden
+000980 Power Zenith
+000973 Lenten Technology
+000974 Innopia Technologies
+000979 Advanced Television Systems Committee
+000966 Thales Navigation
+00096D Powernet Technologies
+000961 Switchgear and Instrumentation
+000A81 Teima Audiotex S.L.
+000A83 Salto Systems S.L.
+000A88 InCypher
+000A7C Tecton
+000A70 Mpls Forum
+000A75 Caterpillar
+000A62 Crinis Networks
+000A64 Eracom Technologies
+000A69 Sunny Bell Technology
+000A5D FingerTec Worldwide Sdn Bhd
+000A18 Vichel
+000A0C Scientific Research
+000A11 ExPet Technologies
+0009F8 Unimo Technology
+0009FB Philips Patient Monitoring
+000A02 Annso
+0009EB HuMANDATA
+0009EC Daktronics
+0009F1 Yamaki Electric
+0009B8 Entise Systems
+0009B7 Cisco Systems
+0009B2 L&F
+0009A5 Hansung Eletronic Industries Development
+0009A6 Ignis Optics
+0009AB Netcontrol Oy
+00099F Videx
+000993 Visteon
+000998 Capinfo Company Limited
+000928 Telecore
+00092F Akom Technology
+000922 TST Biometrics GmbH
+000921 Planmeca Oy
+00091C CacheVision
+000910 Simple Access
+000915 CAS
+00090F Fortinet
+000909 Telenor Connect A/S
+000902 Redline Communications
+0008FD BlueKorea
+0007AD Pentacon GmbH Foto-und Feinwerktechnik
+0007A5 Y.D.K
+00079F Action Digital
+000792 Stron Electronic GmbH
+000799 Tipping Point Technologies
+00078C Elektronikspecialisten i Borlange AB
+000786 Wireless Networks
+000775 Valence Semiconductor
+00077C Westermo Teleindustri AB
+000776 Federal APD
+00077F J Communications
+000780 Bluegiga Technologies OY
+000770 Ubiquoss
+00076B Stralfors AB
+0008B4 Syspol
+0008AE PacketFront Network Products AB
+0008A7 iLogic
+0008A2 ADI Engineering
+0008A1 CNet Technology
+00089B ICP Electronics
+00088D Sigma-Links
+000893 LE Information Communication
+00088E Nihon Computer
+000897 Quake Technologies
+000887 Maschinenfabrik Reinhausen GmbH
+000881 Digital Hands
+0007E1 WIS Communications
+0007D4 Zhejiang Yutong Network Communication
+0007DB Kirana Networks
+0007D5 3e Technologies Int;.
+0005F9 TOA
+0007C5 Gcom
+0007CC Kaba Benzing GmbH
+0007C6 VDS Vosskuhler GmbH
+0007B9 Ginganet
+0007BF Armillaire Technologies
+00047F Chr. Mayr GmbH & KG
+0007B3 Cisco Systems
+02C08C 3com
+00087B RTX Telecom A/S
+000880 BroadTel Canada Communications
+00086E Hyglo AB
+000868 PurOptix
+000861 SoftEnergy
+00084F Qualstar
+00085B Hanbit Electronics
+000855 Nasa-goddard Space Flight Center
+00084E DivergeNet
+00085C Shanghai Dare Technologies
+00075F VCS Video Communication Systems AG
+000766 Chou Chin Industrial
+000759 Boris Manufacturing
+00074C Beicom
+000753 Beijing Qxcomm Technology
+000743 Chelsio Communications
+000744 Unico
+000747 Mecalc
+000737 Soriya
+00073E China Great-Wall Computer Shenzhen
+00072B Jung Myung Telecom
+000731 Ophir-Spiricon
+0008F5 Yestechnology
+0008EF Dibal
+0008EA Motion Control Engineering
+0008DD Telena Communications
+0008DE 3UP Systems
+0008E3 Cisco Systems
+0008D7 HOW
+0008CB Zeta Broadband
+0008D0 Musashi Engineering
+0008C1 Avistar Communications
+0008C6 Philips Consumer Communications
+0008BA Erskine Systems
+0006EC Harris
+0006DF Aidonic
+0006E0 MAT
+0006E5 Fujian Newland Computer
+0006DB Ichips
+0006D0 Elgar Electronics
+0006D7 Cisco Systems
+0006CA American Computer & Digital Components, (acdc)
+0006C4 Piolink
+0006C0 United Internetworks
+00081F Pou Yuen Tech
+000826 Colorado Med Tech
+000820 Cisco Systems
+000825 Acme Packet
+00082C Homag AG
+000819 Banksys
+000810 Key Technology
+000813 Diskbank
+00080A Espera-Werke GmbH
+000804 ICA
+0007FA ITT
+0007E7 FreeWave Technologies
+0007EE telco Informationssysteme GmbH
+0007ED Altera
+0007F4 Eletex
+00071A Finedigital
+000721 Formac Elektronik GmbH
+00070E Cisco Systems
+000715 General Research of Electronics
+000708 Bitrage
+0006F2 Platys Communications
+0006FE Ambrado
+0006FC Fnet
+000645 Meisei Electric
+000644 neix
+00064B Alexon
+00063B Arcturus Networks
+00063A Dura Micro
+000634 GTE Airfone
+00062A Cisco Systems
+000627 Uniwide Technologies
+00062E Aristos Logic
+000617 Redswitch
+00061E Maxan Systems
+000618 DigiPower Manufacturing
+000612 Accusys
+000609 Crossport Systems
+0005C7 I/f-com A/S
+0005CE Prolink Microsystems
+0005C1 A-Kyung Motion
+0005BB Myspace AB
+00059B Cisco Systems
+0005A7 Hyperchip
+0005B5 Broadcom Technologies
+00059A Cisco Systems
+0005A1 Zenocom
+0005AB Cyber Fone
+000588 Sensoria
+000594 HMS Technology Center Ravensburg GmbH
+00058E Flextronics International GmbH & Nfg. KG
+00053D Agere Systems
+000530 Andiamo Systems
+000537 Nets Technology
+000536 Danam Communications
+000524 BTL System (HK) Limited
+00052A Ikegami Tsushinki
+00051D Airocon
+000517 Shellcomm
+000513 VTLinx Multimedia Systems
+00050D Midstream Technologies
+0004CE Patria Ailon
+0004CD Extenway Solutions
+0004C7 NetMount
+0004C8 Liba Maschinenfabrik Gmbh
+0004C1 Cisco Systems
+0004BB Bardac
+0004B5 Equitrac
+0004A7 FabiaTech
+0004A1 Pathway Connectivity
+00049A Cisco Systems
+000460 Knilink Technology
+000494 Breezecom
+000581 Snell
+00057B Chung Nam Electronic
+000582 ClearCube Technology
+000577 SM Information & Communication
+000571 Seiwa Electronics
+00056B C.P. Technology
+000565 Tailyn Communication Company
+00055F Cisco Systems
+00055E Cisco Systems
+000558 Synchronous
+000552 Xycotec Computer GmbH
+000549 Salira Optical Network Systems
+00054C RF Innovations
+000543 IQ Wireless GmbH
+0006BA Westwave Communications
+0006AD KB Electronics
+0006B4 Vorne Industries
+0006AE Himachal Futuristic Communications
+0006B3 Diagraph
+0006A3 Bitran
+00069D Petards
+0006A7 Primarion
+000657 Market Central
+000697 R & D Center
+000691 PT Inovacao
+000684 Biacore AB
+00060F Narad Networks
+000602 Cirkitech Electronics
+0005ED Technikum Joanneum GmbH
+000600 Toshiba Teli
+0005E7 Netrake an AudioCodes Company
+0005F3 Webyn
+0005FA IPOptical
+0005DE Gi Fone Korea
+0005DA Apex Automationstechnik
+0005C8 Verytech
+0005D4 FutureSmart Networks
+0005CD Denon
+00068A NeuronNet R&D Center
+00067E WinCom Systems
+000670 Upponetti Oy
+000676 Novra Technologies
+00067A JMP Systems
+000664 Fostex
+00066A InfiniCon Systems
+000651 Aspen Networks
+00065D Heidelberg Web Systems
+00065E Photuris
+000507 Fine Appliance
+0004FD Japan Control Engineering
+0004F7 Omega Band
+0004F1 WhereNet
+0004DA Relax Technology
+008087 OKI Electric Industry
+0004E0 Procket Networks
+0004D4 Proview Electronics
+000415 Rasteme Systems
+000408 Sanko Electronics
+000409 Cratos Networks
+000402 Nexsan Technologies
+0003F8 SanCastle Technologies
+0003FF Microsoft
+0003F1 Cicada Semiconductor
+0003F2 Seneca Networks
+0003EC ICG Research
+0003E6 Entone
+0003DE OTC Wireless
+0003E1 Winmate Communication
+0003DA Takamisawa Cybernetics
+0003D3 Internet Energy Systems
+000291 Open Network
+00028A Ambit Microsystems
+000287 Adapcom
+00028C Micrel-Synergy Semiconductor
+000282 ViaClix
+00027B Amplify Net
+00024F IPM Datacom S.R.L.
+000274 Tommy Technologies
+000276 Primax Electronics
+00026F Senao International
+000264 AudioRamp.com
+000268 Harris Government Communications
+000453 YottaYotta
+00044D Cisco Systems
+000449 Mapletree Networks
+000443 Agilent Technologies
+00043D Indel AG
+000431 GlobalStreams
+000436 Elansat Technologies
+000430 Netgem
+00042A Wireless Networks
+000424 TMC s.r.l.
+00041B Bridgeworks
+00041E Shikoku Instrumentation
+000356 Wincor Nixdorf International GmbH
+00034B Nortel Networks
+000350 Bticino SPA
+000348 Norscan Instruments
+000345 Routrek Networks
+00033D Ilshin Lab
+0001EC Ericsson Group
+000331 Cisco Systems
+000338 Oak Technology
+000335 Mirae Technology
+00032C ABB Switzerland
+000325 Arima Computer
+00031C Svenska Hardvarufabriken AB
+000315 Cidco Incorporated
+000310 E-Globaledge
+00030D Uniwill Computer
+000309 Texcel Technology PLC
+000304 Pacific Broadband Communications
+00019F ReadyNet
+0002FD Cisco Systems
+0002F6 Equipe Communications
+0002F1 Pinetron
+0002EF CCC Network Systems Group
+0002EB Pico Communications
+0002E6 Gould Instrument Systems
+0002DF Net Com Systems
+0002D3 NetBotz
+0002D8 Brecis Communications
+0002CC M.c.c.i
+0002D0 Comdial
+0002C5 Evertz Microsystems
+0002C0 Bencent Tzeng Industry
+0002BD Bionet
+0002B7 Watanabe Electric Industry
+0002B0 Hokubu Communication & Industrial
+0002A8 Air Link Technology
+0002AB CTC Union Technologies
+0002A4 AddPac Technology
+000299 Apex
+00029D Merix
+0003CE Eten Technologies
+0003CB Nippon Systems Development
+0003C2 Solphone K.K.
+0003C7 hopf Elektronik GmbH
+0003BB Signal Communications Limited
+0003B5 Entra Technology
+0003B0 Xsense Technology
+0003A4 Imation
+0003A9 Axcent Media AG
+0003AD Emerson Energy Systems AB
+000396 EZ Cast
+00039D Qisda
+000391 Advanced Digital Broadcast
+00038A America Online
+00038E Atoga Systems
+00037C Coax Media
+000381 Ingenico International
+000375 NetMedia
+00036E Nicon Systems (Pty) Limited
+000362 Vodtel Communications
+00035B BridgeWave Communications
+00048E Ohm Tech Labs
+000495 Tejas Networks India Limited
+000483 Deltron Technology
+000489 Yafo Networks
+000479 Radius
+00046D Cisco Systems
+000472 Telelynx
+00046C Cyber Technology
+000466 Armitel
+00045A The Linksys Group
+00045F Avalue Technology
+0030A4 Woodwind Communications System
+0030E5 Amper Datos
+0030C0 Lara Technology
+00300E Klotz Digital AG
+003094 Cisco Systems
+00309A Astro Terra
+00300C Congruency
+0030FD Integrated Systems Design
+003023 Cogent Computer Systems
+0030DF Kb/tel Telecomunicaciones
+00307D GRE America
+0030D1 Inova
+003032 MagicRam
+0001E3 Siemens AG
+0001EA Cirilium
+0001EF Camtel Technology
+0001F2 Mark of the Unicorn
+0001D7 F5 Networks
+0001DC Activetelco
+0001DF Isdn Communications
+0001D3 Paxcomm
+0001C5 Simpler Networks
+0001D0 VitalPoint
+0001B2 Digital Processing Systems
+0001C1 Vitesse Semiconductor
+0001BA IC-Net
+0001B6 Saejin T&M
+0001AE Trex Enterprises
+0001AA Airspan Communications
+000177 Edsl
+000161 Meta Machine Technology
+000168 Vitana
+000174 CyberOptics
+00015D Oracle 
+000164 Cisco Systems
+000170 ESE Embedded System Engineer'g
+000152 Chromatek
+000156 Firewiredirect.com
+00013F Neighbor World
+000146 Tesco Controls
+000133 Kyowa Electronic Instruments
+0030E8 Ensim
+0030ED Expert Magnetics
+0030F9 Sollae Systems
+003098 Global Converging Technologies
+0030E2 Garnet Systems
+003002 Expand Networks
+00300B mPHASE Technologies
+00308F Micrilor
+0030F3 At Work Computers
+003009 Tachion Networks
+00302F GE Aviation System
+00012A Telematica Sistems Inteligente
+000130 Extreme Networks
+000137 IT Farm
+000143 Cisco Systems
+00011B Unizone Technologies
+000122 Trend Communications
+00011E Precidia Technologies
+000108 Avlab Technology
+00010B Space CyberLink
+000226 XESystems
+00021E Simtel S.r.l.
+00021A Zuma Networks
+00020B Native Networks
+000212 SierraCom
+000217 Cisco Systems
+000207 VisionGlobal Network
+000204 Bodmann Industries Elektronik GmbH
+0001F8 Texio Technology
+0001FF Data Direct Networks
+0001FB DoTop Technology
+00B0EE Ajile Systems
+00B0E7 British Federal
+00B04A Cisco Systems
+00B069 Honewell Oy
+00B0C2 Cisco Systems
+00B0DF Starboard Storage Systems
+00B0EC Eacem
+003092 ModuNORM GmbH
+0030EE DSG Technology
+003042 DeTeWe-Deutsche Telephonwerke
+00025D Calix Networks
+000258 Flying Packets Communications
+000257 Microcom
+000254 WorldGate
+000248 Pilz GmbH
+00022E Teac R&
+000241 Amer.com
+000232 Avision
+00022B SAXA
+000198 Darim Vision
+000180 AOpen
+000187 I2SE GmbH
+00018F Kenetec
+000183 Anite Telecoms
+00019C JDS Uniphase
+000190 Smk-m
+00306C Hitex Holding GmbH
+00D098 Photon Dynamics Canada
+00D05E Stratabeam Technology
+00D0BE Emutec
+00D0F4 Carinthian Tech Institute
+00D0AA Chase Communications
+00D0FA Thales e-Security
+00D006 Cisco Systems
+00D03D Galileo Technology
+00D014 ROOT
+00D0DD Sunrise Telecom
+00D091 Smartsan Systems
+00D0A2 Integrated Device
+00D0AE Oresis Communications
+00D0D4 V-bits
+00D041 Amigo Technology
+00D0D1 Sycamore Networks
+005048 Infolibria
+0050EA XEL Communications
+0050CE LG International
+005019 Spring Tide Networks
+0050AC Maple Computer
+005044 Asaca
+0050C6 Loop Telecommunication International
+005049 Arbor Networks
+00509F Horizon Computer
+0050C8 Addonics Technologies
+0050DC TAS Telefonbau A. Schwabe Gmbh & KG
+005069 PixStream Incorporated
+0050FA Oxtel
+00D0A1 Oskar Vierling Gmbh + KG
+00D00B RHK Technology
+00D02C Campbell Scientific
+00D0A0 Mips Denmark
+00D04E Logibag
+00D0D9 Dedicated Microcomputers
+00D0CD Atan Technology
+00D01D Furuno Electric
+00D0C7 Pathway
+00D05C Kathrein Technotrend Gmbh
+00D040 Sysmate
+00D08A Photron USA
+00D076 Bank of America
+00D07A Amaquest Computer
+00D0BB Cisco Systems
+00D001 VST Technologies
+0050CA NET TO NET Technologies
+00305A Telgen
+003069 Impacct Technology
+0030EC Borgardt
+0030B4 Intersil
+00308E Cross Match Technologies
+0030D0 Tellabs
+0030A5 Active Power
+003099 Boenig UND Kallenbach OHG
+00D043 Zonal Retail Data Systems
+00D016 SCM Microsystems
+00D012 Gateworks
+00D092 Glenayre Western Multiplex
+00D0EC Nakayo Telecommunications
+00D0C5 Computational Systems
+0001A7 Unex Technology
+00D0B5 IPricot formerly DotCom
+00D0E4 Cisco Systems
+00D08B Adva Optical Networking
+00D0F9 Acute Communications
+00D063 Cisco Systems
+00D069 Technologic Systems
+00D070 Long Well Electronics
+00D061 Tremon Enterprises
+00D0C4 Teratech
+00D0A4 Alantro Communications
+003051 Orbit Avionic & Communication
+0030AB Delta Networks
+003093 Sonnet Technologies
+00303C Onnto
+0030C7 Macromate
+003066 RFM
+00307F Irlan
+003016 Ishida
+00302A Southern Information
+0030DC Rightech
+0030BF Multidata Gmbh
+00D0D7 B2C2
+00D015 Univex Microtechnology
+00D0A5 American Arium
+00D0E5 Solidum Systems
+00D0B3 DRS Technologies Canada
+00D0E9 Advantage Century Telecommunication
+00D094 Seeion Control
+0050A6 Optronics
+0050DB Contemporary Control
+00506B Spx-ateg
+005074 Advanced Hi-tech
+005047 Private
+005067 Aerocomm
+005024 Navic Systems
+005041 Coretronic
+0050D2 CMC Electronics
+00904C Epigram
+009000 Diamond Multimedia
+009025 BAE Systems Australia (Electronic Systems)
+0090F8 Mediatrix Telecom
+009084 Atech System
+009054 Innovative Semiconductors
+009080 NOT Limited
+0090C0 K.J. LAW Engineers
+0090BC Telemann
+00900A Proton Electronic Industrial
+00904E Delem BV
+009050 Teleste OY
+00904A Concur System Technologies
+009029 Crypto AG
+009061 Pacific Research & Engineering
+0090A9 Western Digital
+009006 Hamamatsu Photonics K.K.
+009072 Simrad AS
+009045 Marconi Communications
+0090F6 Escalate Networks
+0090EA Alpha Technologies
+0090FE Elecom,  (laneed DIV.)
+0090EB Sentry Telecom Systems
+00908E Nortel Networks Broadband Access
+0090CA Accord Video Telecommunications
+00908B Tattile SRL
+009099 Allied Telesis
+00900E Handlink Technologies
+0090F7 Nbase Communications
+009024 Pipelinks
+009052 Selcom Elettronica S.r.l.
+0090E5 Teknema
+009085 Golden Enterprises
+009019 Hermes Electronics
+0090DC Teco Information Systems
+0090DE Cardkey Systems
+009060 System Create
+0090F1 DOT Hill Systems
+0090E2 Distributed Processing Technology
+28FD80 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+B0C5CA Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+E81863 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+00903D Biopac Systems
+009057 AANetcom
+00901C mps Software Gmbh
+009056 Telestream
+00907D Lake Communications
+0090DB Next Level Communications
+00901D PEC (nz)
+00902D Data Electronics (aust.)
+009007 Domex Technology
+00906B Applied Resources
+009020 Philips Analytical X-ray
+009065 Finisar
+001035 Elitegroup Computer Systems
+001053 Computer Technology
+0010A3 Omnitronix
+00102B Umax Data Systems
+001055 Fujitsu Microelectronics
+00103C IC Ensemble
+0010D9 IBM Japan, Fujisawa Mt+d
+0010A5 Oxford Instruments
+001046 Alcorn Mcbride
+009048 Zeal
+0090E6 ALi
+009046 Dexdyne
+00905E Rauland-borg
+009067 WalkAbout Computers
+0090DA Dynarc
+009026 Advanced Switching Communications
+0090BB Tainet Communication System
+009033 Innovaphone AG
+009010 Simulation Laboratories
+005086 Telkom SA
+0050E1 NS Tech Electronics SDN BHD
+005013 Chaparral Network Storage
+005022 Zonet Technology
+005040 Panasonic Electric Works
+0050D6 Atlas Copco Tools AB
+005082 Foresson
+005042 SCI Manufacturing Singapore PTE
+0050C0 Gatan
+0050D3 Digital Audio Processing
+00509A TAG Electronic Systems
+00507D IFP
+0050D0 Minerva Systems
+005098 Globaloop
+D07650 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+BC6641 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+9802D8 Ieee Registration Authority  - Please see MAM Public Listing for More Information.
+001015 OOmon
+001088 American Networks
+001008 Vienna Systems
+0010CC CLP Computer Logistik Planung Gmbh
+00109B Emulex
+001094 Performance Analysis Broadband, Spirent plc
+0010BB Data & Information Technology
+001028 Computer Technica
+00108A TeraLogic
+0010C5 Protocol Technologies
+00106D Axxcelera Broadband Wireless
+0010FC Broadband Networks
+001078 Nuera Communications
+001048 Htrc Automation
+001081 DPS
+0060F3 Performance Analysis Broadband, Spirent plc
+00600B Logware Gmbh
+00603F Patapsco Designs
+00607C WaveAccess
+00608D Unipulse
+006049 Vina Technologies
+0060A1 VPNet
+0060C9 ControlNet
+00605F Nippon Unisoft
+006021 DSC
+00601D Lucent Technologies
+000800 Multitech Systems
+0060C7 Amati Communications
+1000E8 National Semiconductor
+006076 Schlumberger Technologies Retail Petroleum Systems
+00E097 Carrier Access
+00E09F Pixel Vision
+00E0F5 Teles AG
+00E070 DH Technology
+00E0B5 Ardent Communications
+00E073 National Amusement Network
+00E09E Quantum
+00E0E8 Gretacoder Data Systems AG
+00E016 Rapid City Communications
+00E001 Strand Lighting Limited
+00E082 Anerma
+00E0EA Innovat Communications
+00E06A Kapsch AG
+00E023 Telrad
+00E0C3 Sakai System Development
+00E011 Uniden
+00E021 Freegate
+00E0D9 Tazmo
+00E0C2 Necsy
+00E09B Engage Networks
+00E045 Touchwave
+00E055 Ingenieria Electronica Comercial Inelcom
+00E037 Century
+00E081 Tyan Computer
+00E0D4 Excellent Computer
+00E01A Comtec Systems.
+00E0BC Symon Communications
+00E084 Compulite R&D
+00E0F6 Decision Europe
+00E027 DUX
+00E0CA Best Data Products
+00E0D5 Emulex
+00E0AB Dimat
+00E0B6 Entrada Networks
+00E0EC Celestica
+00E038 Proxima
+00E090 Beckman LAB. Automation DIV.
+00E02E SPC Electronics
+00E0F4 Inside Technology A/S
+00E03C AdvanSys
+00E096 Shimadzu
+00E0F1 That
+00E07F Logististem S.r.l.
+00E043 VitalCom
+00E0BF Torrent Networking Technologies
+00E09D Sarnoff
+00E0BB NBX
+00E08A GEC Avery
+00E04B Jump Industrielle Computertechnik Gmbh
+00E0DC Nexware
+00102D Hitachi Software Engineering
+00109F PAVO
+0010A1 Kendin Semiconductor
+001084 K-bot Communications
+0010AF TAC Systems
+00100F Industrial CPU Systems
+0010A2 TNS
+001000 Cable Television Laboratories
+00103B Hippi Networking Forum
+00A013 Teltrend
+00A0DF STS Technologies
+00A061 Puritan Bennett
+00A0CE Ecessa
+00A02A Trancell Systems
+00A02C interWAVE Communications
+00A077 Fujitsu Nexion
+00A020 Citicorp/tti
+00A00D THE Panda Project
+00A031 Hazeltine, MS 1-17
+00A041 Inficon
+00609D PMI Food Equipment Group
+0060BF Macraigor Systems
+00604A Saic Ideas Group
+006081 Tv/com International
+0060B4 Glenayre R&D
+006045 Pathlight Technologies
+00A005 Daniel Instruments
+00A053 Compact Devices
+00A033 imc MeBsysteme GmbH
+00A059 Hamilton Hallmark
+00A0AD Marconi SPA
+00A0F6 AutoGas Systems
+00A096 Mitsumi Electric
+00A006 Image Data Processing System Group
+00A0DC O.N. Electronic
+00601F Stallion Technologies
+0060B1 Input/output
+00608F Tekram Technology
+0060C5 Ancot
+006023 Pericom Semiconductor
+006063 Psion Dacom PLC.
+00604F Tattile SRL 
+0060E8 Hitachi Computer Products (america)
+006072 VXL Instruments, Limited
+006054 Controlware Gmbh
+0060C2 MPL AG
+0060A2 Nihon Unisys Limited
+006046 Vmetro
+00A0EB Encore Networks
+00A0C1 Ortivus Medical AB
+00A07D Seeq Technology
+00A0C6 Qualcomm Incorporated
+00A0CF Sotas
+00A03A Kubotek
+00A0D7 Kasten Chase Applied Research
+00A09D Johnathon Freeman Technologies
+00A036 Applied Network Technology
+00A0D2 Allied Telesis International
+00A075 Micron Technology
+00A009 Whitetree Network
+00A060 Acer Peripherals
+00A00C Kingmax Technology
+000288 Global Village Communication
+0060F9 Diamond Lane Communications
+0060EA StreamLogic
+0060EC Hermary Opto Electronics
+00604E Cycle Computer
+00602C Linx Data Terminals
+006028 Macrovision
+00606A Mitsubishi Wireless Communications.
+00601A Keithley Instruments
+0060AF Pacific Micro DATA
+00A0EE Nashoba Networks
+00A0FB Toray Engineering
+00A0E3 XKL Systems
+00A01E EST
+00A080 Tattile SRL 
+00A0C2 R.A. Systems
+00A0CB ARK Telecommunications
+00A074 Perception Technology
+00A06A Verilink
+00A070 Coastcom
+00A079 Alps Electric (usa)
+00A0D0 TEN X Technology
+00A0E0 Tennyson Technologies
+00A099 K-net
+00A03D Opto-22
+00A08C MultiMedia LANs
+0060AE Trio Information Systems AB
+00606C Arescom
+006032 I-cube
+006060 Data Innovations North America
+0060FA Educational Technology Resources
+00A0CA Fujitsu Denso
+00A029 Coulter
+00A06C Shindengen Electric MFG.
+0020FD ITV Technologies
+00200D Carl Zeiss
+002091 J125, National Security Agency
+002054 Sycamore Networks
+0020A7 Pairgain Technologies
+0020DA Alcatel North America ESD
+0020F2 Oracle 
+002005 Simple Technology
+00202B Advanced Telecommunications Modules
+002086 Microtech Electronics Limited
+002052 Ragula Systems
+002090 Advanced Compression Technology
+0020A3 Harmonic
+002059 Miro Computer Products AG
+0020BC Long Reach Networks
+0020A4 Multipoint Networks
+00201C Excel
+00209B Ersat Electronic Gmbh
+0020C9 Victron BV
+0020D1 Microcomputer Systems (M) SDN.
+002084 OCE Printing Systems
+0020C2 Texas Memory Systems
+0020C8 Larscom Incorporated
+0020EC Techware Systems
+002083 Presticom Incorporated
+00206D Data RACE
+00203A Digital Bi0metrics
+0020E8 Datatrek
+00204F Deutsche Aerospace AG
+0020AD Linq Systems
+002046 Ciprico
+002071 IBR Gmbh
+0020A2 Galcom Networking
+002098 Hectronic AB
+00208F ECI Telecom
+002065 Supernet Networking
+002094 Cubix
+0020C3 Counter Solutions
+0020A5 API Engineering
+002070 Hynet
+00201E Netquest
+002097 Applied Signal Technology
+00206A Osaka Computer
+0020DB Xnet Technology
+00A0F8 Zebra Technologies
+00A025 Redcom Labs
+00A0D4 Radiolan
+00A08A Brooktrout Technology
+00C07D Risc Developments
+00C01E LA Francaise DES Jeux
+00C084 Data Link
+00C087 Uunet Technologies
+00C033 Telebit Communications APS
+00C081 Metrodata
+00C006 Nippon Avionics
+00C013 Netrix
+00C058 Dataexpert
+002088 Global Village Communication
+00202E Daystar Digital
+0020B0 Gateway Devices
+0020A9 White Horse Industrial
+002061 GarrettCom
+0020C6 Nectec
+0020D2 RAD Data Communications
+002093 Landings Technology
+002056 Neoproducts
+00C06D Boca Research
+00C0DB IPC (pte)
+00C0DA Nice Systems
+00C09B Reliance Comm/tec
+00C0B8 Fraser's Hill
+00C016 Electronic Theatre Controls
+00C096 Tamura
+00C035 Quintar Company
+00C088 EKF Elektronik Gmbh
+0020A6 Proxim Wireless
+00C073 Xedia
+00C0D4 Axon Networks
+00C0E5 Gespac
+00C0B9 Funk Software
+00C065 Scope Communications
+00C018 Lanart
+00C0FF DOT Hill Systems
+00C056 Somelec
+00C063 Morning Star Technologies
+00C021 Netexpress
+00C049 U.S. Robotics
+00C032 I-cubed Limited
+00C051 Advanced Integration Research
+00C085 Electronics FOR Imaging
+00C0FE Aptec Computer Systems
+00C0E8 Plexcom
+00C0B2 Norand
+00C0B1 Genius NET
+00C0D9 Quinte Network Confidentiality
+00C038 Raster Image Processing System
+004030 GK Computer
+0080DC Picker International
+00C0A8 GVC
+00C010 Hirakawa Hewtech
+00C020 Arco Electronic, Control
+0040A6 Cray
+004098 Dressler Gmbh
+0040E2 Mesa Ridge Technologies
+004078 Wearnes Automation PTE
+00C098 Chuntex Electronic
+00C0DD QLogic
+00C08A Lauterbach GmbH
+00409F Telco Systems
+0040FF Telebit
+0040D7 Studio GEN
+004007 Telmat Informatique
+00408D THE Goodyear Tire & Rubber
+00402C Isis Distributed Systems
+00C03D Wiesemann & Theis Gmbh
+00C026 Lans Technology
+004062 E-systems,/garland DIV.
+0040D2 Pagine
+0040D0 Mitac International
+0040E4 E-M Technology
+0040BF Channel Systems Intern'l
+004094 Shographics
+00407F Flir Systems
+0040A9 Datacom
+0040E3 Quin Systems
+004091 Procomp Industria Eletronica
+004014 Comsoft Gmbh
+00400F Datacom Technologies
+004085 Saab Instruments AB
+004006 Sampo Technology
+00402D Harris Adacom
+004047 Wind River Systems
+0040FA Microboards
+00C0CC Telesciences Systems
+00C078 Computer Systems Engineering
+0040F3 Netcor
+004033 Addtron Technology
+0040A3 Microunity Systems Engineering
+0040ED Network Controls Int'natl
+0040AD SMA Regelsysteme Gmbh
+00400D Lannet Data Communications
+0040F5 OEM Engines
+004019 Aeon Systems
+0040A1 Ergo Computing
+00407E Evergreen Systems
+0040F6 Katron Computers
+004076 Sun Conversion Technologies
+0040F4 Cameo Communications
+0040E8 Charles River Data Systems
+004044 Qnix Computer
+0040DD Hong Technologies
+00403A Impact Technologies
+0040C9 Ncube
+004075 Tattile SRL 
+0080F1 Opus Systems
+00805B Condor Systems
+00801C Newport Systems Solutions
+00002E Societe Evira
+0000ED April
+00003C Auspex Systems
+000051 HOB Electronic Gmbh & KG
+0000A7 Network Computing Devices
+0000F7 Youth Keep Enterprise
+0000FC Meiko
+0000B5 Datability Software SYS.
+000026 Sha-ken
+000022 Visual Technology
+00006D Cray Communications
+0000FA Microsage Computer Systems
+00002B Crisp Automation
+000019 Applied Dynamics International
+000081 Bay Networks
+0000A1 Marquette Electric
+0000F5 Diamond Sales Limited
+0080D2 Shinnihondenko
+0080DF ADC Codenoll Technology
+008071 SAI Technology
+00803D Surigiken
+00804B Eagle Technologiesltd.
+008007 Dlog Nc-systeme
+008001 Periphonics
+008062 Interface 
+0080F3 SUN Electronics
+00808D Westcoast Technology
+0080B2 Network Equipment Technologies
+0080A5 Speed International
+0080A9 Clearpoint Research
+008069 Computone Systems
+008091 Tokyo Electric
+0080F4 Telemecanique Electrique
+00800C Videcom Limited
+0080E8 Cumulus Corporatiion
+0000CD Allied Telesis Labs
+0000A5 Tattile SRL 
+000036 Atari
+0080C6 National Datacomm
+0080FA RWT Gmbh
+008084 THE Cloud
+008046 Tattile SRL 
+0080A6 Republic Technology
+008009 Jupiter Systems
+0080B5 United Networks
+008035 Technology Works
+008088 Victor Company OF Japan
+00809E Datus Gmbh
+008055 Fermilab
+00802A Test Systems & Simulations
+00801E Xinetron
+00804A Pro-log
+008059 Stanley Electric
+00806B Schmid Telecommunication
+0080B8 B.u.g. Moriseiki, Incorporated
+00802C THE Sage Group PLC
+008018 Kobe Steel
+0080EE Thomson CSF
+008013 Thomas-conrad
+00808E Radstone Technology
+0080D3 Shiva
+0000E5 Sigmex
+0000BA SIIG
+00002F Timeplex
+0000B8 Seikosha
+00007F Linotype-hell AG
+0000B7 Dove Computer
+00009A RC Computer A/S
+0000DE Cetia
+00004B ICL Data OY
+000013 Camex
+000095 Sony Tektronix
+0000AE Dassault Electronique
+0000DD TCL Incorporated
+0000D9 Nippon Telegraph & Telephone
+000046 Olivetti North America
+000017 Oracle
+000060 Kontron Elektronik Gmbh
+000011 Normerel Systemes
+08006F Philips Apeldoorn
+0080BD THE Furukawa Electric
+0080A8 Vitacom
+0080FB BVM Limited
+008042 Artesyn Embedded Technologies
+008067 Square D Company
+008045 Matsushita Electric IND.
+00804C Contec
+008020 Network Products
+00809F ALE International
+0000B0 Rnd-rad Network Devices
+00001B Novell
+000071 Adra Systems
+00006C Private
+080081 Astech
+08007A Indata
+080078 Accell
+08006E Masscomp
+08006D Whitechapel Computer Works
+08006C Suntek Technology Int'l
+080067 ComDesign
+080063 Plessey
+080060 Industrial Networking
+08002B Digital Equipment
+08002A Mosaic Technologies
+080029 Megatek
+080026 Norsk Data A.S.
+08001F Sharp
+AA0000 Digital Equipment
+0270B0 M/a-com Companies
+00000B Matrix
+080042 Japan Macnics
+026086 Logic Replacement TECH.
+00009F Ameristar Technologies
+0000E3 Integrated Micro Products
+000073 Siecor
+0000D3 Wang Laboratories
+0000B3 Cimlinc Incorporated
+00009D Locus Computing
+08008F Chipcom
+080055 Stanford Telecomm.
+080048 Eurotherm Gauging Systems
+080049 Univation
+080037 Fuji-xerox
+080031 Little Machines
+08000D International Computers
+00DD05 Ungermann-bass
+00DD0A Ungermann-bass
+00BBF0 Ungermann-bass
+0080E9 Madge
+00DD02 Ungermann-bass
+000003 Xerox
+000008 Xerox
+001CDF Belkin International
+944452 Belkin International
+08863B Belkin International
+080030 Cern
+00DD01 Ungermann-bass
+2082C0 Xiaomi Communications
+18017D Harbin Arteor technology
+001556 Sagemcom Broadband SAS
+002569 Sagemcom Broadband SAS
+001BBF Sagemcom Broadband SAS
+4C17EB Sagemcom Broadband SAS
+7C034C Sagemcom Broadband SAS
+88AE1D Compal Information (kunshan)
+5C353B Compal Broadband Networks
+C8F230 Guangdong Oppo Mobile Telecommunications
+1C4419 Tp-link Technologies
+74F8DB Ieee Registration Authority
+005079 Private
+9C93E4 Private
+B0D5CC Texas Instruments
+5CF821 Texas Instruments
+0CEFAF Ieee Registration Authority
+749DDC 2Wire
+B8CA3A Dell
+F01FAF Dell
+C81F66 Dell
+00183F 2Wire
+0019E4 2Wire
+001AC4 2Wire
+001D5A 2Wire
+34EF44 2Wire
+982CBE 2Wire
+001422 Dell
+782BCB Dell
+00219B Dell
+000874 Dell
+002564 Dell
+842B2B Dell
+E0DB55 Dell
+A41F72 Dell
+001D09 Dell
+001C23 Dell
+F8E079 Motorola Mobility, a Lenovo Company
+1430C6 Motorola Mobility, a Lenovo Company
+044E06 Ericsson AB
+00C04F Dell
+F04DA2 Dell
+BC305B Dell
+E0757D Motorola Mobility, a Lenovo Company
+000D67 Ericsson
+001E65 Intel Corporate
+001F3B Intel Corporate
+0016EA Intel Corporate
+00216B Intel Corporate
+0019D1 Intel Corporate
+001CC0 Intel Corporate
+5CE0C5 Intel Corporate
+E09D31 Intel Corporate
+002710 Intel Corporate
+64D4DA Intel Corporate
+DCA971 Intel Corporate
+001CBF Intel Corporate
+A0A8CD Intel Corporate
+340286 Intel Corporate
+34DE1A Intel Corporate
+CC3D82 Intel Corporate
+809B20 Intel Corporate
+100BA9 Intel Corporate
+247703 Intel Corporate
+C48508 Intel Corporate
+0026C6 Intel Corporate
+74E50B Intel Corporate
+58946B Intel Corporate
+B80305 Intel Corporate
+303A64 Intel Corporate
+ACFDCE Intel Corporate
+183DA2 Intel Corporate
+448500 Intel Corporate
+E09467 Intel Corporate
+00DBDF Intel Corporate
+0C8BFD Intel Corporate
+80000B Intel Corporate
+24DEC6 Aruba Networks
+D8C7C8 Aruba Networks
+D00ED9 Taicang T&W Electronics
+40E3D6 Aruba Networks
+6C2995 Intel Corporate
+18E3BC TCT mobile
+900BC1 Sprocomm Technologies
+485D60 AzureWave Technology
+6C71D9 AzureWave Technology
+384FF0 AzureWave Technology
+54E4BD Fn-link Technology Limited
+0015AF AzureWave Technology
+98743D Shenzhen Jun Kai Hengye Technology
+8841FC AirTies Wireless Netowrks
+182861 AirTies Wireless Netowrks
+00193E ADB Broadband Italia
+0013C8 ADB Broadband Italia
+DC0B1A ADB Broadband Italia
+74888B ADB Broadband Italia
+A04FD4 ADB Broadband Italia
+842615 ADB Broadband Italia
+5CE2F4 AcSiP Technology
+002662 Actiontec Electronics
+ACD074 Espressif
+D05349 Liteon Technology
+0025DC Sumitomo Electric Industries
+E0CB1D Private
+00BB3A Private
+000941 Allied Telesis R&D Center K.K.
+84D6D0 Amazon Technologies
+00014A Sony
+001CA4 Sony Mobile Communications AB
+00248D Sony Computer Entertainment
+002345 Sony Mobile Communications AB
+8C6422 Sony Mobile Communications AB
+90C115 Sony Mobile Communications AB
+8400D2 Sony Mobile Communications AB
+5CB524 Sony Mobile Communications AB
+0015A3 Arris Group
+0015A4 Arris Group
+94A1A2 Ampak Technology
+001A77 Arris Group
+CC7D37 Arris Group
+0017E2 Arris Group
+001784 Arris Group
+0016B5 Arris Group
+001675 Arris Group
+00D088 Arris Group
+74DE2B Liteon Technology
+68A3C4 Liteon Technology
+0017EE Arris Group
+001180 Arris Group
+00909C Arris Group
+8096B1 Arris Group
+7CBFB1 Arris Group
+984B4A Arris Group
+002210 Arris Group
+001FC4 Arris Group
+001C12 Arris Group
+001CFB Arris Group
+0012C9 Arris Group
+E48399 Arris Group
+00211E Arris Group
+0024A0 Arris Group
+002636 Arris Group
+C8FF28 Liteon Technology
+0016E3 Askey Computer
+0024D2 Askey Computer
+DC64B8 Shenzhen JingHanDa ElectronicsLtd
+C4DA7D Ivium Technologies
+9492BC Syntech(hk) Technology Limited
+001A4F AVM GmbH
+00040E AVM GmbH
+30469A Netgear
+0026F2 Netgear
+00184D Netgear
+001E2A Netgear
+E8FCAF Netgear
+4C60DE Netgear
+743170 Arcadyan Technology
+A8D3F7 Arcadyan Technology
+7C4FB5 Arcadyan Technology
+00300A Aztech Electronics Pte
+A06391 Netgear
+9CC7A6 AVM GmbH
+0012BF Arcadyan Technology
+DCEF09 Netgear
+200CC8 Netgear
+480031 Huawei Technologies
+04FE8D Huawei Technologies
+D40129 Broadcom
+0019FB BSkyB
+E03E44 Broadcom
+0CF9C0 BSkyB
+001BA9 Brother industries
+0011B6 Open Systems International
+002283 Juniper Networks
+2C6BF5 Juniper Networks
+84B59C Juniper Networks
+100E7E Juniper Networks
+288A1C Juniper Networks
+3C94D5 Juniper Networks
+B0A86E Juniper Networks
+AC4BC8 Juniper Networks
+FCB698 Cambridge Industries(Group)
+64649B Juniper Networks
+541E56 Juniper Networks
+544B8C Juniper Networks
+00E03A Cabletron Systems
+002159 Juniper Networks
+000117 Canal
+0019C7 Cambridge Industries(Group)
+006DFB Vutrix Technologies
+C81073 Century Opticomm
+744AA4 zte
+00F46F Samsung Electronics
+BC1485 Samsung Electronics
+380195 Samsung Electronics
+5CF6DC Samsung Electronics
+1077B1 Samsung Electronics
+508569 Samsung Electronics
+B85A73 Samsung Electronics
+103047 Samsung Electronics
+109266 Samsung Electronics
+30C7AE Samsung Electronics
+18227E Samsung Electronics
+8425DB Samsung Electronics
+D8C4E9 Samsung Electronics
+50C8E5 Samsung Electronics
+446D6C Samsung Electronics
+804E81 Samsung Electronics
+244B81 Samsung Electronics
+9CD35B Samsung Electronics
+60AF6D Samsung Electronics
+38D40B Samsung Electronics
+B047BF Samsung Electronics
+7C0BC6 Samsung Electronics
+781FDB Samsung Electronics
+08FC88 Samsung Electronics
+50A4C8 Samsung Electronics
+9CE6E7 Samsung Electronics
+647791 Samsung Electronics
+64680C Comtrend
+00CF1C Communication Machinery
+0090F5 Clevo
+0030FF DataFab Systems
+0090A2 CyberTAN Technology
+0030DA Comtrend
+A8A089 Tactical Communications
+48365F Wintecronics
+E498D1 Microsoft Mobile Oy
+0014A5 Gemtek Technology
+001742 Fujitsu Limited
+005A39 Shenzhen Fast Technologies
+5CC6D0 Skyworth Digital Technology(Shenzhen)
+080581 Roku
+B0A737 Roku
+B83E59 Roku
+DC3A5E Roku
+525400 QEMU virtual NIC
+B0C420 Bochs virtual NIC
+DEADCA PearPC virtual NIC
+00FFD1 Cooperative Linux virtual NIC
+080027 Oracle VirtualBox virtual NIC

--- a/wifiphisher/constants.py
+++ b/wifiphisher/constants.py
@@ -8,6 +8,7 @@ PORT = 8080
 SSL_PORT = 443
 PEM = 'wifiphisher/cert/server.pem'
 PHISHING_PAGES_DIR = "wifiphisher/phishing-pages/"
+MAC_PREFIX_FILE = "nmap-mac-prefixes"
 POST_VALUE_PREFIX = "wfphshr"
 NETWORK_IP = "10.0.0.0"
 NETWORK_MASK = "255.255.255.0"

--- a/wifiphisher/macmatcher.py
+++ b/wifiphisher/macmatcher.py
@@ -1,0 +1,61 @@
+"""
+This module was made to match MAC address with vendors
+"""
+
+
+class MACMatcher(object):
+    """
+    This class is using Organizationally Unique Identifiers (OUIs)
+    in order to match MAC addresses of devices to its vendord
+
+    See http://standards.ieee.org/faqs/OUI.html
+    """
+    def __init__(self, mac_prefix_file):
+        """
+        :param self: A MACMatcher object
+        :type self: MACMatcher
+        :param mac_prefix_file: path of max-prefixes file
+        :type mac_prefix_file: string
+        """
+
+        self.mac_to_vendor = {}
+
+        with open(mac_prefix_file, 'r') as prefixes_file:
+            for line in prefixes_file:
+                # skip comments
+                if not line.startswith("#"):
+                    [bssid, vendor] = line.rstrip('\n').split(' ', 1)
+                    self.mac_to_vendor[bssid] = vendor
+
+    def get_vendor_name(self, mac_address):
+        """
+        Return the matched vendor name for the given MAC address
+        or empty if no match.
+
+        :param self: A MACMatcher object
+        :type self: MACMatcher
+        :param mac_address: mac address represended as two
+                            hexadecimal digits separated by colons
+        :type mac_address: string
+        :return: the vendor name of the device
+        :rtype: str
+        """
+
+        # convert mac to match prefix file format
+        vendor_part = mac_address.replace(':', '').upper()[0:6]
+
+        if vendor_part in self.mac_to_vendor:
+            return self.mac_to_vendor[vendor_part]
+        else:
+            return 'Unknown'
+
+    def unbind(self):
+        """
+        Unloads mac to vendor mapping from memory
+        You can not use MACMatcher instance once this method is called
+
+        :param self: A MACMatcher object
+        :type self: MACMatcher
+
+        """
+        self.mac_to_vendor = {}


### PR DESCRIPTION
related with issue #5

Parsing prefixes from https://svn.nmap.org/nmap/nmap-mac-prefixes (provided by nmap project) and create a dictionary (key MAC prefix, value vendor). Using this dictionary to match mac addresses to vendors.

I have also added BSSID and the vendor information in APs that are listed in the target selection menu.
![screenshot from 2016-05-03 23-50-21_censored](https://cloud.githubusercontent.com/assets/733195/14999547/a16453d4-1192-11e6-815a-623e2a811859.jpg)
 
