### PR TITLE
Fix pep8.

### DIFF
--- a/wifiphisher/constants.py
+++ b/wifiphisher/constants.py
@@ -4,7 +4,8 @@
 import os
 
 dir_of_executable = os.path.dirname(__file__)
-path_to_project_root = os.path.abspath(os.path.join(dir_of_executable, '../wifiphisher'))
+path_to_project_root = os.path.abspath(
+    os.path.join(dir_of_executable, '../wifiphisher'))
 dir_of_data = path_to_project_root + '/data/'
 
 # Basic configuration

--- a/wifiphisher/interfaces.py
+++ b/wifiphisher/interfaces.py
@@ -190,7 +190,7 @@ class NetworkAdapter(object):
 
         return self._support_monitor_mode
 
-    def set_channel(self, channel):        
+    def set_channel(self, channel):
         card = pyw.getcard(self._name)
         pyw.chset(card, channel, None)
 
@@ -227,14 +227,14 @@ class NetworkManager(object):
                 self._interfaces[interface] = NetworkAdapter(interface)
             except pyric.error as e:
                 pass
-            #except pyric.error:
+            # except pyric.error:
             #    pass
 
     def up_ifaces(self, ifaces):
-        for i in ifaces:    
+        for i in ifaces:
             card = pyw.getcard(i.get_name())
             pyw.up(card)
-            
+
     def set_interface_mode(self, interface, mode):
         """
         Set the desired mode to the network interface.
@@ -306,10 +306,11 @@ class NetworkManager(object):
             if monitor_available[0] == ap_available[0]:
                 raise NotEnoughInterfacesFoundError()
 
-        # We only have one AP mode interface. We don't want to use it for jamming.
+        # We only have one AP mode interface. We don't want to use it for
+        # jamming.
         if len(monitor_available) > 1 and \
-        len(ap_available) == 1 and \
-        ap_available[0] in monitor_available:
+                len(ap_available) == 1 and \
+                ap_available[0] in monitor_available:
             # Select an AP interface and remove it from available interfaces
             ap_interface = ap_available[0]
             ap_available.remove(ap_interface)
@@ -329,7 +330,6 @@ class NetworkManager(object):
 
         return monitor_interface, ap_interface
 
-
     def get_jam_iface(self, interface_name):
         for k, interface in self._interfaces.iteritems():
             if k == interface_name and not interface.being_used:
@@ -343,7 +343,7 @@ class NetworkManager(object):
         for k, interface in self._interfaces.iteritems():
             if interface_name == None:
                 if interface.has_ap_mode():
-                    return interface 
+                    return interface
             if k == interface_name and not interface.being_used:
                 if interface.has_ap_mode():
                     return interface

--- a/wifiphisher/macmatcher.py
+++ b/wifiphisher/macmatcher.py
@@ -4,6 +4,7 @@ This module was made to match MAC address with vendors
 
 from constants import *
 
+
 class MACMatcher(object):
     """
     This class is using Organizationally Unique Identifiers (OUIs)
@@ -11,6 +12,7 @@ class MACMatcher(object):
 
     See http://standards.ieee.org/faqs/OUI.html
     """
+
     def __init__(self, mac_prefix_file):
         """
         :param self: A MACMatcher object
@@ -71,7 +73,7 @@ class MACMatcher(object):
             vendor_part = mac_address.replace(':', '').upper()[0:6]
 
             if vendor_part in self.mac_to_vendor and \
-            len(self.mac_to_vendor[vendor_part]) > 2:
+                    len(self.mac_to_vendor[vendor_part]) > 2:
                 return LOGOS_DIR + self.mac_to_vendor[vendor_part][2]
 
         return None

--- a/wifiphisher/phishinghttp.py
+++ b/wifiphisher/phishinghttp.py
@@ -11,6 +11,7 @@ from constants import *
 template = False
 terminate = False
 
+
 class SecureHTTPServer(BaseHTTPServer.HTTPServer):
     """
     Simple HTTP server that extends the SimpleHTTPServer standard
@@ -22,6 +23,7 @@ class SecureHTTPServer(BaseHTTPServer.HTTPServer):
 
     It also reacts to self.stop flag.
     """
+
     def __init__(self, server_address, HandlerClass):
         SocketServer.BaseServer.__init__(self, server_address, HandlerClass)
         self.socket = ssl.SSLSocket(
@@ -47,6 +49,7 @@ class SecureHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
     Request handler for the HTTPS server. It responds to
     everything with a 301 redirection to the HTTP server.
     """
+
     def do_QUIT(self):
         """
         Sends a 200 OK response, and sets server.stop to True
@@ -62,7 +65,8 @@ class SecureHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
 
     def do_GET(self):
         self.send_response(301)
-        self.send_header('Location', 'http://' + NETWORK_GW_IP + ':' + str(PORT))
+        self.send_header('Location', 'http://' +
+                         NETWORK_GW_IP + ':' + str(PORT))
         self.end_headers()
 
     def log_message(self, format, *args):
@@ -87,6 +91,7 @@ class HTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
     """
     Request handler for the HTTP server that logs POST requests.
     """
+
     def redirect(self, page="/"):
         self.send_response(301)
         self.send_header('Location', page)

--- a/wifiphisher/phishingpage.py
+++ b/wifiphisher/phishingpage.py
@@ -10,6 +10,7 @@ from shutil import copyfile
 import ConfigParser
 from jinja2 import Environment, FileSystemLoader
 
+
 def config_section_map(config_file, section):
     """
     Map the values of a config file to a dictionary.
@@ -29,6 +30,7 @@ def config_section_map(config_file, section):
         except:
             dict1[option] = None
     return dict1
+
 
 class InvalidTemplate(Exception):
     """ Exception class to raise in case of a invalid template """
@@ -63,7 +65,7 @@ class PhishingTemplate(object):
         self._payload = False
         if 'payloadpath' in info:
             self._payload = info['payloadpath']
-        
+
         self._path = PHISHING_PAGES_DIR + self._name.lower() + "/"
 
         self._context = config_section_map(config_path, 'context')
@@ -156,7 +158,7 @@ class PhishingTemplate(object):
         if path is not None and os.path.isfile(path):
             filename = os.path.basename(path)
             copyfile(path, self.get_path() + filename)
-            self._extra_files.append(self.get_path() + filename) 
+            self._extra_files.append(self.get_path() + filename)
             return filename
 
     def remove_extra_files(self):

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -24,7 +24,7 @@ from constants import *
 VERSION = "1.2GIT"
 conf.verb = 0
 count = 0  # for channel hopping Thread
-APs = {} # for listing APs
+APs = {}  # for listing APs
 clients_APs = []
 hop_daemon_running = True
 sniff_daemon_running = True
@@ -34,6 +34,7 @@ lock = Lock()
 args = 0
 mon_MAC = 0
 first_pass = 1
+
 
 def parse_args():
     # Create the arguments
@@ -91,23 +92,24 @@ def parse_args():
         "-e",
         "--essid",
         help=("Enter the ESSID of the rogue Access Point. " +
-             "This option will skip Access Point selection phase. " +
-             "Example: --essid 'Free WiFi'"
-             )
+              "This option will skip Access Point selection phase. " +
+              "Example: --essid 'Free WiFi'"
+              )
     )
     parser.add_argument(
         "-p",
         "--phishingscenario",
-        help=("Choose the phishing scenario to run."+
+        help=("Choose the phishing scenario to run." +
               "This option will skip the scenario selection phase. " +
               "Example: -p firmware_upgrade"))
     parser.add_argument(
         "-pK",
         "--presharedkey",
-        help=("Add WPA/WPA2 protection on the rogue Access Point. " + 
+        help=("Add WPA/WPA2 protection on the rogue Access Point. " +
               "Example: -pK s3cr3tp4ssw0rd"))
 
     return parser.parse_args()
+
 
 def check_args(args):
     """
@@ -115,23 +117,26 @@ def check_args(args):
     """
 
     if args.presharedkey and \
-    (len(args.presharedkey) < 8 \
-    or len(args.presharedkey) > 64):
-        sys.exit('[' + R + '-' + W + '] Pre-shared key must be between 8 and 63 printable characters.')
+        (len(args.presharedkey) < 8
+         or len(args.presharedkey) > 64):
+        sys.exit(
+            '[' + R + '-' + W + '] Pre-shared key must be between 8 and 63 printable characters.')
 
-    if ((args.jamminginterface and not args.apinterface) or \
-    (not args.jamminginterface and args.apinterface)) and \
-    not (args.nojamming and args.apinterface):
+    if ((args.jamminginterface and not args.apinterface) or
+            (not args.jamminginterface and args.apinterface)) and \
+            not (args.nojamming and args.apinterface):
         sys.exit('[' + R + '-' + W + '] --apinterface (-aI) and --jamminginterface (-jI) (or --nojamming (-nJ)) are used in conjuction.')
 
-    if args.nojamming and args.jamminginterface: 
-        sys.exit('[' + R + '-' + W + '] --nojamming (-nJ) and --jamminginterface (-jI) cannot work together.')
+    if args.nojamming and args.jamminginterface:
+        sys.exit(
+            '[' + R + '-' + W + '] --nojamming (-nJ) and --jamminginterface (-jI) cannot work together.')
 
 
 def stopfilter(x):
     if not sniff_daemon_running:
         return True
     return False
+
 
 def shutdown(template=None, network_manager=None):
     """
@@ -161,7 +166,7 @@ def shutdown(template=None, network_manager=None):
         try:
             network_manager.reset_ifaces_to_managed()
         except:
-            print '[' + R + '!' + W + '] Failed to reset interface' 
+            print '[' + R + '!' + W + '] Failed to reset interface'
 
     # Remove any template extra files
     if template:
@@ -222,8 +227,8 @@ def sniffing(interface, cb):
     '''This exists for if/when I get deauth working
     so that it's easy to call sniff() in a thread'''
     try:
-        sniff(iface=interface, prn=cb, stop_filter=stopfilter, \
-        store=False, lfilter=lambda p: (Dot11Beacon in p or Dot11ProbeResp in p))
+        sniff(iface=interface, prn=cb, stop_filter=stopfilter,
+              store=False, lfilter=lambda p: (Dot11Beacon in p or Dot11ProbeResp in p))
     except socket.error as e:
         # Network is down
         if e.errno == 100:
@@ -244,13 +249,17 @@ def targeting_cb(pkt):
     crypto = set()
     while isinstance(p, Dot11Elt):
         if p.ID == 0:
-            try: p.info.decode('utf8')
-            except UnicodeDecodeError: essid = "<contains non-printable chars>"
-            else: essid = p.info
+            try:
+                p.info.decode('utf8')
+            except UnicodeDecodeError:
+                essid = "<contains non-printable chars>"
+            else:
+                essid = p.info
         elif p.ID == 3:
             try:
                 channel = str(ord(p.info))
-            # TypeError: ord() expected a character, but string of length 2 found
+            # TypeError: ord() expected a character, but string of length 2
+            # found
             except Exception:
                 return
         elif p.ID == 48:
@@ -282,7 +291,7 @@ def target_APs():
     max_name_size = max(map(lambda ap: len(ap[1]), APs.itervalues()))
 
     header = ('{0:3}  {1:3}  {2:{width}}   {3:19}  {4:14}  {5:}'
-        .format('num', 'ch', 'ESSID', 'BSSID', 'encr', 'vendor', width=max_name_size + 1))
+              .format('num', 'ch', 'ESSID', 'BSSID', 'encr', 'vendor', width=max_name_size + 1))
 
     print header
     print '-' * len(header)
@@ -294,16 +303,16 @@ def target_APs():
         vendor = mac_matcher.get_vendor_name(mac)
 
         print ((G + '{0:2}' + W + ' - {1:2}  - ' +
-               T + '{2:{width}} ' + W + ' - ' +
-               B + '{3:17}' + W + ' - {4:12} - ' + 
-               R + ' {5:}' + W
-            ).format(ap,
-                    APs[ap][0],
-                    APs[ap][1],
-                    mac,
-                    crypto,
-                    vendor,
-                    width=max_name_size))
+                T + '{2:{width}} ' + W + ' - ' +
+                B + '{3:17}' + W + ' - {4:12} - ' +
+                R + ' {5:}' + W
+                ).format(ap,
+                         APs[ap][0],
+                         APs[ap][1],
+                         mac,
+                         crypto,
+                         vendor,
+                         width=max_name_size))
 
 
 def copy_AP():
@@ -427,9 +436,10 @@ def start_ap(mon_iface, channel, essid, args):
         ) % args.presharedkey
 
     with open('/tmp/hostapd.conf', 'w') as dhcpconf:
-            dhcpconf.write(config % (mon_iface, essid, channel))
+        dhcpconf.write(config % (mon_iface, essid, channel))
 
-    hostapd_proc = Popen(['hostapd', '/tmp/hostapd.conf'], stdout=DN, stderr=DN)
+    hostapd_proc = Popen(['hostapd', '/tmp/hostapd.conf'],
+                         stdout=DN, stderr=DN)
     try:
         time.sleep(6)  # Copied from Pwnstar which said it was necessary?
         if hostapd_proc.poll() != None:
@@ -572,7 +582,8 @@ def deauth(monchannel):
             args.deauthpackets = 1
 
         for p in pkts:
-            send(p, inter=float(args.timeinterval), count=int(args.deauthpackets))
+            send(p, inter=float(args.timeinterval),
+                 count=int(args.deauthpackets))
 
 
 def output(monchannel):
@@ -742,6 +753,7 @@ def sniff_dot11(mon_iface):
         else:
             raise
 
+
 def kill_interfering_procs():
     # Kill any possible programs that may interfere with the wireless card
     # For systems with airmon-ng installed
@@ -763,10 +775,11 @@ def kill_interfering_procs():
 
         time.sleep(1)
 
+
 def run():
 
-    print ('[' + T + '*' + W + '] Starting Wifiphisher %s at %s' % \
-          (VERSION, time.strftime("%Y-%m-%d %H:%M")))
+    print ('[' + T + '*' + W + '] Starting Wifiphisher %s at %s' %
+           (VERSION, time.strftime("%Y-%m-%d %H:%M")))
 
     # Parse args
     global args, APs, clients_APs, mon_MAC, mac_matcher, hop_daemon_running
@@ -792,24 +805,26 @@ def run():
     try:
         if not args.nojamming:
             if args.jamminginterface and args.apinterface:
-                mon_iface = network_manager.get_jam_iface(args.jamminginterface)
+                mon_iface = network_manager.get_jam_iface(
+                    args.jamminginterface)
                 ap_iface = network_manager.get_ap_iface(args.apinterface)
             else:
                 mon_iface, ap_iface = network_manager.find_interface_automatically()
             network_manager.set_jam_iface(mon_iface.get_name())
             network_manager.set_ap_iface(ap_iface.get_name())
             # display selected interfaces to the user
-            print ("[{0}+{1}] Selecting {0}{2}{1} interface for the deauthentication "\
-                   "attack\n[{0}+{1}] Selecting {0}{3}{1} interface for creating the "\
+            print ("[{0}+{1}] Selecting {0}{2}{1} interface for the deauthentication "
+                   "attack\n[{0}+{1}] Selecting {0}{3}{1} interface for creating the "
                    "rogue Access Point").format(G, W, mon_iface.get_name(), ap_iface.get_name())
         else:
             if args.apinterface:
-                ap_iface = network_manager.get_ap_iface(interface_name=args.apinterface)
+                ap_iface = network_manager.get_ap_iface(
+                    interface_name=args.apinterface)
             else:
                 ap_iface = network_manager.get_ap_iface()
             mon_iface = ap_iface
             network_manager.set_ap_iface(ap_iface.get_name())
-            print ("[{0}+{1}] Selecting {0}{2}{1} interface for creating the "\
+            print ("[{0}+{1}] Selecting {0}{2}{1} interface for creating the "
                    "rogue Access Point").format(G, W, ap_iface.get_name())
 
         kill_interfering_procs()
@@ -868,7 +883,8 @@ def run():
             if not os.path.isfile(payload_path):
                 print '[' + R + '-' + W + '] Invalid file path!'
         print '[' + T + '*' + W + '] Using ' + G + payload_path + W + ' as payload '
-        copyfile(payload_path, PHISHING_PAGES_DIR + template.get_payload_path())
+        copyfile(payload_path, PHISHING_PAGES_DIR +
+                 template.get_payload_path())
 
     APs_context = []
     for i in APs:
@@ -889,7 +905,7 @@ def run():
         'target_ap_bssid': ap_mac,
         'target_ap_encryption': enctype,
         'target_ap_vendor': mac_matcher.get_vendor_name(ap_mac),
-        'target_ap_logo_path': ap_logo_path 
+        'target_ap_logo_path': ap_logo_path
     })
 
     phishinghttp.serve_template(template)
@@ -930,7 +946,8 @@ def run():
     # Start HTTPS server in a background thread
     Handler = phishinghttp.SecureHTTPRequestHandler
     try:
-        httpd = phishinghttp.SecureHTTPServer((NETWORK_GW_IP, SSL_PORT), Handler)
+        httpd = phishinghttp.SecureHTTPServer(
+            (NETWORK_GW_IP, SSL_PORT), Handler)
     except socket.error, v:
         errno = v[0]
         sys.exit((


### PR DESCRIPTION
This doesn't actually fix all pep8 problems, only the ones autopep8 could handle automatically. There are still 36 pep8 violations:

```
➜  wifiphisher git:(pep8) pep8 *.py | cut -d':' -f4 | cut -d'(' -f1 | count-lines 
21:      E501 line too long 
7:       E402 module level import not at top of file
3:       W291 trailing whitespace
2:       W503 line break before binary operator
2:       E711 comparison to None should be 'if cond is None
1:       E711 comparison to None should be 'if cond is not None
```