### PR TITLE
Fix: print credentials with -qS

### DIFF
--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -187,7 +187,8 @@ def shutdown(template=None, network_manager=None):
         template.remove_extra_files()
 
     print '[' + R + '!' + W + '] Closing'
-    sys.exit(0)
+    for c in phishinghttp.creds:
+        sys.exit('[' + R + '+' + W + '] Captured credentials:' + R + c)
 
 
 def set_fw_rules():


### PR DESCRIPTION
-qS (--quitonsuccess) option prints the credentials, but then the terminal window gets wiped clean.

This makes sure the credentials are printed when automatically quitting on success.