### PR TITLE
Fix travis fails

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ entry_points = {
 install_requires = [
 'PyRIC',
 'tornado',
-'blessings']
+'blessings>=1.6']
 )
 
 def get_dnsmasq():


### PR DESCRIPTION
This should fix the problem where travis ci build would fail due
to it being unable to find a blessing installation candidate.