### PR TITLE
Fix AttributeError after #262

### DIFF
--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -863,8 +863,7 @@ def run():
             interfaces.JammingInterfaceInvalidError,
             interfaces.ApInterfaceInvalidError,
             interfaces.NoApInterfaceFoundError,
-            interfaces.NoMonitorInterfaceFoundError, interfaces.IwCmdError,
-            interfaces.IwconfigCmdError, interfaces.IfconfigCmdError) as err:
+            interfaces.NoMonitorInterfaceFoundError) as err:
         print ("[{0}!{1}] " + str(err)).format(R, W)
         shutdown()
 


### PR DESCRIPTION
This patch will fix the `AttributeError` error after the #262 was pushed to the master branch. This error was the produce of non-existence error classes.